### PR TITLE
feat(databricks): add nimble_agent_describe UDTF + restructure setup docs

### DIFF
--- a/databricks/01_setup.sql
+++ b/databricks/01_setup.sql
@@ -6,7 +6,7 @@
  *             CREATE FUNCTION on nimble_integration.tools.
  * Creates:    nimble_integration catalog, tools + recipes schemas.
  * Prereq:     The `nimble` secret scope + `api_key` secret exist, and the
- *             serverless networking Preview is enabled — see 00_prereqs.md.
+ *             serverless networking Preview is enabled — see INSTALL.md.
  * Runtime:    ~5 seconds.
  *
  * Re-runnable. Every statement is `CREATE ... IF NOT EXISTS` so a second run

--- a/databricks/INSTALL.md
+++ b/databricks/INSTALL.md
@@ -1,6 +1,6 @@
-# 00_prereqs — one-time Databricks CLI setup
+# INSTALL — one-time Databricks setup & deploy
 
-Everything below is `bash` against the [Databricks CLI v0.205+](https://docs.databricks.com/en/dev-tools/cli/install.html). Run once per workspace. After this, the SQL files in `01_setup.sql` and beyond can be deployed by anyone with `CREATE SCHEMA` and `CREATE FUNCTION` privileges on the target catalog.
+The complete install path for this cookbook: CLI auth, the networking Preview, the secret scope, then deploying the SQL files. Run once per workspace. Most steps are `bash` against the [Databricks CLI v0.205+](https://docs.databricks.com/en/dev-tools/cli/install.html). After this, the SQL files in `01_setup.sql` and beyond can be deployed by anyone with `CREATE SCHEMA` and `CREATE FUNCTION` privileges on the target catalog.
 
 ## 1. Authenticate the CLI
 
@@ -59,16 +59,15 @@ databricks secrets list-acls nimble
 # users    READ
 ```
 
-## 5. (Optional) Run the SQL deploys from the CLI
+## 5. Deploy the SQL files
 
-`databricks api post /api/2.0/sql/statements` lets you fire a statement at a SQL warehouse without leaving the shell. That endpoint accepts **one statement per call**, and the SQL files in this directory contain multiple statements plus function COMMENTs that legitimately include `;` inside string literals. The repo ships a tiny helper that splits + posts correctly:
+This is the canonical deploy path (you can also paste each file into a Databricks SQL editor by hand). `databricks api post /api/2.0/sql/statements` fires a statement at a SQL warehouse without leaving the shell. That endpoint accepts **one statement per call**, and the SQL files in this directory contain multiple statements plus function COMMENTs that legitimately include `;` inside string literals. The repo ships a tiny helper that splits + posts correctly:
 
 ```bash
-WH=<your-serverless-warehouse-id>     # databricks warehouses list
+# Grab a warehouse id automatically (first one); or set WH explicitly. Needs jq.
+WH=$(databricks warehouses list -o json | jq -r '.[0].id')
 
-python3 databricks/helpers/deploy_sql.py --file databricks/01_setup.sql --warehouse "$WH"
-
-for f in databricks/tools/*.sql; do
+for f in databricks/01_setup.sql databricks/tools/*.sql; do
     python3 databricks/helpers/deploy_sql.py --file "$f" --warehouse "$WH"
 done
 ```

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -18,14 +18,15 @@ FROM my_catalog.web.urls u,
 ```
 databricks/
   README.md                ← you are here
-  00_prereqs.md            one-time setup: CLI auth, secret scope, the Previews toggle
+  INSTALL.md               one-time setup + deploy: CLI auth, secret scope, Previews toggle, SQL deploy
   01_setup.sql             catalog + schemas (tools + recipes)
   ADDING_A_TOOL.md         how to wrap a new Nimble endpoint as a UDTF
   tools/                   one table function per Nimble capability — installable as-is
     nimble_search.sql        nimble_search(query, ...)               — Web Search API
     nimble_extract.sql       nimble_extract(url, ...)                — Extract API
-    nimble_agent_list.sql    nimble_agent_list(...)                  — agent catalog
-    nimble_agent_run.sql     nimble_agent_run(agent, params_json, ...) — generic agent runner
+    nimble_agent_list.sql      nimble_agent_list(...)                  — agent catalog
+    nimble_agent_describe.sql  nimble_agent_describe(agent_name)       — one row per agent input param
+    nimble_agent_run.sql       nimble_agent_run(agent, params_json, ...) — generic agent runner
   recipes/                 runnable SQL — per-tool snippets + end-to-end recipes
     local_business_universe.sql   stitch many agent calls → governed Delta table
   helpers/                 deploy_sql.py (multi-statement deploy) + create_genie_space.py
@@ -36,47 +37,16 @@ Every tool is a **table function** — call it in the FROM clause. Each `tools/*
 ## Prerequisites
 
 - A Databricks workspace with a **serverless SQL warehouse**.
-- **Outbound networking enabled for the warehouse** — enable the Preview **"Enable networking for isolated workloads in Serverless SQL Warehouses"** and **cold-restart** the warehouse (Stop → Start). Without this, the tools return zero rows and the underlying request fails with `Connection refused`. See [`00_prereqs.md`](00_prereqs.md) §1.5.
+- **Outbound networking enabled for the warehouse** (a Preview toggle + cold restart) — without it the tools silently return zero rows. Setup and the symptom to watch for: [`INSTALL.md`](INSTALL.md) §1.5.
 - Privilege to create a catalog/schema (or an existing schema you own) and `CREATE FUNCTION` on it.
 - A **Nimble API key** — get one at <https://online.nimbleway.com/account-settings/api-keys>.
 - The **Databricks CLI v0.205+** installed and authenticated (`databricks auth login`).
 
-## Deployment
+## Install
 
-### 1. One-time prereqs ([`00_prereqs.md`](00_prereqs.md))
+Full setup and deploy — CLI auth, the networking Preview + cold restart, the secret scope, deploying the SQL files, and the smoke test — live in [`INSTALL.md`](INSTALL.md). Run it once per workspace.
 
-CLI auth, the Previews toggle + cold restart, and the secret scope:
-
-```bash
-databricks secrets create-scope nimble
-databricks secrets put-secret  nimble api_key   # paste token, Ctrl-D
-databricks secrets put-acl     nimble users READ
-```
-
-### 2. Run the SQL files
-
-`helpers/deploy_sql.py` splits multi-statement files and posts each statement (it treats `$$ … $$` UDTF bodies as opaque).
-
-```bash
-WH=<your-serverless-warehouse-id>   # databricks warehouses list
-
-python3 databricks/helpers/deploy_sql.py --file databricks/01_setup.sql --warehouse "$WH"
-for f in databricks/tools/*.sql; do
-    python3 databricks/helpers/deploy_sql.py --file "$f" --warehouse "$WH"
-done
-```
-
-1. **`01_setup.sql`** — creates catalog `nimble_integration`, schemas `tools` + `recipes`.
-2. **`tools/*.sql`** — installs the table functions.
-
-Smoke test:
-
-```sql
-SELECT count(*) AS n FROM nimble_integration.tools.nimble_search('AI agents news', 5);  -- expect > 0
-SELECT length(content) FROM nimble_integration.tools.nimble_extract('https://www.nimbleway.com');
-```
-
-If a tool returns zero rows, re-check the Previews toggle + cold restart (Prerequisites).
+In short: `01_setup.sql` creates the `nimble_integration` catalog (schemas `tools` + `recipes`), then `tools/*.sql` installs the table functions via `helpers/deploy_sql.py`.
 
 ## The tools
 
@@ -85,6 +55,7 @@ If a tool returns zero rows, re-check the Previews toggle + cold restart (Prereq
 | `nimble_search(query, max_results, focus, search_depth, ...)` | Live web search → rows of `title, description, url, content`. |
 | `nimble_extract(url, render, format, ...)` | Fetch + parse one URL → a row of `url, format, content` (markdown/html/links). |
 | `nimble_agent_list(privacy, managed_by, ...)` | The Nimble agent catalog → one row per agent. |
+| `nimble_agent_describe(agent_name)` | A single agent's input params → one row per param (`param_name, required, type`, localization/pagination flags). Use it to build a valid `nimble_agent_run` `params_json` without guessing. |
 | `nimble_agent_run(agent, params_json, localization)` | Run any agent → one row: envelope + `parsing_json`. |
 
 See [`recipes/`](recipes/) for runnable patterns — including `local_business_universe.sql`, which stitches many `nimble_agent_run('google_maps_search', …)` calls into a governed Delta table.
@@ -115,6 +86,7 @@ python3 databricks/helpers/create_genie_space.py \
     --function nimble_integration.tools.nimble_search \
     --function nimble_integration.tools.nimble_extract \
     --function nimble_integration.tools.nimble_agent_list \
+    --function nimble_integration.tools.nimble_agent_describe \
     --function nimble_integration.tools.nimble_agent_run
 ```
 

--- a/databricks/helpers/create_genie_space.py
+++ b/databricks/helpers/create_genie_space.py
@@ -26,6 +26,7 @@ Usage
         --function nimble_integration.tools.nimble_search \\
         --function nimble_integration.tools.nimble_extract \\
         --function nimble_integration.tools.nimble_agent_list \\
+        --function nimble_integration.tools.nimble_agent_describe \\
         --function nimble_integration.tools.nimble_agent_run
 
 Requirements: Python 3.9+, the `databricks` CLI on $PATH and

--- a/databricks/helpers/nimble_genie_instructions.md
+++ b/databricks/helpers/nimble_genie_instructions.md
@@ -30,7 +30,14 @@ Parameters: url, render (boolean), format (markdown|html|links). Returns one row
 
 Returns the Nimble agent catalog (e-commerce, Google Maps, LinkedIn, etc.), one row per agent: `name`, `display_name`, `description`, `vertical`, `entity_type`, `domain`, `managed_by`, `is_public`.
 
-**4. Run Any Agent**
+**4. Describe an Agent's Inputs**
+
+    SELECT param_name, required, type, is_localization_param
+    FROM nimble_integration.tools.nimble_agent_describe('amazon_serp')
+
+Returns one row per input parameter of a single agent: `param_name`, `required`, `type`, `description`, `is_localization_param`, `is_pagination_param`, `default_value`, `examples_json`, plus the agent's `vertical`/`entity_type`/`domain` and `is_localization_supported`/`is_pagination_supported` repeated on each row. Use it to build a valid `nimble_agent_run` `params_json` without guessing param names (they differ per agent — Amazon search wants `keyword`, not `query`). Output fields are not returned here — run the agent once and inspect `to_json(parsing[0])` for those.
+
+**5. Run Any Agent**
 
     SELECT * FROM nimble_integration.tools.nimble_agent_run('agent_name', '{"param":"value"}', FALSE)
 
@@ -51,5 +58,5 @@ Parameters: agent name, params as JSON string, optional localization boolean. Re
 
 1. Run `DESCRIBE FUNCTION EXTENDED` first to see parameter options and examples.
 2. Use `nimble_search` for open-web questions; `nimble_extract` when you already have a URL.
-3. Check `nimble_agent_list()` to discover available agents before `nimble_agent_run()`.
+3. Check `nimble_agent_list()` to discover agents, then `nimble_agent_describe('<agent>')` to learn its exact input params, before calling `nimble_agent_run()`.
 4. Parse `parsing_json` carefully — schemas are agent-specific.

--- a/databricks/recipes/local_business_universe.sql
+++ b/databricks/recipes/local_business_universe.sql
@@ -11,7 +11,7 @@
 -- Prereqs:
 --   ../01_setup.sql
 --   ../tools/nimble_agent_run.sql
---   Outbound networking enabled for the warehouse (see ../00_prereqs.md §1.5).
+--   Outbound networking enabled for the warehouse (see ../INSTALL.md §1.5).
 --
 -- Run this in the Databricks SQL editor (Run All). The CTAS fans out one
 -- google_maps_search call per query (~20 here), so it runs for a few minutes —

--- a/databricks/recipes/nimble_agent_describe.sql
+++ b/databricks/recipes/nimble_agent_describe.sql
@@ -1,0 +1,17 @@
+-- Basic nimble_agent_describe patterns. Prereqs:
+--   ../01_setup.sql
+--   ../tools/nimble_agent_describe.sql
+--
+-- nimble_agent_describe is a table function (UDTF) — call it in the FROM clause.
+-- It returns one row per INPUT parameter of a single agent, so you know what to
+-- pass to nimble_agent_run (param names differ per agent).
+
+-- 1. All input params for one agent.
+SELECT param_name, required, type, is_localization_param
+FROM nimble_integration.tools.nimble_agent_describe('amazon_pdp');
+
+
+-- 2. Just the required params — the minimum you must supply to run it.
+SELECT param_name, type
+FROM nimble_integration.tools.nimble_agent_describe('amazon_serp')
+WHERE required;

--- a/databricks/tools/nimble_agent_describe.sql
+++ b/databricks/tools/nimble_agent_describe.sql
@@ -1,0 +1,160 @@
+/*
+ * tools/nimble_agent_describe.sql — wraps Nimble's GET /v1/agents/{agent_name}
+ * endpoint as a UC table function. Returns one row per INPUT PROPERTY of a
+ * single agent — the exact param names, types, and required/localization/
+ * pagination flags you need to build a valid nimble_agent_run params_json.
+ *
+ * Why this exists: nimble_agent_list() tells you which agents exist, but not
+ * how to call them. Param names differ across agents (Amazon search wants
+ * `keyword`, not `query`) and localization is per-agent — so discover inputs at
+ * runtime, never hardcode. Output FIELDS are intentionally NOT returned here
+ * (they are large and best discovered from a real call): run the agent once and
+ * inspect `to_json(parsing[0])` to see the emitted fields.
+ *
+ * Privileges: USE on nimble_integration + nimble_integration.tools; plus
+ *             CREATE FUNCTION on the schema; READ on secret('nimble','api_key').
+ * Creates:    nimble_integration.tools._nimble_agent_describe(...) RETURNS TABLE  (Python UDTF)
+ *             nimble_integration.tools.nimble_agent_describe(...)   RETURNS TABLE  (public wrapper)
+ * Prereq:     01_setup.sql has run; the `nimble` secret scope + `api_key` exist;
+ *             the workspace Preview "Enable networking for isolated workloads in
+ *             Serverless SQL Warehouses" is ON and the warehouse was cold-restarted.
+ * Runtime:    ~5 seconds to create; ~1-3s per call.
+ *
+ * API docs:   https://docs.nimbleway.com/api-reference/agents/get-agent-details
+ *             (append `.md` to the URL for the plain-text spec)
+ *
+ * Design (UDTF-only):
+ *   Databricks Genie registers TABLE functions as tools, so every capability
+ *   ships as a table function — no scalar / `_table` twin to maintain.
+ *     - _nimble_agent_describe : LANGUAGE PYTHON UDTF. eval() does requests.get
+ *                                and yields one row per input property, with the
+ *                                agent-level vertical/entity_type/domain and the
+ *                                localization/pagination feature flags repeated on
+ *                                each row. `import`s live INSIDE eval(). Yields
+ *                                zero rows on error (or for an unknown agent).
+ *     - nimble_agent_describe  : thin SQL RETURNS TABLE wrapper that injects the
+ *                                API key via secret().
+ *
+ * Notes on parameters:
+ *   - agent_name: the agent name from nimble_agent_list, e.g. "amazon_serp".
+ */
+
+CREATE OR REPLACE FUNCTION nimble_integration.tools._nimble_agent_describe(
+    agent_name STRING,
+    api_key    STRING
+)
+RETURNS TABLE(
+    agent_name               STRING,
+    param_name               STRING,
+    required                 BOOLEAN,
+    type                     STRING,
+    description              STRING,
+    is_localization_param    BOOLEAN,
+    is_pagination_param      BOOLEAN,
+    default_value            STRING,
+    examples_json            STRING,
+    vertical                 STRING,
+    entity_type              STRING,
+    domain                   STRING,
+    is_localization_supported BOOLEAN,
+    is_pagination_supported   BOOLEAN
+)
+LANGUAGE PYTHON
+HANDLER 'Handler'
+COMMENT 'Internal Python UDTF behind nimble_agent_describe(). Call the public nimble_agent_describe() wrapper instead.'
+AS $$
+class Handler:
+    def eval(self, agent_name, api_key):
+        import json
+        import requests
+
+        def as_bool(v):
+            if isinstance(v, bool):
+                return v
+            if isinstance(v, str):
+                return v.strip().lower() == "true"
+            return None
+
+        if not agent_name:
+            return
+
+        headers = {
+            "Authorization": "Bearer " + (api_key or ""),
+            "Content-Type": "application/json",
+            "X-Client-Source": "nimble-dbx-udtf",
+        }
+        try:
+            resp = requests.get(
+                "https://sdk.nimbleway.com/v1/agents/" + agent_name,
+                headers=headers,
+                timeout=30,
+            )
+            data = resp.json() if 200 <= resp.status_code < 300 else {}
+        except Exception:
+            data = {}
+
+        if not isinstance(data, dict) or not data:
+            return
+
+        vertical = data.get("vertical")
+        entity_type = data.get("entity_type")
+        domain = data.get("domain")
+        flags = data.get("feature_flags") or {}
+        loc_supported = as_bool(flags.get("is_localization_supported"))
+        pag_supported = as_bool(flags.get("is_pagination_supported"))
+
+        props = data.get("input_properties") or []
+        for p in props:
+            if not isinstance(p, dict):
+                continue
+            examples = p.get("examples")
+            examples_json = json.dumps(examples) if examples is not None else None
+            default_val = p.get("default")
+            default_value = None if default_val is None else str(default_val)
+            yield (
+                agent_name,
+                p.get("name"),
+                as_bool(p.get("required")),
+                p.get("type"),
+                p.get("description"),
+                as_bool(p.get("is_localization_param")),
+                as_bool(p.get("is_pagination_param")),
+                default_value,
+                examples_json,
+                vertical,
+                entity_type,
+                domain,
+                loc_supported,
+                pag_supported,
+            )
+$$;
+
+CREATE OR REPLACE FUNCTION nimble_integration.tools.nimble_agent_describe(
+    agent_name STRING
+        COMMENT 'Agent name from nimble_agent_list, e.g. "amazon_serp". Required.'
+)
+RETURNS TABLE(
+    agent_name                STRING  COMMENT 'The agent that was described.',
+    param_name                STRING  COMMENT 'Input parameter name to put in nimble_agent_run params_json, e.g. "keyword".',
+    required                  BOOLEAN COMMENT 'Whether this parameter is required.',
+    type                      STRING  COMMENT 'Parameter type, e.g. string, integer.',
+    description               STRING  COMMENT 'What the parameter does.',
+    is_localization_param     BOOLEAN COMMENT 'TRUE if this param localizes results (e.g. zip_code); set localization=TRUE on nimble_agent_run to use it.',
+    is_pagination_param       BOOLEAN COMMENT 'TRUE if this param paginates results (e.g. page).',
+    default_value             STRING  COMMENT 'Default value for the parameter, if any (as a string).',
+    examples_json             STRING  COMMENT 'Example values as a JSON array string, if provided.',
+    vertical                  STRING  COMMENT 'Agent vertical / category, e.g. Ecommerce. Repeated on every row.',
+    entity_type               STRING  COMMENT 'Entity the agent targets, e.g. Product Detail Page (PDP). Repeated on every row.',
+    domain                    STRING  COMMENT 'Primary target domain, e.g. www.amazon.com. Repeated on every row.',
+    is_localization_supported BOOLEAN COMMENT 'Whether the agent supports localization at all. Repeated on every row.',
+    is_pagination_supported   BOOLEAN COMMENT 'Whether the agent supports pagination at all. Repeated on every row.'
+)
+COMMENT 'Describes a single Nimble agent: one row per INPUT property (param_name, required, type, localization/pagination flags, default, examples), with the agent vertical/entity_type/domain and feature flags repeated on each row. Use to learn the exact params to pass to nimble_agent_run before calling it (param names and localization differ per agent). Does NOT return output fields — discover those by running the agent once and inspecting to_json(parsing[0]). Returns zero rows on failure or unknown agent rather than raising.'
+RETURN SELECT * FROM nimble_integration.tools._nimble_agent_describe(
+    agent_name, secret('nimble', 'api_key')
+);
+
+-- Smoke test (uncomment to verify after deploy):
+-- SELECT param_name, required, type, is_localization_param
+-- FROM nimble_integration.tools.nimble_agent_describe('amazon_pdp');
+-- Expect: asin (required, string) and zip_code (is_localization_param = true).


### PR DESCRIPTION
## What

Adds **`nimble_agent_describe(agent_name)`** — a UC table function wrapping `GET /v1/agents/{agent_name}` that returns **one row per agent input parameter** (`param_name`, `required`, `type`, localization/pagination flags, `default_value`, `examples_json`, plus agent-level `vertical`/`entity_type`/`domain` and feature flags).

It fills the gap `nimble_agent_list` leaves: list tells you *which* agents exist, but not *how to call them*. Param names differ per agent (Amazon search wants `keyword`, not `query`) and localization is per-agent — so this lets you build a valid `nimble_agent_run` `params_json` without guessing.

Output *fields* are intentionally left out (they're large and best discovered from a real call — run the agent once and inspect `to_json(parsing[0])`).

## Why

Unblocks packaging the `nimble-databricks-data-products` Agent Skill for **Databricks Genie Code** (INNOV-391), whose Agent mode is SQL/notebook-native with no `nimble` CLI. The skill's only hard CLI dependency for agent discovery was `nimble agent get`; this UDTF is its SQL-native replacement (`agent_describe` was dropped during the UDTF-only rebuild in #9, so this re-adds it as a proper table function).

## Changes

- **New:** `tools/nimble_agent_describe.sql` (UDTF + thin SQL wrapper, same pattern as the other tools — `secret()` injection, zero rows on error).
- **New:** `recipes/nimble_agent_describe.sql` (basic patterns).
- Wired into `README.md`, `helpers/nimble_genie_instructions.md`, and `helpers/create_genie_space.py`.

### Docs cleanup (drive-by)
- Renamed `00_prereqs.md` → **`INSTALL.md`** — it already covers prereqs *and* deploy, so the old name under-labeled it. Now the single source of truth for setup/deploy.
- Removed the duplicated deploy block from `README.md` (it appeared in both files); README now points to `INSTALL.md`.
- Deploy snippet now auto-resolves the warehouse id (`databricks warehouses list -o json | jq -r '.[0].id'`) and folds setup into the single deploy loop.

## Testing

Function not yet deployed live — smoke test (uncommented in the tool file) is next, in the demo workspace:
\`\`\`sql
SELECT param_name, required, type, is_localization_param
FROM nimble_integration.tools.nimble_agent_describe('amazon_pdp');
-- expect: asin (required) + zip_code (is_localization_param = true)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)