### PR TITLE
docs: align terminology to "live web search" across the Databricks integration

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -1,6 +1,6 @@
-# Databricks × Nimble: Live Web Data as SQL Table Functions
+# Databricks × Nimble: Live Web Search as SQL Table Functions
 
-Turn a Databricks workspace into a live-web data platform: Unity Catalog **table functions** backed by Nimble's APIs and agents, callable from any SQL query, notebook, dashboard, or Databricks Genie agent — and landing results in governed Delta tables.
+Turn a Databricks workspace into a live web search platform: Unity Catalog **table functions** backed by Nimble's APIs and agents, callable from any SQL query, notebook, dashboard, or Databricks Genie agent — and landing results in governed Delta tables.
 
 ```sql
 -- Live web search, straight from SQL:
@@ -61,9 +61,9 @@ In short: `01_setup.sql` creates the `nimble_integration` catalog (schemas `tool
 
 See [`recipes/`](recipes/) for runnable patterns — including `local_business_universe.sql`, which stitches many `nimble_agent_run('google_maps_search', …)` calls into a governed Delta table.
 
-## Land web data as a governed Delta table
+## Land web search data as a governed Delta table
 
-The point of SQL-native web data: results compose with `CREATE TABLE … AS` and inherit Unity Catalog governance.
+The point of SQL-native web search data: results compose with `CREATE TABLE … AS` and inherit Unity Catalog governance.
 
 ```sql
 -- A table of companies → enrich each homepage → governed Delta table.
@@ -81,7 +81,7 @@ Genie registers **table functions** as tools, so each public function is directl
 
 ```bash
 python3 databricks/helpers/create_genie_space.py \
-    --title "Nimble Web Data" --warehouse "$WH" \
+    --title "Nimble Web Search" --warehouse "$WH" \
     --parent-path "/Users/you@example.com" \
     --instructions-file databricks/helpers/nimble_genie_instructions.md \
     --function nimble_integration.tools.nimble_search \

--- a/databricks/genie-code-skills/README.md
+++ b/databricks/genie-code-skills/README.md
@@ -1,7 +1,7 @@
 # Genie Code skills — Nimble on Databricks
 
 Custom [Agent Skills](https://agentskills.io/specification) for **Databricks Genie Code** (Agent
-mode). They package the "live web data → Delta → dashboard/app" workflow so a user can ask Genie Code
+mode). They package the "live web search data → Delta → dashboard/app" workflow so a user can ask Genie Code
 in plain English and it drives the whole flow natively — using the Nimble Unity Catalog functions
 ([`../`](../) cookbook) plus Genie's native dashboard agent and AppsAgent. No `nimble` CLI, no shell
 scripts.

--- a/databricks/genie-code-skills/nimble-data-products/SKILL.md
+++ b/databricks/genie-code-skills/nimble-data-products/SKILL.md
@@ -11,11 +11,11 @@ description: |
   functions — no CLI, no shell. Do NOT use for generic Databricks work with no live-web-data angle.
 ---
 
-# Nimble on Databricks — live web data → Delta → dashboard (Genie Code)
+# Nimble on Databricks — live web search → Delta → dashboard (Genie Code)
 
 Turn a natural-language brief like `pricing comparison on dog products from Amazon and Walmart` into a
 working Databricks data product, all inside Genie Code:
-**discover agents (SQL) → ingest live web data into a Delta table (SQL) → build an AI/BI dashboard
+**discover agents (SQL) → ingest live web search data into a Delta table (SQL) → build an AI/BI dashboard
 and/or a deployed app (Genie's native dashboard agent + AppsAgent) → deliver the link + headline.**
 
 You run everything natively — SQL against the warehouse and Genie's built-in dashboard agent. There is
@@ -93,7 +93,7 @@ view set and the exact hand-off wording from `references/deliverables.md`.
 
 - **Dashboard** → hand off to Genie's built-in **dashboard agent**: point it at the unified results
   table, request the per-vertical widgets (KPIs, comparison bars, price-vs-rating scatter, product
-  table with Open links), apply branding (title wordmark + a top text widget "Live web data · Powered
+  table with Open links), apply branding (title wordmark + a top text widget "Live web search · Powered
   by Nimble", yellow accent), and publish.
 - **App** (only if chosen) → create a Databricks App; Genie's **AppsAgent** scaffolds and deploys it.
   Default to a **Python** framework (Streamlit / Dash / Gradio) — the native path for Genie Code apps

--- a/databricks/genie-code-skills/nimble-data-products/references/branding.md
+++ b/databricks/genie-code-skills/nimble-data-products/references/branding.md
@@ -11,7 +11,7 @@ yellow used only as an accent — never as the page background.
 ## On the AI/BI dashboard (what to tell the dashboard agent)
 - Prefix the dashboard name with the mark + "Powered by Nimble"
   (e.g. `"🐶 Dog Products: Amazon vs Walmart · Powered by Nimble"`).
-- Add a markdown **text widget** at the top: `_Live web data · **Powered by Nimble**_`.
+- Add a markdown **text widget** at the top: `_Live web search · **Powered by Nimble**_`.
 - Set the **primary chart series** color to `#F2F23B` where it reads well on light; keep contrast
   legible (yellow fills, black text — never yellow text on white).
 

--- a/databricks/genie-code-skills/nimble-data-products/references/deliverables.md
+++ b/databricks/genie-code-skills/nimble-data-products/references/deliverables.md
@@ -37,7 +37,7 @@ Example:
 > `users.<me>.dog_products`. Add: KPI counters for product count and average price; a bar of average
 > price by source; a price-vs-rating scatter colored by source; a comparison bar of average price per
 > keyword across sources; and a product table (name, source, price, rating) with the URL as a
-> clickable Open link. Add a markdown text widget at the top reading "_Live web data · **Powered by
+> clickable Open link. Add a markdown text widget at the top reading "_Live web search · **Powered by
 > Nimble**_". Use Nimble yellow (#F2F23B) as the primary series accent on a light theme. Then publish.
 
 The agent reads the table schema itself — don't pre-declare datasets. Confirm it published; grab the link.

--- a/databricks/helpers/create_genie_space.py
+++ b/databricks/helpers/create_genie_space.py
@@ -19,7 +19,7 @@ Discovery of the schema:
 Usage
 -----
     python databricks/helpers/create_genie_space.py \\
-        --title "Nimble Web Data" \\
+        --title "Nimble Web Search" \\
         --warehouse <warehouse-id> \\
         --parent-path "/Users/<you>@<domain>" \\
         --instructions-file path/to/instructions.md \\

--- a/databricks/helpers/nimble_genie_instructions.md
+++ b/databricks/helpers/nimble_genie_instructions.md
@@ -1,4 +1,4 @@
-### Nimble Web Data Integration
+### Nimble Web Search Integration
 
 This workspace provides Nimble's live-web capabilities through Unity Catalog **table functions**. Call them in the FROM clause.
 


### PR DESCRIPTION
Aligns positioning, naming, and descriptive copy across the Databricks integration with the term the code already uses for the capability — the `nimble_search` function is documented as **"Live web search via the Nimble Search API"**. Updates "live web data" / "web data" to "live web search" / "web search data" where appropriate.

Targeted, not a blanket find-replace — the skill auto-load trigger text is preserved.

### Changes
- **Hero titles** — `README.md` and `SKILL.md` H1s; README platform tagline
- **Dashboard banner copy** — the "· Powered by Nimble" text widget (`SKILL.md`, `references/branding.md`, `references/deliverables.md`)
- **Genie space renamed** "Nimble Web Data" → "Nimble Web Search" (`helpers/create_genie_space.py` usage, README example, `helpers/nimble_genie_instructions.md` header)
- **Descriptive copy** — "web data" → "web search data" where it names data sourced from web search ("Land … as a governed Delta table", the "→ Delta → dashboard" pipeline lines)

### Deliberately unchanged
- `SKILL.md` `description:` / auto-load **trigger text** — left as-is to avoid degrading tool selection
- "Nimble **web-data agents**" — product term
- `01_setup.sql` integration comment and `nimble_genie_instructions.md` "live-web capabilities"

🤖 Generated with [Claude Code](https://claude.com/claude-code)