### PR TITLE
docs(databricks): add Genie Code custom skill (nimble-data-products)

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -30,6 +30,7 @@ databricks/
   recipes/                 runnable SQL — per-tool snippets + end-to-end recipes
     local_business_universe.sql   stitch many agent calls → governed Delta table
   helpers/                 deploy_sql.py (multi-statement deploy) + create_genie_space.py
+  genie-code-skills/       custom Agent Skill for Databricks Genie Code (NL → Delta → dashboard/app)
 ```
 
 Every tool is a **table function** — call it in the FROM clause. Each `tools/*.sql` ships a Python **UDTF** (`_name`, does the HTTP call and yields rows) plus a thin SQL `RETURNS TABLE` wrapper (`name`, supplies DEFAULTs and injects the API key). The public wrapper is what you call and what Genie registers; there is no scalar twin.
@@ -89,6 +90,13 @@ python3 databricks/helpers/create_genie_space.py \
     --function nimble_integration.tools.nimble_agent_describe \
     --function nimble_integration.tools.nimble_agent_run
 ```
+
+## Use it from Genie Code
+
+For **Genie Code** (Agent mode), [`genie-code-skills/`](genie-code-skills/) ships a custom Agent Skill that turns a
+plain-English brief into a Databricks data product end to end (discover agents → ingest into Delta →
+build a dashboard/app), built on the table functions above. See [`genie-code-skills/README.md`](genie-code-skills/README.md)
+for install (User or Workspace skill) and the Git-folder sync path.
 
 ## Conventions
 

--- a/databricks/genie-code-skills/README.md
+++ b/databricks/genie-code-skills/README.md
@@ -1,0 +1,77 @@
+# Genie Code skills — Nimble on Databricks
+
+Custom [Agent Skills](https://agentskills.io/specification) for **Databricks Genie Code** (Agent
+mode). They package the "live web data → Delta → dashboard/app" workflow so a user can ask Genie Code
+in plain English and it drives the whole flow natively — using the Nimble Unity Catalog functions
+([`../`](../) cookbook) plus Genie's native dashboard agent and AppsAgent. No `nimble` CLI, no shell
+scripts.
+
+## What's here
+
+```
+genie-code-skills/
+└── nimble-data-products/   ← the skill (folder name = skill `name`)
+    ├── SKILL.md                        discover → ingest → dashboard/app workflow
+    └── references/
+        ├── nimble-agents.md            SQL discovery + the control-table + LATERAL ingest
+        ├── deliverables.md             per-vertical views + how to instruct the dashboard agent / AppsAgent
+        └── branding.md                 "Powered by Nimble"
+```
+
+## Prerequisite
+
+The Nimble × Databricks integration must be installed (the five `nimble_integration.tools.*` table
+functions). See [`../INSTALL.md`](../INSTALL.md). The skill's Phase 0 gate checks for them and stops
+with install guidance if missing.
+
+## Install
+
+Genie Code loads skills from a `.assistant/skills/` directory (see the Databricks
+[agent skills guide](https://docs.databricks.com/aws/en/genie-code/skills)). Copy the skill folder
+there — the folder name must stay `nimble-data-products`.
+
+- **User skill** (just you; the prototype path): `/Users/{username}/.assistant/skills/`
+- **Workspace skill** (org-wide; admins): `Workspace/.assistant/skills/`
+
+Quickest path — open the skills folder from the Genie Code panel (**⚙ Settings → Open skills folder**)
+and copy the folder in. Then start a **new** Agent-mode chat (edits don't apply to active threads).
+
+### Keep it in sync with this repo (recommended)
+
+Back the skills folder with a [Databricks Git folder](https://docs.databricks.com/aws/en/repos/) so
+updates here flow to the workspace:
+
+1. In the workspace, create a Git folder from this repo.
+2. Point `.assistant/skills/nimble-data-products` at
+   `databricks/genie-code-skills/nimble-data-products` (symlink/copy on pull, or clone the repo
+   under `.assistant/skills/` and keep only this subtree).
+3. `git pull` to update; start a new Agent-mode chat to pick up changes.
+
+(Manual copy works too — just re-copy the folder when it changes.)
+
+## Use
+
+In a Genie Code [Agent-mode](https://docs.databricks.com/aws/en/genie-code/use-genie-code) chat,
+describe the goal in plain English — the skill auto-loads by its description (skills load only in
+Agent mode). Examples:
+
+- `pricing comparison on dog products from Amazon and Walmart`
+- `scrape Zillow listings for Austin into a Delta table and build a dashboard`
+- `show competitor prices from the web in a dashboard`
+
+You can also `@`-mention the skill to force it.
+
+## Relationship to the Claude Code / Cursor skill
+
+The same workflow ships as a published skill in [`Nimbleway/agent-skills`](https://github.com/Nimbleway/agent-skills)
+for Claude Code and Cursor, where it uses helper scripts and the `databricks` CLI. This Genie Code
+variant is built for Genie's native execution: discovery/ingest run as inline SQL, dashboards go to
+Genie's dashboard agent, and apps go to the AppsAgent (Python frameworks by default — Streamlit / Dash
+/ Gradio — with React supported build-less via a CDN).
+
+## See also
+
+- [Use Genie Code](https://docs.databricks.com/aws/en/genie-code/use-genie-code) — Agent mode, modes, and how Genie Code works.
+- [Extend Genie Code with agent skills](https://docs.databricks.com/aws/en/genie-code/skills) — the authoritative guide to creating and installing custom skills (`.assistant/skills/`, User vs Workspace, `@`-mention).
+- [Nimble × Databricks integration](../README.md) — the `nimble_integration.tools.*` SQL functions this skill builds on.
+- [Agent Skills specification](https://agentskills.io/specification) — the open standard both this skill and Genie Code follow.

--- a/databricks/genie-code-skills/nimble-data-products/SKILL.md
+++ b/databricks/genie-code-skills/nimble-data-products/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: nimble-data-products
+description: |
+  Builds a Databricks data product from live web data, natively in Genie Code, end to end:
+  discovers the right Nimble web-data agents, scrapes into a Delta table, and assembles an AI/BI
+  dashboard — table → dashboard, for a quick demo or a real data product. Use whenever a request
+  pairs live or scraped web data WITH a Databricks destination — e.g. "pricing comparison on dog
+  products from Amazon and Walmart", "scrape Zillow/Instagram/Maps/search results into a Delta table
+  and build a dashboard", "show competitor prices from the web in a dashboard", "live web data in
+  Databricks". Runs entirely on SQL + Genie's native dashboard agent via the Nimble Unity Catalog
+  functions — no CLI, no shell. Do NOT use for generic Databricks work with no live-web-data angle.
+---
+
+# Nimble on Databricks — live web data → Delta → dashboard (Genie Code)
+
+Turn a natural-language brief like `pricing comparison on dog products from Amazon and Walmart` into a
+working Databricks data product, all inside Genie Code:
+**discover agents (SQL) → ingest live web data into a Delta table (SQL) → build an AI/BI dashboard
+and/or a deployed app (Genie's native dashboard agent + AppsAgent) → deliver the link + headline.**
+
+You run everything natively — SQL against the warehouse and Genie's built-in dashboard agent. There is
+**no `nimble` CLI, no `databricks` CLI, and no shell**: every Nimble capability is a Unity Catalog
+table function in `nimble_integration.tools`, and dashboards/apps are built by Genie's native
+dashboard agent and AppsAgent.
+
+## Golden rules
+
+- **Discover, don't assume.** Read agent names with `nimble_agent_list()`, input params with
+  `nimble_agent_describe('<agent>')`, and output fields by probing one call
+  (`SELECT parsing FROM nimble_agent_run(...)`). Never hardcode from memory — Amazon search takes
+  `keyword`, not `query`.
+- **Probe before fanning out.** Run one `nimble_agent_run` per source first to learn its real field
+  names, the localization flag, and value formats (some sources return numeric prices, others
+  currency strings). This catches surprises in ~40s instead of after a wasted full round.
+- **One unified table.** A `source` column + a normalized core (`product_name, price, currency,
+  rating, review_count, brand, url, …`) + a `raw VARIANT` catch-all. Keep only fields the chosen
+  agents actually emit.
+- **Defensive casts, per-agent localization.** Strip non-numerics before casting prices
+  (`try_cast(regexp_replace(...))`), and set localization per agent (it is not global).
+- **Confirm the target before writing.** Recommend a writable `catalog.schema` (default
+  `users.<username>`) and confirm before creating tables.
+- **Branding is always on, neutral.** "Powered by Nimble", light theme, yellow as an accent only.
+  See `references/branding.md`.
+- **End with the link + the one-sentence insight** (e.g. the price gap).
+
+## Workflow
+
+Track these as todos so nothing is skipped.
+
+### Phase 0 — Preflight (SQL only)
+1. `SELECT current_user()` — capture the username (for the default `users.<username>` schema).
+2. **Integration gate** — confirm all five Nimble functions exist:
+   ```sql
+   SHOW FUNCTIONS IN nimble_integration.tools;
+   -- expect: nimble_search, nimble_extract, nimble_agent_list, nimble_agent_describe, nimble_agent_run
+   ```
+   **If missing → STOP** and tell the user to install the Nimble × Databricks integration from the
+   cookbook (<https://github.com/Nimbleway/cookbook/tree/main/databricks>). Do not try to auto-install.
+3. **Recommend + confirm** a writable `catalog.schema` (default `users.<username>`). Verify
+   writability — some shared catalogs deny `CREATE TABLE`.
+
+(Genie runs against a SQL warehouse already, so there is no warehouse selection step.)
+
+### Phase 1 — Interpret the brief + clarify
+Parse the brief into: **domain/entity · search terms · sources · analysis goal**. Then confirm:
+- **Deliverable** — table, table + dashboard, or table + dashboard + app (always ask).
+- **Sources** — the agents you matched (e.g. Amazon + Walmart SERP).
+- **Volume** — default ~8–10 search terms, ~100+ rows/source.
+
+Keep the brief's intent (the "analysis goal") — it picks the Phase 4 dashboard shape and the headline.
+
+### Phase 2 — Discover agents + map a unified schema
+See `references/nimble-agents.md`.
+1. `nimble_agent_list()` (SQL) — filter by the source/domain keywords.
+2. `nimble_agent_describe('<agent>')` (SQL) — read each chosen agent's input params (required ones,
+   exact names, localization/pagination flags). Output fields come from the §2.5 probe, not here.
+3. Design **one unified table**: `source` column + normalized core + `raw VARIANT`.
+
+### Phase 3 — Ingest (control table + one set-based INSERT)
+See `references/nimble-agents.md` for the full SQL.
+1. **Probe one call per source first** — read the real field names, localization flag, and price format.
+2. Create a **control (queries) table** (one row per source × term) and the **unified results table**.
+3. Run **one INSERT** that calls `nimble_agent_run` via a correlated `LATERAL` join over the control
+   table (with a `/*+ REPARTITION(N) */` hint so the agent calls run in parallel). It is one
+   long-running statement — Genie runs it inline; the live agent calls take ~30–40s each, parallelized.
+4. **Reconcile against the control table** (LEFT JOIN) to confirm every source landed data; if a
+   source shows 0, re-check its localization flag and casts.
+
+### Phase 4 — Build the deliverable(s) — Genie's native agents
+Genie builds both deliverables natively from plain-English intent — describe **what**; the agents
+assemble it. Do **not** hand-write Lakeview JSON or scaffold app files yourself. Pick the per-vertical
+view set and the exact hand-off wording from `references/deliverables.md`.
+
+- **Dashboard** → hand off to Genie's built-in **dashboard agent**: point it at the unified results
+  table, request the per-vertical widgets (KPIs, comparison bars, price-vs-rating scatter, product
+  table with Open links), apply branding (title wordmark + a top text widget "Live web data · Powered
+  by Nimble", yellow accent), and publish.
+- **App** (only if chosen) → create a Databricks App; Genie's **AppsAgent** scaffolds and deploys it.
+  Default to a **Python** framework (Streamlit / Dash / Gradio) — the native path for Genie Code apps
+  (React is supported too, build-less via a CDN). Tell it to query the
+  unified table, show the per-vertical views, and brand it "Powered by Nimble" (light theme, yellow
+  accent). Confirm it reaches RUNNING and grab the URL.
+
+For multi-source briefs, always include the cross-source comparison (aggregate bars by source) and,
+if confident item-level matches exist, a "same-product price gap" view.
+
+### Phase 5 — Verify, deliver & headline
+- Confirm the dashboard published; collect the link.
+- Summarize what was built and the **headline insight** (the comparison takeaway).
+- Offer iterations (more charts, item-level matching, a scheduled refresh).
+
+## Reference map
+- `references/nimble-agents.md` — discovery, schema mapping, the control-table + `LATERAL` ingest SQL, and gotchas.
+- `references/deliverables.md` — per-vertical view sets + the instructions to give Genie's dashboard agent and AppsAgent.
+- `references/branding.md` — "Powered by Nimble" tokens + how to brand an AI/BI dashboard.

--- a/databricks/genie-code-skills/nimble-data-products/references/branding.md
+++ b/databricks/genie-code-skills/nimble-data-products/references/branding.md
@@ -1,0 +1,28 @@
+# Branding — "Powered by Nimble" (always on, neutral)
+
+Branding is **always applied** (no flag). The look is **neutral light**: clean light UI, Nimble
+yellow used only as an accent — never as the page background.
+
+## Tokens
+- **Nimble yellow** `#F2F23B` — accent only (links, highlights, primary chart series).
+- **Black** `#0A0A0A` — text.
+- **Background** white / near-white. Light theme everywhere.
+
+## On the AI/BI dashboard (what to tell the dashboard agent)
+- Prefix the dashboard name with the mark + "Powered by Nimble"
+  (e.g. `"🐶 Dog Products: Amazon vs Walmart · Powered by Nimble"`).
+- Add a markdown **text widget** at the top: `_Live web data · **Powered by Nimble**_`.
+- Set the **primary chart series** color to `#F2F23B` where it reads well on light; keep contrast
+  legible (yellow fills, black text — never yellow text on white).
+
+## In a Databricks App (Python — Dash / Gradio / Streamlit)
+The AppsAgent scaffolds a Python app, so brand it in that framework (no React/AppKit):
+- A **header** with the "Powered by Nimble" wordmark (markdown/HTML text is fine; add the logo image
+  only if one is available in the app's static dir).
+- **Light theme**; Nimble yellow `#F2F23B` as the accent on primary chart series / highlights.
+- A small **footer** credit "Powered by Nimble" linking to <https://www.nimbleway.com>.
+Keep it a tasteful credit — let the AppsAgent place it in the header/footer.
+
+## Tone
+A tasteful "made with" credit, not a takeover. Neutral, professional, yellow as a spark — not a
+yellow wall.

--- a/databricks/genie-code-skills/nimble-data-products/references/deliverables.md
+++ b/databricks/genie-code-skills/nimble-data-products/references/deliverables.md
@@ -1,0 +1,69 @@
+# Deliverables — what to tell Genie's native dashboard agent and AppsAgent
+
+Genie Code builds both deliverables **natively** from plain-English intent — you describe **what**,
+the specialized agents assemble it. **Do not hand-write Lakeview JSON or scaffold app files yourself.**
+
+- **Dashboard** → Genie's built-in **dashboard agent**: creates the dashboard, builds datasets from a
+  UC table, adds widgets, renders them, and publishes.
+- **App** → Genie's **AppsAgent**: `create a Databricks App`, then the AppsAgent scaffolds and
+  deploys it. **Default to a Python framework** (Streamlit / Dash / Gradio) — the native path for Genie
+  Code apps, fast and reliable for a demo. React is supported too and runs build-less (React from a
+  CDN, inline) — choose it only when the user wants a richer UI.
+
+## Per-vertical widget / view sets
+
+Pick by the matched agents' `vertical` / `entity_type` — this drives both the dashboard widgets and
+the app's views:
+
+| Vertical | Views to request |
+|----------|------------------|
+| **Ecommerce** (SERP/PDP/CLP) | KPIs (product count, avg price); avg price & listing count by source/keyword; sponsored share; price-vs-rating scatter; product table with Open links; **multi-source → comparison bars + best-effort item-level price gap** |
+| **Social** | volume/engagement by account/post; top-content table; like/follower distributions |
+| **Real Estate** | price & price/sqft; listings by location; beds/baths breakdowns |
+| **Maps / Local** | avg rating; review counts; places table with links |
+| **LLM / AEO** | source/answer presence; share-of-voice; citation table |
+| **_fallback_** | KPIs + 2 categorical bars + the raw table (works off any schema) |
+
+**Comparison depth (multi-source):** always include the aggregate comparison (avg price/rating by
+source); *additionally* attempt item-level matching (normalize brand + key tokens) and, if confident,
+add a "same-product price gap" view — otherwise keep the aggregate and note matching wasn't confident.
+
+## Dashboard — how to hand it off
+
+Instruct the dashboard agent with the **source table**, the **widgets** (above), and **branding**.
+Example:
+
+> Build an AI/BI dashboard named "🐶 Dog Products: Amazon vs Walmart · Powered by Nimble" on
+> `users.<me>.dog_products`. Add: KPI counters for product count and average price; a bar of average
+> price by source; a price-vs-rating scatter colored by source; a comparison bar of average price per
+> keyword across sources; and a product table (name, source, price, rating) with the URL as a
+> clickable Open link. Add a markdown text widget at the top reading "_Live web data · **Powered by
+> Nimble**_". Use Nimble yellow (#F2F23B) as the primary series accent on a light theme. Then publish.
+
+The agent reads the table schema itself — don't pre-declare datasets. Confirm it published; grab the link.
+
+## App — how to hand it off
+
+Only if the user chose the **+app** deliverable. Create the app, then let the AppsAgent scaffold +
+deploy. Example:
+
+> Create a Databricks App named "nimble-dog-products". Scaffold a minimal Streamlit (or Dash) app that
+> queries `users.<me>.dog_products` and shows: KPI metrics (product count, avg price), an average-price-
+> by-source bar, a price-vs-rating scatter, and a searchable product table with clickable URLs. Brand
+> it "Powered by Nimble" — light theme, a header with the wordmark, Nimble yellow (#F2F23B) accent.
+> Deploy it and give me the URL.
+
+The AppsAgent owns the scaffold (`app.py`, `app.yaml`), the SQL-warehouse wiring, and the deploy — you
+supply the table, the views (per-vertical, above), and the branding (`references/branding.md`).
+Confirm it reached **RUNNING** and collect the URL.
+
+**Framework note:** default to **Python** (Streamlit / Dash / Gradio) — the native path, fastest and
+most reliable for a demo. React is supported too and runs build-less (CDN-inline); choose it only when
+the user wants a richer UI.
+
+## Notes
+
+- If a widget/view comes out wrong (e.g. a currency-string price treated as text), the fix is upstream:
+  the defensive numeric cast in the ingest (`references/nimble-agents.md` §4), not the deliverable.
+- App vs dashboard is the user's per-run choice (Phase 1). A dashboard is the fast default; an app is
+  the richer, interactive "never leave Databricks" deliverable.

--- a/databricks/genie-code-skills/nimble-data-products/references/nimble-agents.md
+++ b/databricks/genie-code-skills/nimble-data-products/references/nimble-agents.md
@@ -1,0 +1,138 @@
+# Nimble agents — discover, introspect, ingest (Genie Code, SQL-native)
+
+The heart of the skill: find the right agents, learn their exact I/O at runtime, and load their
+output into a Delta table — all via SQL against `nimble_integration.tools`. **Never hardcode an
+agent's params or output from memory** — read them live. (Example trap: Amazon search wants
+`keyword`, not `query`.)
+
+## 1. Discover agents
+
+> Agent names here (`amazon_serp`, `walmart_serp`, …) are illustrative. The catalog evolves — always
+> discover names at runtime with `nimble_agent_list()` and introspect with `nimble_agent_describe`.
+
+```sql
+SELECT name, display_name, vertical, entity_type, domain
+FROM nimble_integration.tools.nimble_agent_list()
+WHERE lower(domain) LIKE '%amazon%' OR lower(name) LIKE '%amazon%'
+ORDER BY name;
+```
+Match the brief's **sources** against `name`/`domain`, and pick the `entity_type` that fits the goal:
+**SERP** (keyword → many product rows, best for assortment/pricing), **PDP** (per-URL detail),
+**CLP/best_sellers** (category pages). For "analysis on X from <retailers>", `*_serp` is usually right.
+
+## 2. Introspect the chosen agents — read the INPUTS
+
+```sql
+SELECT param_name, required, type, is_localization_param, is_pagination_param, default_value, examples_json
+FROM nimble_integration.tools.nimble_agent_describe('amazon_serp')
+ORDER BY required DESC;
+```
+- **The required param is your search term** — e.g. `keyword`, not `query`. Use its exact `param_name`
+  when you build `params_json` in §3/§4.
+- **`is_localization_param`** flags the localization input (e.g. `zip_code`); **`is_pagination_param`**
+  the pagination input (e.g. `page`). `default_value` / `examples_json` give sane starting values.
+
+Do this for **every** chosen source — param names differ across agents.
+
+> **Output fields come from a probe, not from `describe`** (which returns inputs only). Learn the
+> emitted fields by running the agent once and inspecting the payload — see §2.5.
+
+## 2.5 Probe ONE call per source before fanning out (fail fast)
+
+Before seeding the control table, run **one** call per source and inspect three things — it surfaces
+the surprises in ~40s instead of after a wasted full round:
+
+```sql
+SELECT status,
+       to_json(parsing[0]) AS first_item,            -- see the REAL field names
+       parsing[0]:price, parsing[0]:product_price     -- which price field exists?
+FROM nimble_integration.tools.nimble_agent_run('walmart_serp', to_json(named_struct('keyword','dog food')), true);
+```
+Decide, per source: (1) **localization flag** — per-agent; if `parsing` is empty, flip it and re-probe;
+(2) **field names** — they vary (`price` vs `product_price`); (3) **value format** — sample a price;
+some are plain numbers, others currency strings like `"$125.99"` (a bare `CAST` rejects those).
+
+## 3. Two tables: a control table + the unified results table
+
+Drive everything from a **control (queries) table** so the run is set-based, reproducible, and
+expandable — add a row, re-run.
+
+```sql
+CREATE OR REPLACE TABLE <schema>.<table>_queries (
+  source STRING, agent STRING, keyword STRING,
+  params_json STRING, localization BOOLEAN, enabled BOOLEAN
+);
+
+INSERT INTO <schema>.<table>_queries VALUES
+  -- localization is PER-AGENT (from the §2.5 probe): e.g. amazon_serp=true, walmart_serp=false.
+  ('amazon','amazon_serp','dog food',  to_json(named_struct('keyword','dog food')),  true,  true),
+  ('walmart','walmart_serp','dog food',to_json(named_struct('keyword','dog food')),  false, true);
+  -- … one row per (source × term). params_json uses each agent's REAL param name.
+
+CREATE OR REPLACE TABLE <schema>.<table> (
+  source STRING, search_keyword STRING, position INT,
+  product_name STRING, brand STRING, price DOUBLE, currency STRING,
+  rating DOUBLE, review_count INT, sponsored BOOLEAN,
+  product_url STRING, image_url STRING,
+  raw VARIANT, ingested_at TIMESTAMP
+) COMMENT 'Nimble demo — <brief>. Powered by Nimble.';
+```
+Adjust the results columns to the vertical (social → `account, post_url, likes, …`; real estate →
+`address, price, beds, baths, sqft, …`). Always keep `source`, `raw`, `ingested_at`.
+
+## 4. One set-based ingest (correlated LATERAL)
+
+A **single INSERT** runs the agent for every enabled control row and explodes the results. Coalesce
+field-name variants and use defensive numeric casts so one INSERT serves all sources.
+
+```sql
+INSERT INTO <schema>.<table>
+SELECT /*+ REPARTITION(8) */   -- ≈ number of enabled rows; keep modest (high parallelism can trip 429s)
+  q.source,
+  q.keyword AS search_keyword,
+  try_cast(v.value:position AS INT),
+  CAST(coalesce(v.value:product_name, v.value:title) AS STRING) AS product_name,
+  initcap(split(trim(CAST(coalesce(v.value:product_name, v.value:title) AS STRING)), ' ')[0]) AS brand,
+  try_cast(regexp_replace(CAST(coalesce(v.value:price, v.value:product_price) AS STRING), '[^0-9.]', '') AS DOUBLE) AS price,
+  CAST(coalesce(v.value:currency, '$') AS STRING) AS currency,
+  try_cast(regexp_replace(CAST(coalesce(v.value:rating, v.value:product_rating) AS STRING), '[^0-9.]', '') AS DOUBLE) AS rating,
+  try_cast(regexp_replace(CAST(coalesce(v.value:review_count, v.value:ratings_count) AS STRING), '[^0-9]', '') AS INT) AS review_count,
+  try_cast(v.value:sponsored AS BOOLEAN) AS sponsored,
+  CAST(coalesce(v.value:product_url, v.value:url) AS STRING) AS product_url,
+  CAST(coalesce(v.value:image_url, v.value:image) AS STRING) AS image_url,
+  v.value AS raw,
+  current_timestamp()
+FROM <schema>.<table>_queries q,
+LATERAL nimble_integration.tools.nimble_agent_run(q.agent, q.params_json, q.localization) AS r,
+LATERAL variant_explode(r.parsing) AS v
+WHERE q.enabled AND r.status = 'success';
+```
+Adjust the coalesced field names to whatever §2.5 actually showed.
+
+**Running it in Genie:** this is one long statement — **run it directly** (Genie executes it inline; no
+async wrapper or CLI needed). The live agent calls take ~30–40s each; `/*+ REPARTITION(N) */` spreads
+them across N Spark tasks so they run in parallel (set N ≈ enabled rows, kept modest — each task is a
+live call, so very high parallelism can trip HTTP 429). For hundreds of terms, batch across runs.
+A bare `CAST(v.value:price AS DOUBLE)` throws `INVALID_VARIANT_CAST` on a currency string — the
+`try_cast(regexp_replace(...))` form is harmless on numeric data and saves a wasted round.
+
+## 5. Reconcile against the control table
+
+A term that yields no items returns an empty result, and a correlated inner `LATERAL` drops empty
+rows — so reconcile to confirm every source is covered:
+```sql
+SELECT q.source, q.keyword, COALESCE(r.n, 0) AS rows
+FROM (SELECT source, keyword FROM <schema>.<table>_queries WHERE enabled) q
+LEFT JOIN (SELECT source, search_keyword AS keyword, COUNT(*) n
+           FROM <schema>.<table> GROUP BY source, search_keyword) r USING (source, keyword)
+ORDER BY rows;   -- any 0 = that (source,keyword) landed no items
+```
+If one source is 0 while another is healthy, work through: (1) **localization** flag (most common —
+flip per-agent and re-run); (2) **cast failure** on a currency string; (3) **field-name mismatch**
+(widen the coalesce). Re-run is cheap: fix the control row or cast and re-run the ingest (optionally
+`DELETE FROM <table> WHERE source = '<that source>'` first to avoid double-counting).
+
+## Search-term expansion
+If the brief names a domain but not terms (e.g. "dog products"), expand to ~8–10 sensible
+subcategories (food, treats, toys, beds, leashes, collars, crates, harness) and confirm with the user
+in Phase 1 before seeding the control table.


### PR DESCRIPTION
## What

Adds a **Databricks Genie Code** custom [Agent Skill](https://docs.databricks.com/aws/en/genie-code/skills), `nimble-data-products`, under `databricks/genie-code-skills/`. A user asks Genie Code in plain English ("pricing comparison on dog products from Amazon and Walmart") and the skill drives the full flow natively: discover Nimble agents (SQL) → ingest live web data into a Delta table → build an AI/BI dashboard and/or app.

## Why

Completes the "never leave Databricks" story for the agentic-coding surface — the Databricks analog of the Snowflake Cortex Code path. It builds on the `nimble_integration.tools.*` functions from this cookbook and runs **entirely on SQL + Genie-native execution** (no `nimble` CLI, no shell scripts).

## Design

Validated live in a Genie Code workspace. The skill maps each phase to Genie's native execution:
- **Discover / ingest** → inline SQL (`nimble_agent_list` → `nimble_agent_describe` → control table + `LATERAL nimble_agent_run`).
- **Dashboard** → Genie's native dashboard agent (no Lakeview JSON).
- **App** → Genie's native AppsAgent — Python frameworks (Streamlit/Dash/Gradio) by default, React supported build-less via a CDN.

This is the counterpart to the published Claude Code / Cursor skill in [`Nimbleway/agent-skills`](https://github.com/Nimbleway/agent-skills) (which uses helper scripts and the `databricks` CLI). The Genie variant is trimmed for native execution.

## Contents

- `databricks/genie-code-skills/nimble-data-products/` — `SKILL.md` + `references/` (`nimble-agents.md`, `deliverables.md`, `branding.md`)
- `databricks/genie-code-skills/README.md` — install (User/Workspace skill, Git-folder sync) + links to the Databricks Genie Code docs
- `databricks/README.md` — tree entry + "Use it from Genie Code" pointer

Prereq: the five `nimble_integration.tools.*` functions (see `databricks/INSTALL.md`); the skill's Phase 0 gate checks for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)