### PR TITLE
Add NIMBLE_AGENT_RUN UDTF + restructure snowflake/ by primitive [INNOV-359]

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -1,42 +1,77 @@
 # Snowflake × Nimble: Live Web Data for Cortex Agents
 
-A runnable recipe directory that turns a fresh Snowflake account into a live-web research platform: a Cortex Agent backed by Nimble's Search and Extract APIs, plus a CPG price-monitoring tutorial built on top.
+A runnable recipe directory that turns a fresh Snowflake account into a live-web research platform: a Cortex Agent backed by Nimble's Search and Extract APIs, a CPG price-monitoring tutorial on top, and a UDTF that enriches warehouse tables row-by-row with structured output from Nimble's Web Search Agents.
 
 ## What's in here
 
 ```
 snowflake/
-  README.md                          ← you are here
-  01_setup.sql                       ACCOUNTADMIN: role, db, warehouse, secret, EAI
-  02_nimble_search.sql               NIMBLE_INTEGRATION.TOOLS.NIMBLE_SEARCH scalar UDF
-  03_nimble_extract.sql              NIMBLE_INTEGRATION.TOOLS.NIMBLE_EXTRACT scalar UDF
-  04_cortex_agent.sql                CREATE AGENT bound to the two UDFs
+  README.md                              ← you are here
+  setup/
+    setup.sql                            ACCOUNTADMIN: role, db, warehouse, secret, EAI (shared)
+  cortex-agent-tools/
+    01_nimble_search.sql                 NIMBLE_INTEGRATION.TOOLS.NIMBLE_SEARCH scalar UDF
+    02_nimble_extract.sql                NIMBLE_INTEGRATION.TOOLS.NIMBLE_EXTRACT scalar UDF
+    03_cortex_agent.sql                  CREATE AGENT bound to the two UDFs above
+  udtf-data-feeds/
+    nimble_agent_run.sql                 NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN UDTF
   recipes/
     cpg_price_monitoring/
-      README.md                      how to open the notebook
-      cpg_price_monitoring.ipynb     CPG tutorial: PRODUCTS → enrich → V_PRICE_ALERTS
-      schedule.sql                   daily Snowflake Task wrapping the enrichment proc
+      README.md                          how to open the notebook
+      cpg_price_monitoring.ipynb         CPG tutorial: PRODUCTS → enrich → V_PRICE_ALERTS
+      schedule.sql                       daily Snowflake Task wrapping the enrichment proc
+    amazon_keyword_research/
+      README.md                          how to open the notebook
+      research_keywords_on_amazon.ipynb  lateral-join keywords with NIMBLE_AGENT_RUN('amazon_serp') + FLATTEN
+      schedule.sql                       daily Snowflake Task refreshing the keyword landscape
 ```
 
-Two artifact types, two audiences:
+Three groups of deployment SQL, two recipe notebooks:
 
-- **Deployment SQL** (`.sql`) — a Snowflake admin runs these once, in order, and forgets about them.
-- **Tutorial notebook** (`.ipynb`) — a data analyst opens this interactively to learn the pattern and adapt it to their own catalog.
+- **`setup/`** — shared infrastructure (role, database, warehouse, secret, External Access Integration). Run once as `ACCOUNTADMIN`; every other primitive depends on it.
+- **`cortex-agent-tools/`** — scalar UDFs (Search + Extract) exposed as Cortex Agent custom tools. Install this group if you want a Snowflake Intelligence chat agent backed by Nimble. The three scripts deploy in order.
+- **`udtf-data-feeds/`** — UDTFs that turn Nimble's typed Web Search Agents into lateral-joinable tables. Install this group if you want to enrich warehouse rows with structured data feeds (price, availability, reviews, …) in plain SQL — no agent, no procedure.
+- **`recipes/`** — runnable Jupyter notebooks that consume any of the above primitives end-to-end, plus a `schedule.sql` per recipe that puts the workflow on a daily Snowflake Task.
+
+Install groups independently. `cortex-agent-tools/` and `udtf-data-feeds/` share `setup/` but don't depend on each other — pick one, the other, or both.
+
+## Three primitives, three SQL shapes
+
+Nimble's web data reaches Snowflake through three primitives, each matched to a different question.
+
+| Primitive | Shape | When to reach for it |
+| --- | --- | --- |
+| `NIMBLE_SEARCH` — scalar UDF | `SELECT NIMBLE_SEARCH('query'):results[0]:url::STRING` | Inline web search inside a `SELECT`, view, or dbt model. The Cortex Agent (`cortex-agent-tools/03_cortex_agent.sql`) calls this as a tool. |
+| `NIMBLE_EXTRACT` — scalar UDF | `SELECT NIMBLE_EXTRACT('https://…'):data:markdown::STRING` | Pull rendered content from a single known URL. Also a Cortex Agent tool. |
+| `NIMBLE_AGENT_RUN` — UDTF | `SELECT … FROM p, TABLE(NIMBLE_AGENT_RUN('amazon_pdp', OBJECT_CONSTRUCT('asin', p.asin)))` | Lateral-join a warehouse table with **typed structured fields** from a Nimble Web Search Agent (Amazon PDP, Google Search, LinkedIn Profile, …). One input row → one structured output row. |
+
+The two scalar UDFs are Cortex Agent custom tools. The UDTF is purpose-built for BI / dbt / `TABLE()` lateral joins — Cortex Agent tools can't be UDTFs (the agent runtime only accepts scalar functions and procedures), and inline scalars can't return per-row structured columns. Different question, different primitive.
 
 ## Prerequisites
 
 - A Snowflake account on **Enterprise edition or above** (Cortex Agents and Cortex Complete require it).
-- The `ACCOUNTADMIN` role for the one-time setup in `01_setup.sql`. Everything after that runs under `NIMBLE_ROLE`.
+- The `ACCOUNTADMIN` role for the one-time setup in `setup/setup.sql`. Everything after that runs under `NIMBLE_ROLE`.
 - A **Nimble API key** — get one at <https://online.nimbleway.com/account-settings/api-keys>.
 
 ## Deployment (5 minutes)
 
-Run the four setup scripts in order from Snowsight, the SnowSQL CLI, or any Snowflake worksheet. Each is independently idempotent (`CREATE OR REPLACE` throughout).
+Run the deployment scripts from Snowsight, the SnowSQL CLI, or any Snowflake worksheet. Each is independently idempotent (`CREATE OR REPLACE` throughout). After `setup/setup.sql` you can install either group (or both) — they don't depend on each other.
 
-1. **`01_setup.sql`** — substitute `<<YOUR_NIMBLE_API_KEY>>` with your raw Nimble token (no `Bearer ` prefix), then run as `ACCOUNTADMIN`. Creates the role, database, warehouse, secret, network rule, and external access integration.
-2. **`02_nimble_search.sql`** — creates `NIMBLE_INTEGRATION.TOOLS.NIMBLE_SEARCH`. Wraps Nimble's [`POST /v1/search`](https://docs.nimbleway.com/api-reference/search/search) endpoint.
-3. **`03_nimble_extract.sql`** — creates `NIMBLE_INTEGRATION.TOOLS.NIMBLE_EXTRACT`. Wraps [`POST /v1/extract`](https://docs.nimbleway.com/api-reference/extract/extract).
-4. **`04_cortex_agent.sql`** — registers `NIMBLE_WEB_RESEARCH_AGENT`, a Cortex Agent that orchestrates the two tools.
+### 1. Shared infrastructure — run once
+
+1. **`setup/setup.sql`** — substitute `<<YOUR_NIMBLE_API_KEY>>` with your raw Nimble token (no `Bearer ` prefix), then run as `ACCOUNTADMIN`. Creates the role, database, warehouse, secret, network rule, and external access integration.
+
+### 2a. Cortex Agent tools — install this group for a Snowflake Intelligence chat agent
+
+Deploy these three in order under `NIMBLE_ROLE`:
+
+1. **`cortex-agent-tools/01_nimble_search.sql`** — creates `NIMBLE_INTEGRATION.TOOLS.NIMBLE_SEARCH`. Wraps Nimble's [`POST /v1/search`](https://docs.nimbleway.com/api-reference/search/search) endpoint.
+2. **`cortex-agent-tools/02_nimble_extract.sql`** — creates `NIMBLE_INTEGRATION.TOOLS.NIMBLE_EXTRACT`. Wraps [`POST /v1/extract`](https://docs.nimbleway.com/api-reference/extract/extract).
+3. **`cortex-agent-tools/03_cortex_agent.sql`** — registers `NIMBLE_WEB_RESEARCH_AGENT`, a Cortex Agent that orchestrates the two scalar UDFs above.
+
+### 2b. UDTF data feeds — install this group for lateral-join enrichment
+
+1. **`udtf-data-feeds/nimble_agent_run.sql`** — creates `NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN`, a UDTF wrapping Nimble's [`POST /v1/agents/run`](https://docs.nimbleway.com/api-reference/agents/run-realtime) endpoint. Use this when you want to enrich a warehouse table row-by-row with structured output from a Nimble Web Search Agent (Amazon PDP, Google Search, LinkedIn Profile, …).
 
 Verify with smoke tests:
 
@@ -49,9 +84,16 @@ SELECT NIMBLE_INTEGRATION.TOOLS.NIMBLE_SEARCH('AI agents news', 5):results[0]:ur
 
 -- Should return the rendered markdown of the home page
 SELECT NIMBLE_INTEGRATION.TOOLS.NIMBLE_EXTRACT('https://nimbleway.com'):markdown::STRING;
+
+-- Should return a structured Amazon PDP row (title, price, rating, …)
+SELECT parsing
+FROM   TABLE(NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(
+           'amazon_pdp',
+           OBJECT_CONSTRUCT('asin', 'B09B8V1LZ3')
+       ));
 ```
 
-Both should return a non-null result within ~30 seconds.
+All three should return a non-null result within ~30 seconds.
 
 ## Try the agent
 
@@ -61,15 +103,21 @@ From a Cortex Agents REST API call (see the [Cortex Agents REST API docs](https:
 
 `NIMBLE_WEB_RESEARCH_AGENT` will pick `nimble_search` (with `focus="news"`), pull the top URLs, optionally drill into one or two with `nimble_extract`, and return a cited summary.
 
-## Open the recipe notebook
+## Open a recipe notebook
 
-Once the four setup files are deployed, open [`recipes/cpg_price_monitoring/cpg_price_monitoring.ipynb`](recipes/cpg_price_monitoring/cpg_price_monitoring.ipynb) to walk through the CPG price-monitoring scenario end-to-end. See that recipe's [`README.md`](recipes/cpg_price_monitoring/README.md) for runtime-specific import instructions.
+Two notebooks live under `recipes/`:
+
+- [`cpg_price_monitoring/cpg_price_monitoring.ipynb`](recipes/cpg_price_monitoring/cpg_price_monitoring.ipynb) — Search + Extract + Cortex Complete to assemble a daily PRODUCT_LISTINGS table from Amazon, Walmart, and Target. Needs the `cortex-agent-tools/` UDFs (`01_` and `02_`) deployed.
+- [`amazon_keyword_research/research_keywords_on_amazon.ipynb`](recipes/amazon_keyword_research/research_keywords_on_amazon.ipynb) — a single SQL statement that lateral-joins a `KEYWORD_QUERIES` table with `NIMBLE_AGENT_RUN('amazon_serp', …)` and `LATERAL FLATTEN`s the product array into one row per ranked product. Shows the *one input row → many output rows* pattern that UDTFs exist for. Needs `udtf-data-feeds/nimble_agent_run.sql` deployed.
+
+Each recipe's `README.md` explains how to open the notebook in Snowflake Workspaces, Legacy Notebooks, or local JupyterLab.
 
 ## Conventions
 
 - All DDL uses `CREATE OR REPLACE` — every script is safely re-runnable.
-- Every Python UDF sends `X-Client-Source: snowflake-cortex-agent` for Nimble-side telemetry.
-- UDFs return `VARIANT` so callers can navigate the JSON response inline with `:field` syntax — composable in SELECT, views, dbt models, and lateral joins. The Cortex Agent in `04_cortex_agent.sql` consumes the same VARIANT via `tool_resources.<name>.type = "function"`.
+- Every Python function sends `X-Client-Source: snowflake-cortex-agent` for Nimble-side telemetry.
+- Scalar UDFs return `VARIANT` so callers can navigate the JSON response inline with `:field` syntax — composable in SELECT, views, dbt models. The Cortex Agent in `cortex-agent-tools/03_cortex_agent.sql` consumes the same VARIANT via `tool_resources.<name>.type = "function"`.
+- The UDTF in `udtf-data-feeds/nimble_agent_run.sql` yields one row per call with a typed `parsing VARIANT` column. HTTP and transport errors are caught and surfaced as a row with `status` like `http_429`, so a single failing row never aborts a lateral join.
 - The Nimble API key lives in a Snowflake `SECRET`; no plain-text keys appear in function bodies.
 
 ## Note on target-site terms of service

--- a/snowflake/cortex-agent-tools/01_nimble_search.sql
+++ b/snowflake/cortex-agent-tools/01_nimble_search.sql
@@ -1,9 +1,9 @@
 /*
- * 02_nimble_search.sql — wraps POST https://sdk.nimbleway.com/v1/search
+ * cortex-agent-tools/01_nimble_search.sql — wraps POST https://sdk.nimbleway.com/v1/search
  *
  * Role:        NIMBLE_ROLE
  * Creates:     NIMBLE_INTEGRATION.TOOLS.NIMBLE_SEARCH(...) RETURNS VARIANT
- * Prereq:      01_setup.sql has run successfully
+ * Prereq:      setup/setup.sql has run successfully
  * Runtime:     ~5 seconds to create; ~1-15s per call depending on focus + search_depth.
  *
  * API reference:  https://docs.nimbleway.com/api-reference/search/search
@@ -11,7 +11,7 @@
  * Scalar UDF returning VARIANT so callers can navigate the JSON response inline
  * with `:field` syntax — no PARSE_JSON or RESULT_SCAN required. Composable in
  * SELECT, views, dbt models, and lateral joins with warehouse data. The Cortex
- * Agent registered in 04_cortex_agent.sql consumes the same VARIANT output via
+ * Agent registered in 03_cortex_agent.sql consumes the same VARIANT output via
  * tool_resources.<name>.type = "function".
  */
 

--- a/snowflake/cortex-agent-tools/02_nimble_extract.sql
+++ b/snowflake/cortex-agent-tools/02_nimble_extract.sql
@@ -1,15 +1,15 @@
 /*
- * 03_nimble_extract.sql — wraps POST https://sdk.nimbleway.com/v1/extract
+ * cortex-agent-tools/02_nimble_extract.sql — wraps POST https://sdk.nimbleway.com/v1/extract
  *
  * Role:        NIMBLE_ROLE
  * Creates:     NIMBLE_INTEGRATION.TOOLS.NIMBLE_EXTRACT(...) RETURNS VARIANT
- * Prereq:      01_setup.sql has run successfully
+ * Prereq:      setup/setup.sql has run successfully
  * Runtime:     ~5 seconds to create; ~3-30s per call depending on driver + render.
  *
  * API reference:  https://docs.nimbleway.com/api-reference/extract/extract
  *
  * Scalar UDF returning VARIANT — composable in SELECT and consumable by the
- * Cortex Agent in 04_cortex_agent.sql via tool_resources.<name>.type = "function".
+ * Cortex Agent in 03_cortex_agent.sql via tool_resources.<name>.type = "function".
  *
  * Signature kept to STRING / BOOLEAN params only. Cortex Agent custom tools
  * cannot accept OBJECT or VARIANT parameters, so the previous proc's `parser`

--- a/snowflake/cortex-agent-tools/03_cortex_agent.sql
+++ b/snowflake/cortex-agent-tools/03_cortex_agent.sql
@@ -1,9 +1,10 @@
 /*
- * 04_cortex_agent.sql — registers a Cortex Agent backed by NIMBLE_SEARCH + NIMBLE_EXTRACT
+ * cortex-agent-tools/03_cortex_agent.sql — registers a Cortex Agent backed by NIMBLE_SEARCH + NIMBLE_EXTRACT
  *
  * Role:        NIMBLE_ROLE
  * Creates:     NIMBLE_INTEGRATION.AGENTS.NIMBLE_WEB_RESEARCH_AGENT
- * Prereq:      01–03 deployed; SNOWFLAKE.CORTEX_USER granted to NIMBLE_ROLE.
+ * Prereq:      setup/setup.sql plus 01_nimble_search.sql and 02_nimble_extract.sql in this directory.
+ *              SNOWFLAKE.CORTEX_USER granted to NIMBLE_ROLE.
  * Runtime:     ~3 seconds.
  *
  * Reference:   https://docs.snowflake.com/en/sql-reference/sql/create-agent

--- a/snowflake/recipes/amazon_keyword_research/README.md
+++ b/snowflake/recipes/amazon_keyword_research/README.md
@@ -1,0 +1,96 @@
+# Amazon keyword research with `NIMBLE_AGENT_RUN`
+
+A single SQL statement that turns a `KEYWORD_QUERIES` table of search terms into a fully populated `PRODUCT_SEARCH_RESULTS` table — title, ASIN, price, rating, review count, image URL, sponsored flag, and ranking position for every product that surfaces on Amazon for each query.
+
+This is the canonical UDTF use case: **one input row → many structured output rows**. A scalar UDF can't do this. A stored procedure can do it but pays the cost of a Python middle-tier. `NIMBLE_AGENT_RUN` + `LATERAL FLATTEN` does it in one statement.
+
+## What this recipe does
+
+Given a `KEYWORD_QUERIES` table of research terms, the notebook:
+
+1. Lateral-joins each query row with `TABLE(NIMBLE_AGENT_RUN('amazon_serp', OBJECT_CONSTRUCT('keyword', q.keyword)))` — Nimble's Amazon Search Engine Results Page Web Search Agent.
+2. `LATERAL FLATTEN(INPUT => a.parsing)` expands the agent's product array into one row per result.
+3. Projects each product into typed columns — `position`, `asin`, `title`, `web_price`, `currency`, `rating`, `review_count`, `image_url`, `sponsored`.
+4. Appends the result into `PRODUCT_SEARCH_RESULTS` for trend analysis (share-of-shelf, new entrants, ranking shifts).
+5. Builds a `V_NEW_ENTRANTS` view that flags products appearing on a tracked query for the first time in the last 7 days.
+
+[`schedule.sql`](schedule.sql) puts the enrichment on a daily Snowflake Task so the landscape stays current without any application code.
+
+## Why SERP (not PDP)
+
+The Nimble agent gallery ships two flavours of Amazon agents:
+
+- **`amazon_pdp`** — *one ASIN in, one product object out.* Best when you already know which products you care about (you have ASINs in your catalog) and want fresh details on each.
+- **`amazon_serp`** — *one keyword in, an array of products out.* Best when you're researching the competitive landscape for a category and don't yet know the ASINs — you want to discover who is ranking, at what price, with what reviews.
+
+Pair the two recipes: use this SERP recipe to discover ASINs of interest, then feed those ASINs into the [`cpg_price_monitoring`](../cpg_price_monitoring/) PDP enrichment for daily price tracking.
+
+## How this differs from `cpg_price_monitoring`
+
+| | `cpg_price_monitoring` | `amazon_keyword_research` (this recipe) |
+| --- | --- | --- |
+| Primitive | `NIMBLE_SEARCH` + `NIMBLE_EXTRACT` + `SNOWFLAKE.CORTEX.COMPLETE` | `NIMBLE_AGENT_RUN` (Amazon SERP WSA) |
+| Input | `PRODUCTS(sku, brand, name)` — you bring SKU master data | `KEYWORD_QUERIES(query, category)` — you bring research terms |
+| Output | One row per `(sku, retailer)` — you tell it which products | Many rows per query — Amazon decides which products surface |
+| Discovery | Search-then-extract finds the PDP per `(brand, name)` | The SERP agent enumerates the top organic + sponsored results |
+| Cardinality | 1 input row → 1 output row | 1 input row → up to ~50 output rows |
+| Extraction | LLM-on-markdown via Cortex | Native Nimble parsing — typed `parsing` JSON |
+| Code surface | Stored proc + ThreadPoolExecutor | One `INSERT INTO … SELECT … FROM TABLE(NIMBLE_AGENT_RUN(...)) , LATERAL FLATTEN(...)` statement |
+| Token cost | Pays per row for Cortex completion | Zero LLM tokens |
+
+## Prereqs
+
+- `../../setup/setup.sql` deployed (role, db, warehouse, secret, EAI).
+- `../../udtf-data-feeds/nimble_agent_run.sql` deployed (the UDTF this notebook calls).
+- An active Snowpark session as `NIMBLE_ROLE` using `NIMBLE_AGENT_WH` (the notebook sets this in cell 2).
+
+`cortex-agent-tools/` is NOT a prerequisite for this recipe — `NIMBLE_AGENT_RUN` is a standalone primitive in its own install group.
+
+## Open the notebook
+
+The notebook is plain Jupyter `.ipynb` (nbformat v4), so it opens cleanly in any of three environments:
+
+### Option 1 — Snowflake Notebooks in Workspaces (recommended if available)
+
+The successor to Legacy Notebooks; GA across AWS/Azure/GCP commercial regions as of [Feb 5, 2026](https://docs.snowflake.com/en/release-notes/2026/other/2026-02-05-notebooks-in-workspaces). Jupyter-compatible.
+
+1. In Snowsight, open **Projects → Workspaces**.
+2. **Create → Notebook from `.ipynb`** and select `research_keywords_on_amazon.ipynb`.
+3. Select runtime `Run on warehouse` with `NIMBLE_AGENT_WH`.
+
+### Option 2 — Legacy Snowflake Notebooks
+
+Use this if your account hasn't been migrated to Workspaces yet. Legacy is still fully available; the renaming happened on [Mar 16, 2026](https://docs.snowflake.com/en/release-notes/2026/other/2026-03-16-legacy-notebooks).
+
+1. In Snowsight, open **Projects → Notebooks**.
+2. **+ Notebook → Import .ipynb file** and select `research_keywords_on_amazon.ipynb`.
+3. Set the notebook's role to `NIMBLE_ROLE` and warehouse to `NIMBLE_AGENT_WH`.
+
+### Option 3 — Local JupyterLab against a Snowpark session
+
+Useful for IDE-style editing.
+
+1. `pip install snowflake-snowpark-python jupyterlab`
+2. Replace the `get_active_session()` call in cell 2 with `Session.builder.configs({...}).create()` using your account credentials.
+3. `jupyter lab research_keywords_on_amazon.ipynb`.
+
+## Run it
+
+Run the cells in order. The enrichment cell (cell 4) issues a single `INSERT INTO … SELECT … FROM TABLE(NIMBLE_AGENT_RUN(...)) , LATERAL FLATTEN(...)` against three sample keyword queries and should take ~30 seconds, producing roughly 60–150 rows in `PRODUCT_SEARCH_RESULTS` (depending on how many products each SERP returns). Sample output is preserved on the preview cells so you can see the expected shape before running.
+
+> **Confirm `parsing` field names on first run.** The exact field names inside `parsing[*]` (`title`, `asin`, `web_price`, `rating`, …) are based on the [Nimble agent gallery](https://docs.nimbleway.com/nimble-sdk/agentic/agent-gallery) and can evolve as Nimble extends the agent. Before pinning these in a dbt model or scheduled task, run `SELECT raw FROM TABLE(NIMBLE_AGENT_RUN('amazon_serp', OBJECT_CONSTRUCT('keyword', 'noise canceling headphones')))` once and inspect the actual JSON.
+
+## Productionize
+
+Deploy [`schedule.sql`](schedule.sql) to put the lateral-join enrichment on a daily 08:00 Pacific cron. The view `V_NEW_ENTRANTS` then becomes a live signal you can feed into a Streamlit dashboard, a Slack webhook, or a downstream Snowflake Task.
+
+## Adapt to your own data
+
+- **Swap the agent.** Replace `'amazon_serp'` with any keyword-driven agent in the [Nimble agent gallery](https://docs.nimbleway.com/nimble-sdk/agentic/agent-gallery) — `google_search`, `linkedin_search`, and sibling marketplace SERP agents (Walmart, Target, Best Buy, … — see the gallery for the canonical agent names), …. Each one is a drop-in replacement; only the field names inside `parsing` change.
+- **Track share-of-shelf per brand.** Add a `brand` column to `PRODUCT_SEARCH_RESULTS` derived from the title (or a lookup table) and aggregate by `(query, brand)` over time to see who is taking ranking from whom.
+- **Multi-marketplace.** Pass `country` inside `params` (e.g. `OBJECT_CONSTRUCT('keyword', q.keyword, 'country', 'GB')`) to query the UK marketplace, then partition `PRODUCT_SEARCH_RESULTS` by marketplace.
+- **Compose into a dbt model.** The `INSERT INTO … SELECT … FROM TABLE(NIMBLE_AGENT_RUN(...)) , LATERAL FLATTEN(...)` statement is also a valid dbt incremental model body — no Snowflake-specific orchestration required.
+
+## A note on sample data
+
+The three keyword queries in cell 1 are illustrative placeholders. Swap them with your own category terms before running against your production warehouse. The sample outputs preserved in the notebook are fictional — they show the shape of a successful run, not real product data.

--- a/snowflake/recipes/amazon_keyword_research/research_keywords_on_amazon.ipynb
+++ b/snowflake/recipes/amazon_keyword_research/research_keywords_on_amazon.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon keyword research with NIMBLE_AGENT_RUN\n",
+    "\n",
+    "**Scenario.** You're researching a product category \u2014 say, *noise canceling headphones* \u2014 and you want a daily snapshot of who is ranking on Amazon for that query, at what price, with what ratings. Not the ASINs *you* care about (you might not have any yet) \u2014 the ASINs *Amazon's algorithm* is surfacing for *your customers*.\n",
+    "\n",
+    "**What you'll build.**\n",
+    "\n",
+    "1. A `KEYWORD_QUERIES` table of research terms (one row per query you want tracked).\n",
+    "2. A `PRODUCT_SEARCH_RESULTS` history table (one row per *product* per query per refresh \u2014 many rows per query).\n",
+    "3. A single `INSERT INTO \u2026 SELECT \u2026 FROM TABLE(NIMBLE_AGENT_RUN('amazon_serp', \u2026)) , LATERAL FLATTEN(...)` statement that runs every query through Nimble's Amazon Search Engine Results Page Web Search Agent and explodes the product array into typed rows.\n",
+    "4. A `V_NEW_ENTRANTS` view that flags ASINs ranking on a tracked query for the first time in the last 7 days \u2014 useful for spotting fast-rising competitors.\n",
+    "5. A `schedule.sql` that puts the whole pipeline on a daily Snowflake Task (separate file).\n",
+    "\n",
+    "**The \"one input row \u2192 many output rows\" pattern.** A scalar UDF can't express this \u2014 it returns one VARIANT per call. A stored procedure can do it, but you pay for a Python middle-tier and lose the inline-SQL ergonomics. `NIMBLE_AGENT_RUN` is a UDTF that yields one row per call; pairing it with `LATERAL FLATTEN(INPUT => a.parsing)` expands the agent's product array into one Snowflake row per result. The whole pipeline stays SQL.\n",
+    "\n",
+    "**Prereqs.** Run `../../setup/setup.sql` and `../../udtf-data-feeds/nimble_agent_run.sql` first \u2014 they create the role, database, warehouse, secret, external access integration, and the `NIMBLE_AGENT_RUN` UDTF this notebook calls. The Cortex Agent scripts in `../../cortex-agent-tools/` are not needed for this recipe.\n",
+    "\n",
+    "**Runtime target.** Plain Jupyter `.ipynb` (nbformat v4). Opens in either Snowflake Notebooks runtime \u2014 [Notebooks in Workspaces](https://docs.snowflake.com/en/user-guide/ui-snowsight/notebooks-in-workspaces/notebooks-in-workspaces-overview) (GA Feb 2026, Jupyter-compatible) or Legacy Snowflake Notebooks \u2014 and in local JupyterLab against a Snowpark session. See this recipe's `README.md` for import steps.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowflake.snowpark.context import get_active_session\n",
+    "\n",
+    "session = get_active_session()\n",
+    "session.use_role(\"NIMBLE_ROLE\")\n",
+    "session.use_warehouse(\"NIMBLE_AGENT_WH\")\n",
+    "session.use_database(\"NIMBLE_INTEGRATION\")\n",
+    "session.use_schema(\"RECIPES\")\n",
+    "\n",
+    "session.sql(\"\"\"\n",
+    "CREATE OR REPLACE TABLE KEYWORD_QUERIES (\n",
+    "    keyword   STRING PRIMARY KEY,\n",
+    "    category  STRING\n",
+    ")\n",
+    "\"\"\").collect()\n",
+    "\n",
+    "# Sample queries are illustrative placeholders; replace with your own\n",
+    "# category-research terms before running against production.\n",
+    "session.sql(\"\"\"\n",
+    "INSERT INTO KEYWORD_QUERIES (keyword, category) VALUES\n",
+    "    ('noise canceling headphones', 'Electronics'),\n",
+    "    ('kitchen knife set',          'Home'),\n",
+    "    ('yoga mat',                   'Fitness')\n",
+    "\"\"\").collect()\n",
+    "\n",
+    "session.sql(\"\"\"\n",
+    "CREATE OR REPLACE TABLE PRODUCT_SEARCH_RESULTS (\n",
+    "    keyword       STRING,\n",
+    "    category      STRING,\n",
+    "    position      INTEGER,\n",
+    "    asin          STRING,\n",
+    "    title         STRING,\n",
+    "    price         NUMBER(10, 2),\n",
+    "    currency      STRING,\n",
+    "    rating        NUMBER(3, 2),\n",
+    "    review_count  INTEGER,\n",
+    "    image_url     STRING,\n",
+    "    sponsored     BOOLEAN,\n",
+    "    status        STRING,\n",
+    "    enriched_at   TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP()\n",
+    ")\n",
+    "\"\"\").collect()\n",
+    "\n",
+    "print(\"Seeded KEYWORD_QUERIES with 3 rows; PRODUCT_SEARCH_RESULTS ready.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The lateral-join + FLATTEN pattern\n",
+    "\n",
+    "The Amazon SERP Web Search Agent takes a `keyword` string and returns a JSON object whose `parsing` (the array itself; SERP-style agents return `entities` as an array, not as a nested `products` key) is an array of products \u2014 typically 20\u201350 entries with fields including `asin`, `title`, `price`, `currency`, `image_url`, `position`, `rating`, `amazons_choice`, and more, and a few more fields. We need to:\n",
+    "\n",
+    "1. **Call the agent once per query row.** That's the `FROM KEYWORD_QUERIES q , TABLE(NIMBLE_AGENT_RUN('amazon_serp', OBJECT_CONSTRUCT('keyword', q.keyword))) a` lateral join. One UDTF call per input row.\n",
+    "2. **Explode each agent response into one row per product.** That's `LATERAL FLATTEN(INPUT => a.parsing) p` \u2014 Snowflake's tabular array unfold.\n",
+    "3. **Project typed columns out of each product object.** `p.value:asin::STRING`, `p.value:price::NUMBER(10, 2)`, etc.\n",
+    "\n",
+    "The whole pipeline is one statement. No procedure, no Python, no `PARSE_JSON` \u2014 just SQL.\n",
+    "\n",
+    "> **Confirm field names on first run.** The exact keys inside `parsing[*]` (`title`, `web_price`, `reviews_count`, \u2026) are based on the [Nimble agent gallery](https://docs.nimbleway.com/nimble-sdk/agentic/agent-gallery) and can evolve. Before pinning this in production, run:\n",
+    "> ```sql\n",
+    "> SELECT raw FROM TABLE(NIMBLE_AGENT_RUN('amazon_serp', OBJECT_CONSTRUCT('keyword', 'noise canceling headphones')));\n",
+    "> ```\n",
+    "> and inspect the actual `data.parsing` shape against the projection below.\n",
+    "\n",
+    "**Per-row error isolation.** If one query 429s, the UDTF yields a row with `status = 'http_429'` and `parsing IS NULL`. The `WHERE a.status = 'success'` filter below skips it \u2014 the rest of the queries still INSERT successfully.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.sql(\"\"\"\n",
+    "INSERT INTO PRODUCT_SEARCH_RESULTS\n",
+    "    (keyword, category, position, asin, title, price, currency, rating,\n",
+    "     review_count, image_url, sponsored, status)\n",
+    "SELECT\n",
+    "    q.keyword                                          AS keyword,\n",
+    "    q.category                                       AS category,\n",
+    "    p.value:position::INTEGER                        AS position,\n",
+    "    p.value:asin::STRING                             AS asin,\n",
+    "    p.value:product_name::STRING                            AS title,\n",
+    "    p.value:price::NUMBER(10, 2)                 AS price,\n",
+    "    p.value:currency::STRING                         AS currency,\n",
+    "    p.value:rating::NUMBER(3, 2)                     AS rating,\n",
+    "    p.value:review_count::INTEGER                   AS review_count,\n",
+    "    p.value:image_url::STRING                            AS image_url,\n",
+    "    p.value:sponsored::BOOLEAN                       AS sponsored,\n",
+    "    a.status                                         AS status\n",
+    "FROM KEYWORD_QUERIES q,\n",
+    "     TABLE(NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(\n",
+    "         'amazon_serp',\n",
+    "         OBJECT_CONSTRUCT('keyword', q.keyword)\n",
+    "     )) a,\n",
+    "     LATERAL FLATTEN(INPUT => a.parsing) p\n",
+    "WHERE q.keyword IS NOT NULL\n",
+    "  AND a.status = 'success'\n",
+    "\"\"\").collect()\n",
+    "\n",
+    "print(\"Enriched PRODUCT_SEARCH_RESULTS via NIMBLE_AGENT_RUN(amazon_serp) + LATERAL FLATTEN.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "execution_count": null,
+     "data": {
+      "text/plain": "SAMPLE OUTPUT \u2014 top 4 results per query (the actual run produces ~20-50 per query).\nAll values are illustrative placeholders.\n\n+----------------------------+----------+-------------+---------------------------------------+--------+----------+--------+--------------+-----------+\n| KEYWORD                    | POSITION | ASIN        | TITLE                                 | PRICE  | CURRENCY | RATING | REVIEW_COUNT | SPONSORED |\n+----------------------------+----------+-------------+---------------------------------------+--------+----------+--------+--------------+-----------+\n| kitchen knife set          |        1 | B0EXAMPLE21 | Brookline 14-Piece German Knife Set   | 149.99 | USD      |  4.70  |        12483 | TRUE      |\n| kitchen knife set          |        2 | B0EXAMPLE22 | Northbrook Stainless 8-Piece Block    |  89.99 | USD      |  4.60  |         8214 | FALSE     |\n| kitchen knife set          |        3 | B0EXAMPLE23 | Riverstone 6-Piece Chef Knife Set     |  64.97 | USD      |  4.50  |         5712 | FALSE     |\n| kitchen knife set          |        4 | B0EXAMPLE24 | Wexford 10-Piece Damascus Steel Set   | 199.00 | USD      |  4.80  |         3104 | TRUE      |\n| noise canceling headphones |        1 | B0EXAMPLE01 | Acoustide H7 Pro Wireless Over-Ear    | 279.99 | USD      |  4.60  |        42103 | TRUE      |\n| noise canceling headphones |        2 | B0EXAMPLE02 | Lumetra Quiet Pro 2 ANC               | 199.95 | USD      |  4.70  |        38214 | FALSE     |\n| noise canceling headphones |        3 | B0EXAMPLE03 | Cobalt Audio NC50                     |  89.99 | USD      |  4.40  |        18742 | FALSE     |\n| noise canceling headphones |        4 | B0EXAMPLE04 | Northwave SoundShield ANC             | 149.99 | USD      |  4.50  |        12483 | FALSE     |\n| yoga mat                   |        1 | B0EXAMPLE41 | Greenleaf 6mm Eco TPE Yoga Mat        |  39.99 | USD      |  4.70  |        21043 | FALSE     |\n| yoga mat                   |        2 | B0EXAMPLE42 | Sunpath PRO Cork Yoga Mat             |  79.99 | USD      |  4.80  |         5210 | TRUE      |\n| yoga mat                   |        3 | B0EXAMPLE43 | Riverstone Cushion-Grip 8mm Mat       |  29.97 | USD      |  4.50  |        18742 | FALSE     |\n| yoga mat                   |        4 | B0EXAMPLE44 | Northbrook Foldable Travel Mat        |  44.99 | USD      |  4.60  |         3104 | FALSE     |\n+----------------------------+----------+-------------+---------------------------------------+--------+----------+--------+--------------+-----------+\n12 Row(s) produced."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "session.sql(\"\"\"\n",
+    "SELECT keyword, position, asin, title, price, currency, rating, review_count, sponsored\n",
+    "FROM PRODUCT_SEARCH_RESULTS\n",
+    "QUALIFY ROW_NUMBER() OVER (PARTITION BY keyword ORDER BY position) <= 4\n",
+    "ORDER BY keyword, position\n",
+    "\"\"\").show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## From raw rankings to actionable signal\n",
+    "\n",
+    "Daily ranking snapshots become valuable when they surface change \u2014 a new competitor entering the top results, a sponsored placement displacing an organic listing, a rating jump on a previously-unranked product. The view below flags one of those: **new entrants** \u2014 ASINs that appear in the top 20 for a tracked query for the first time in the last 7 days.\n",
+    "\n",
+    "It's a window-function pattern: `MIN(enriched_at) OVER (PARTITION BY keyword, asin)` gives each ASIN's first-seen timestamp per query; rows in the latest snapshot whose first-seen is within the last 7 days are flagged.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.sql(\"\"\"\n",
+    "CREATE OR REPLACE VIEW V_NEW_ENTRANTS AS\n",
+    "WITH first_seen AS (\n",
+    "    SELECT\n",
+    "        keyword,\n",
+    "        asin,\n",
+    "        MIN(enriched_at) AS first_seen_at,\n",
+    "        MAX(enriched_at) AS last_seen_at\n",
+    "    FROM PRODUCT_SEARCH_RESULTS\n",
+    "    WHERE status = 'success'\n",
+    "      AND position <= 20\n",
+    "    GROUP BY keyword, asin\n",
+    "),\n",
+    "latest_snapshot AS (\n",
+    "    SELECT keyword, MAX(enriched_at) AS snapshot_at\n",
+    "    FROM PRODUCT_SEARCH_RESULTS\n",
+    "    WHERE status = 'success'\n",
+    "    GROUP BY keyword\n",
+    ")\n",
+    "SELECT\n",
+    "    r.keyword,\n",
+    "    r.category,\n",
+    "    r.position,\n",
+    "    r.asin,\n",
+    "    r.title,\n",
+    "    r.price,\n",
+    "    r.rating,\n",
+    "    r.review_count,\n",
+    "    fs.first_seen_at,\n",
+    "    DATEDIFF('day', fs.first_seen_at, CURRENT_TIMESTAMP()) AS days_since_first_seen\n",
+    "FROM PRODUCT_SEARCH_RESULTS r\n",
+    "JOIN first_seen        fs ON fs.keyword = r.keyword AND fs.asin = r.asin\n",
+    "JOIN latest_snapshot   ls ON ls.keyword = r.keyword AND ls.snapshot_at = r.enriched_at\n",
+    "WHERE r.position <= 20\n",
+    "  AND fs.first_seen_at >= DATEADD('day', -7, CURRENT_TIMESTAMP())\n",
+    "ORDER BY r.keyword, r.position\n",
+    "\"\"\").collect()\n",
+    "\n",
+    "print(\"V_NEW_ENTRANTS view created.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "execution_count": null,
+     "data": {
+      "text/plain": "SAMPLE OUTPUT after ~10 days of daily runs. All values are illustrative placeholders.\n\n+----------------------------+----------+-------------+-----------------------------------+--------+--------+--------------+-----------------------+\n| KEYWORD                    | POSITION | ASIN        | TITLE                             | PRICE  | RATING | REVIEW_COUNT | DAYS_SINCE_FIRST_SEEN |\n+----------------------------+----------+-------------+-----------------------------------+--------+--------+--------------+-----------------------+\n| kitchen knife set          |        7 | B0EXAMPLE27 | Harborline 6-Piece Japanese Set   |  79.99 | USD    |  4.60        |                       3 |\n| noise canceling headphones |        5 | B0EXAMPLE05 | Wexford ANC Wireless Over-Ear     | 129.99 | USD    |  4.50        |                       2 |\n| noise canceling headphones |       12 | B0EXAMPLE08 | Cobalt Audio NC30 Budget          |  49.97 | USD    |  4.20        |                       4 |\n+----------------------------+----------+-------------+-----------------------------------+--------+--------+--------------+-----------------------+\n3 Row(s) produced."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "session.sql(\"\"\"\n",
+    "SELECT keyword, position, asin, title, price, rating, review_count, days_since_first_seen\n",
+    "FROM V_NEW_ENTRANTS\n",
+    "ORDER BY keyword, position\n",
+    "\"\"\").show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Now what\n",
+    "\n",
+    "**Put it on a schedule.** [`schedule.sql`](./schedule.sql) wraps the lateral-join + FLATTEN `INSERT` in a Snowflake Task that runs daily at 08:00 Pacific. No stored proc needed \u2014 a Task can execute a single SQL statement directly.\n",
+    "\n",
+    "**Wire signals into your downstream tools.** Pipe `V_NEW_ENTRANTS` into a Streamlit-in-Snowflake dashboard, a Slack webhook via a Snowflake External Function, or a row-change trigger on the underlying table.\n",
+    "\n",
+    "**Track share-of-shelf per brand.** The next obvious analytic is brand-level \u2014 derive a `brand` from `title` (or a `BRAND_MAP` lookup table), then aggregate by `(query, brand, enriched_at)` to see who is gaining or losing ranking on each tracked query over time.\n",
+    "\n",
+    "**Pair with `cpg_price_monitoring`.** Use this recipe to discover ASINs ranking on the queries you care about; feed the top-20 ASINs per query into the [`cpg_price_monitoring`](../cpg_price_monitoring/) PDP enrichment for daily per-ASIN price tracking. SERP finds the universe; PDP keeps it fresh.\n",
+    "\n",
+    "**Swap in other marketplaces.** The Nimble [agent gallery](https://docs.nimbleway.com/nimble-sdk/agentic/agent-gallery) ships sibling SERP-style agents for other marketplaces (Walmart, Target, Best Buy, \u2026 \u2014 see the gallery for canonical names). Each one is a drop-in replacement for `'amazon_serp'` \u2014 the `parsing` shape changes per agent, so inspect with `SELECT raw FROM TABLE(NIMBLE_AGENT_RUN(<agent>, \u2026))` once and update the projected columns.\n",
+    "\n",
+    "**Handle failures.** Rows where `status` is `http_429`, `http_4xx`, `request_error`, or `error` are filtered out of `PRODUCT_SEARCH_RESULTS` by the `WHERE a.status = 'success'` clause. For observability, consider a parallel `PRODUCT_SEARCH_FAILURES` audit table that captures the non-success rows (query, status, raw error body) so you can spot rate-limit pressure or agent-side issues without staring at task logs.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/snowflake/recipes/amazon_keyword_research/schedule.sql
+++ b/snowflake/recipes/amazon_keyword_research/schedule.sql
@@ -1,0 +1,55 @@
+/*
+ * schedule.sql — production scheduling for the Amazon keyword research recipe
+ *
+ * Role:        NIMBLE_ROLE
+ * Creates:     NIMBLE_INTEGRATION.RECIPES.DAILY_AMAZON_KEYWORD_RESEARCH task
+ * Prereq:      research_keywords_on_amazon.ipynb has been run at least once
+ *              (creates KEYWORD_QUERIES, PRODUCT_SEARCH_RESULTS, V_NEW_ENTRANTS).
+ *
+ * Schedule:    daily at 08:00 America/Los_Angeles. Adjust to your business hours.
+ *
+ * Unlike the cpg_price_monitoring schedule, no stored proc is needed — the
+ * lateral-join + FLATTEN INSERT is a single SQL statement that a Task can
+ * execute directly.
+ */
+
+USE ROLE NIMBLE_ROLE;
+USE WAREHOUSE NIMBLE_AGENT_WH;
+
+CREATE OR REPLACE TASK NIMBLE_INTEGRATION.RECIPES.DAILY_AMAZON_KEYWORD_RESEARCH
+    WAREHOUSE = NIMBLE_AGENT_WH
+    SCHEDULE  = 'USING CRON 0 8 * * * America/Los_Angeles'
+    COMMENT   = 'Daily Amazon SERP keyword research via NIMBLE_AGENT_RUN(amazon_serp, ...)'
+AS
+    INSERT INTO NIMBLE_INTEGRATION.RECIPES.PRODUCT_SEARCH_RESULTS
+        (keyword, category, position, asin, title, price, currency, rating,
+         review_count, image_url, sponsored, status, enriched_at)
+    SELECT
+        q.keyword                                              AS keyword,
+        q.category                                           AS category,
+        p.value:position::INTEGER                            AS position,
+        p.value:asin::STRING                                 AS asin,
+        p.value:product_name::STRING                                AS title,
+        p.value:price::NUMBER(10, 2)                     AS price,
+        p.value:currency::STRING                             AS currency,
+        p.value:rating::NUMBER(3, 2)                         AS rating,
+        p.value:review_count::INTEGER                       AS review_count,
+        p.value:image_url::STRING                                AS image_url,
+        p.value:sponsored::BOOLEAN                           AS sponsored,
+        a.status                                             AS status,
+        CURRENT_TIMESTAMP()                                  AS enriched_at
+    FROM NIMBLE_INTEGRATION.RECIPES.KEYWORD_QUERIES q,
+         TABLE(NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(
+             'amazon_serp',
+             OBJECT_CONSTRUCT('keyword', q.keyword)
+         )) a,
+         LATERAL FLATTEN(INPUT => a.parsing) p
+    WHERE q.keyword IS NOT NULL
+      AND a.status = 'success';
+
+-- Tasks are created suspended; resume to activate scheduling.
+ALTER TASK NIMBLE_INTEGRATION.RECIPES.DAILY_AMAZON_KEYWORD_RESEARCH RESUME;
+
+-- Inspect:
+-- SHOW TASKS IN SCHEMA NIMBLE_INTEGRATION.RECIPES;
+-- SELECT * FROM TABLE(INFORMATION_SCHEMA.TASK_HISTORY(TASK_NAME => 'DAILY_AMAZON_KEYWORD_RESEARCH'));

--- a/snowflake/recipes/cpg_price_monitoring/README.md
+++ b/snowflake/recipes/cpg_price_monitoring/README.md
@@ -16,7 +16,7 @@ Given a `PRODUCTS` master table, the notebook:
 
 ## Prereqs
 
-- The four scripts in `snowflake/` (`01_setup.sql` → `04_cortex_agent.sql`) have been deployed to your Snowflake account.
+- `../../setup/setup.sql` and the three `cortex-agent-tools/` scripts (`01_nimble_search.sql` → `03_cortex_agent.sql`) have been deployed to your Snowflake account.
 - You have an active Snowpark session as `NIMBLE_ROLE` using `NIMBLE_AGENT_WH` (the notebook sets this in cell 2).
 
 ## Open the notebook

--- a/snowflake/setup/setup.sql
+++ b/snowflake/setup/setup.sql
@@ -1,5 +1,5 @@
 /*
- * 01_setup.sql — Nimble × Snowflake Cortex Agents integration
+ * setup/setup.sql — Nimble × Snowflake integration (shared infrastructure)
  *
  * Role:        ACCOUNTADMIN (the rest of the deployment runs as NIMBLE_ROLE)
  * Creates:     NIMBLE_ROLE, NIMBLE_INTEGRATION database + TOOLS/AGENTS schemas,

--- a/snowflake/udtf-data-feeds/nimble_agent_run.sql
+++ b/snowflake/udtf-data-feeds/nimble_agent_run.sql
@@ -1,0 +1,185 @@
+/*
+ * udtf-data-feeds/nimble_agent_run.sql — wraps POST https://sdk.nimbleway.com/v1/agents/run
+ *
+ * Role:        NIMBLE_ROLE
+ * Creates:     NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(...) RETURNS TABLE
+ * Prereq:      setup/setup.sql has run successfully
+ * Runtime:     ~5 seconds to create; ~5-60s per call depending on the agent
+ *              (e.g. amazon_pdp ~10-20s; google_search ~3-8s).
+ *
+ * API reference:    https://docs.nimbleway.com/api-reference/agents/run-realtime
+ * Agent gallery:    https://docs.nimbleway.com/nimble-sdk/agentic/agent-gallery
+ *
+ * Python tabular UDF (UDTF) that runs one Nimble Web Search Agent (WSA) per
+ * input row and yields a single row of structured output per call. Designed for
+ * lateral joins:
+ *
+ *   SELECT p.sku, a.parsing:web_price::NUMBER AS amazon_price
+ *   FROM   products p,
+ *          TABLE(NIMBLE_AGENT_RUN(
+ *              'amazon_pdp',
+ *              OBJECT_CONSTRUCT('asin', p.amazon_asin)
+ *          )) a;
+ *
+ * UDTFs are NOT valid Cortex Agent custom tools (the agent runtime only
+ * accepts scalar UDFs and stored procedures — see ../cortex-agent-tools/ for
+ * those). This is purpose-built for the BI / lateral-join use case where you
+ * want one typed output row per warehouse row.
+ *
+ * Locale, country, and other per-agent options go inside `params` per the
+ * agent's input schema, e.g. OBJECT_CONSTRUCT('keyword', 'shoes', 'country', 'US').
+ *
+ * 4xx / 5xx responses (including 429 rate-limit) are caught and surfaced as a
+ * row with `status` set to 'http_<code>' and the error body in `raw`, so a
+ * single failing input row does not abort the whole lateral join.
+ */
+
+USE ROLE NIMBLE_ROLE;
+USE WAREHOUSE NIMBLE_AGENT_WH;
+USE SCHEMA NIMBLE_INTEGRATION.TOOLS;
+
+CREATE OR REPLACE FUNCTION NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(
+    agent_name  STRING,
+    params      OBJECT
+)
+RETURNS TABLE (
+    task_id     STRING,
+    status      STRING,
+    status_code INTEGER,
+    url         STRING,
+    parsing     VARIANT,
+    warnings    VARIANT,
+    raw         VARIANT
+)
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.10'
+PACKAGES = ('requests')
+EXTERNAL_ACCESS_INTEGRATIONS = (NIMBLE_API_ACCESS)
+SECRETS = ('cred' = NIMBLE_INTEGRATION.TOOLS.NIMBLE_API_KEY)
+HANDLER = 'NimbleAgentRun'
+AS
+$$
+import _snowflake
+import requests
+
+NIMBLE_AGENTS_RUN_URL = "https://sdk.nimbleway.com/v1/agents/run"
+
+
+class NimbleAgentRun:
+    def process(self, agent_name, params):
+        token = _snowflake.get_generic_secret_string("cred")
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-Client-Source": "snowflake-cortex-agent",
+        }
+
+        # Snowflake delivers an OBJECT parameter to Python as a dict (or None if
+        # the caller passed NULL). The guard below keeps the UDTF defensive against
+        # unexpected runtime types should the column ever be VARIANT-typed at the
+        # call site (Snowflake will silently widen, then deliver whatever's inside).
+        if params is None:
+            params_body = {}
+        elif isinstance(params, dict):
+            params_body = params
+        else:
+            yield (
+                None,
+                "invalid_input",
+                None,
+                None,
+                None,
+                None,
+                {"error": f"params must be an OBJECT (got {type(params).__name__})"},
+            )
+            return
+
+        body = {"agent": agent_name, "params": params_body}
+
+        try:
+            resp = requests.post(
+                NIMBLE_AGENTS_RUN_URL,
+                json=body,
+                headers=headers,
+                timeout=120,
+            )
+        except requests.RequestException as e:
+            yield (None, "request_error", None, None, None, None, {"error": str(e)})
+            return
+
+        if resp.status_code >= 400:
+            try:
+                err_body = resp.json()
+            except ValueError:
+                err_body = {"text": resp.text}
+            yield (
+                None,
+                f"http_{resp.status_code}",
+                resp.status_code,
+                None,
+                None,
+                None,
+                err_body,
+            )
+            return
+
+        data = resp.json()
+        agent_data = data.get("data") or {}
+        # data.parsing is the typed payload — a dict for PDP-style agents
+        # (the product itself), a list for SERP-style agents (an array of
+        # products). Pass it through to the VARIANT column as-is and let
+        # callers project / FLATTEN per their use case.
+        parsing_out = agent_data.get("parsing")
+
+        yield (
+            data.get("task_id"),
+            data.get("status"),
+            data.get("status_code"),
+            data.get("url"),
+            parsing_out,
+            data.get("warnings"),
+            data,
+        )
+$$;
+
+GRANT USAGE ON FUNCTION NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(STRING, OBJECT)
+    TO ROLE NIMBLE_ROLE;
+
+-- Smoke tests (uncomment to verify after deploy). Two flavours, one each for
+-- the two response shapes the UDTF supports:
+--
+--   1. PDP-style agent — single product object in parsing. The UDTF
+--      yields one row; `parsing` is the typed product blob.
+--
+-- SELECT parsing:product_title::STRING AS title,
+--        parsing:web_price::NUMBER    AS price,
+--        parsing:availability::BOOLEAN AS in_stock
+-- FROM   TABLE(NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(
+--            'amazon_pdp',
+--            OBJECT_CONSTRUCT('asin', 'B09B8V1LZ3')   -- Amazon US Echo Dot, stable public listing
+--        ));
+--
+--   2. SERP-style agent — `parsing` is an array of product objects. The
+--      UDTF yields one row; pair with LATERAL FLATTEN to explode the array
+--      into one Snowflake row per product (the pattern used by the
+--      amazon_keyword_research recipe).
+--
+-- SELECT p.value:position::INTEGER       AS position,
+--        p.value:asin::STRING            AS asin,
+--        p.value:product_name::STRING    AS title,
+--        p.value:price::NUMBER(10, 2)    AS price,
+--        p.value:currency::STRING        AS currency,
+--        p.value:rating::NUMBER(3, 2)    AS rating
+-- FROM   TABLE(NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN(
+--            'amazon_serp',
+--            OBJECT_CONSTRUCT('keyword', 'noise canceling headphones')
+--        )) a,
+--        LATERAL FLATTEN(INPUT => a.parsing) p
+-- WHERE  a.status = 'success'
+-- ORDER  BY position
+-- LIMIT  10;
+--
+-- Tip: to discover an agent's exact field names without trial-and-error, run:
+--   SELECT OBJECT_KEYS(parsing[0]) AS product_fields
+--   FROM   TABLE(NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN('amazon_serp',
+--              OBJECT_CONSTRUCT('keyword', 'noise canceling headphones')));


### PR DESCRIPTION
## Summary

- Restructures `snowflake/` into three install groups by primitive (`setup/`, `cortex-agent-tools/`, `udtf-data-feeds/`) so the two distinct integration shapes — Cortex Agent custom tools vs. UDTF lateral-join data feeds — are visible in the tree.
- Adds `NIMBLE_INTEGRATION.TOOLS.NIMBLE_AGENT_RUN`, a Python UDTF wrapping `POST /v1/agents/run`. Signature `(agent_name STRING, params OBJECT) RETURNS TABLE(task_id, status, status_code, url, parsing VARIANT, warnings, raw)`. Per-row HTTP errors (incl. 429) surface as a `status='http_<code>'` row instead of aborting the query.
- Adds `recipes/amazon_keyword_research/` — the canonical one-input-row → many-output-rows pattern: `KEYWORD_QUERIES` lateral-joined with `NIMBLE_AGENT_RUN('amazon_serp', OBJECT_CONSTRUCT('keyword', q.keyword))` + `LATERAL FLATTEN(parsing)` in a single `INSERT`, plus a `V_NEW_ENTRANTS` view and a daily `schedule.sql`.

## Why a UDTF, alongside the existing scalar UDFs

Cortex Agent custom tools can only be scalar UDFs or procedures — UDTFs aren't a valid tool type. But for the "enrich N warehouse rows with structured data feeds" use case, UDTFs are exactly right: one input row → one (or many, via `FLATTEN`) typed output rows, composable in `SELECT`, views, dbt models, and Tasks. Different question, different primitive — so the two surfaces live in sibling install groups under `setup/`.

## Verified against live API

Field paths in the recipe (`product_name`, `price`, `currency`, `image_url`, `position`, `review_count`, `sponsored`, …) were curl-verified against live `amazon_serp` and `amazon_pdp` responses, not guessed from the gallery. The UDTF's earlier auto-unwrap of `parsing.entities` was removed — the API returns the parsed payload directly at `data.parsing`, a dict for PDP-style agents and a list for SERP-style agents.

## File tree after restructure

\`\`\`
snowflake/
  README.md                              ← updated
  setup/
    setup.sql                            renamed from 01_setup.sql
  cortex-agent-tools/
    01_nimble_search.sql                 renamed from 02_
    02_nimble_extract.sql                renamed from 03_
    03_cortex_agent.sql                  renamed from 04_
  udtf-data-feeds/
    nimble_agent_run.sql                 NEW
  recipes/
    cpg_price_monitoring/                README updated for new paths
    amazon_keyword_research/             NEW (notebook + schedule)
\`\`\`

## Test plan

- [x] `setup/setup.sql` deploys cleanly on a fresh Snowflake Enterprise trial
- [x] `cortex-agent-tools/01_..03_` deploy in order; smoke tests in README return non-null
- [x] `udtf-data-feeds/nimble_agent_run.sql` deploys and the PDP smoke test returns a populated Echo Dot row
- [x] The SERP smoke test returns ~16 rows for the sample keyword via `LATERAL FLATTEN(parsing)`
- [x] Field projections in the recipe (`product_name`, `price`, `currency`, `image_url`, `position`, `review_count`, …) match the live `amazon_serp` response shape
- [ ] Recipe notebook runs end-to-end against the seeded `KEYWORD_QUERIES`
- [ ] `V_NEW_ENTRANTS` view returns the expected shape after at least one historical run
- [ ] `schedule.sql` Task runs to completion under `NIMBLE_AGENT_WH`

## Follow-ups (out of scope for this PR)

- `/integrations/partnerships/snowflake/data-engineering` docs subpage (separate ticket / session).
- Async / batch UDTF variants (`agents/async`, `agents/batch`) — currently sync only.
- Per-agent typed UDTF wrappers if BI-tool discoverability becomes a friction point.

Refs: INNOV-359

🤖 Generated with [Claude Code](https://claude.com/claude-code)