### PR TITLE
Fix competitor intelligence monitor: runtime bugs and setup docs

### DIFF
--- a/apps/competitor-intelligence-monitor/agent/.gitignore
+++ b/apps/competitor-intelligence-monitor/agent/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.pyc

--- a/apps/competitor-intelligence-monitor/agent/agent.py
+++ b/apps/competitor-intelligence-monitor/agent/agent.py
@@ -16,7 +16,7 @@ from langgraph.graph import StateGraph, START, END
 from langgraph.types import Send
 from typing_extensions import TypedDict
 
-load_dotenv(override=True)
+load_dotenv(Path(__file__).parent / ".env", override=True)
 
 # ─── Load config ──────────────────────────────────────────────────────────────
 
@@ -641,11 +641,26 @@ def _finding_block(item: dict, show_competitor: bool = False) -> dict:
         summary_text = f"_{parts[0]}._\n↳ _{parts[1]}_"
     else:
         summary_text = f"_{summary}_"
+    linked_title = f"<{url}|{title}>" if url else title
     return {"type": "section", "text": {"type": "mrkdwn",
-            "text": f"{sent}  {prefix}*<{url}|{title}>*\n{summary_text}\n`{meta}`"}}
+            "text": f"{sent}  {prefix}*{linked_title}*\n{summary_text}\n`{meta}`"}}
 
 
 def post_slack(state: AgentState) -> dict:
+    if not SLACK_TOKEN or not SLACK_CHANNEL:
+        s = state.get("synthesis", {})
+        print("\n── Synthesis Results ──────────────────────────────────────")
+        print(s.get("overview", "No overview generated."))
+        for f in s.get("findings", []):
+            print(f"\n[{f.get('competitor')}] {f.get('title')}\n  {f.get('summary')}\n  {f.get('url')}")
+        if s.get("nimble_findings"):
+            print(f"\n── {YOUR_COMPANY} mentions ──")
+            for f in s.get("nimble_findings", []):
+                print(f"  {f.get('title')}\n  {f.get('url')}")
+        print("────────────────────────────────────────────────────────────\n")
+        print("Tip: add Slack credentials to .env to receive these as a formatted digest.")
+        return {}
+
     s = state.get("synthesis", {})
     overview = s.get("overview", "")
     findings = s.get("findings", [])
@@ -696,8 +711,9 @@ def post_slack(state: AgentState) -> dict:
             comp = alert.get("competitor", "")
             alert_type = alert.get("type", "")
             tag = f"{YOUR_COMPANY} Comparison" if alert_type == "nimble_comparison" else "Pitch Change"
+            linked = f"<{url}|{title}>" if url else title
             blocks.append({"type": "section", "text": {"type": "mrkdwn",
-                "text": f"{sent}  *{comp}*  —  *<{url}|{title}>*\n_{summary}_\n`{tag} · Positioning`"}})
+                "text": f"{sent}  *{comp}*  —  *{linked}*\n_{summary}_\n`{tag} · Positioning`"}})
         blocks.append({"type": "divider"})
 
     # ── Findings by competitor (max 3 each) ───────────────────────────────────
@@ -812,7 +828,8 @@ def _build_dm_blocks(name: str, team: str, overview: str, signal,
                 url = alert.get("url", "")
                 comp = alert.get("competitor", "")
                 tag = f"{YOUR_COMPANY} Comparison" if alert.get("type") == "nimble_comparison" else "Pitch Change"
-                lines.append(f"\n{sent}  *{comp}*  —  *<{url}|{title}>*\n_{summary}_\n`{tag} · Positioning`")
+                linked = f"<{url}|{title}>" if url else title
+                lines.append(f"\n{sent}  *{comp}*  —  *{linked}*\n_{summary}_\n`{tag} · Positioning`")
             blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}})
             blocks.append({"type": "divider"})
 
@@ -866,6 +883,8 @@ def _prev_delivery_date(selected_days: list, reference_date: datetime) -> str:
 
 
 def send_personalized_dms(state: AgentState) -> dict:
+    if not SLACK_TOKEN:
+        return {}
     try:
         from user_prefs import load_all_prefs, save_prefs
     except ImportError:
@@ -996,6 +1015,8 @@ def save_state(state: AgentState) -> dict:
 # ─── Weekly summary (Mondays only) ───────────────────────────────────────────
 
 def post_weekly_summary(state: AgentState) -> dict:
+    if not SLACK_TOKEN or not SLACK_CHANNEL:
+        return {}
     if NOW.weekday() != 0:  # 0 = Monday
         return {}
 

--- a/apps/competitor-intelligence-monitor/agent/onboard.py
+++ b/apps/competitor-intelligence-monitor/agent/onboard.py
@@ -2,7 +2,7 @@
 """
 Competitor Monitor — Interactive Onboarding Wizard
 
-Run with:  python onboard.py
+Run with:  python3 onboard.py
 """
 
 import json
@@ -157,24 +157,14 @@ def step_competitors():
         )
         aliases = [a.strip() for a in aliases_raw.split(",") if a.strip()]
 
-        github_repo = prompt_optional(
-            "  GitHub repo",
-            hint="owner/repo, e.g. openai/openai-python — leave blank if unknown",
-        )
-
-        pypi_package = prompt_optional(
-            "  PyPI package name",
-            hint="e.g. openai — leave blank if not on PyPI",
-        )
-
         color = pick_color(index)
         print(f"  {green('✓')} Assigned color: {bold(color)}")
 
         competitors.append({
             "name": name_raw,
             "aliases": aliases,
-            "github_repo": github_repo if github_repo else None,
-            "pypi_package": pypi_package if pypi_package else None,
+            "github_repo": None,
+            "pypi_package": None,
             "color": color,
         })
         index += 1
@@ -321,10 +311,10 @@ def print_summary(company, competitors, env_vars, config_path, env_path):
 
     print(f"\n{CYAN}{BOLD}  Next steps:{RESET}\n")
     print(f"  1. {bold('Run the agent')} (daily data collection + AI synthesis):")
-    print(f"     {green('python agent.py')}\n")
+    print(f"     {green('python3 agent.py')}\n")
     print(f"  2. {bold('Set up automated daily runs')} via GitHub Actions:")
-    print(f"     {dim('Add your .env values as repository secrets,')}")
-    print(f"     {dim('then push to main — the workflow runs at 8 AM UTC by default.')}\n")
+    print(f"     {dim('See AGENT_SETUP.md — create a standalone repo, add secrets,')}")
+    print(f"     {dim('and schedule via cron-job.org.')}\n")
     if skipped:
         print(f"  3. {bold('Add skipped integrations')} by editing {green('.env')} and re-running.\n")
 
@@ -357,7 +347,7 @@ def main():
         slack = step_slack()
         github = step_github()
     except KeyboardInterrupt:
-        print(f"\n\n  {red('Setup cancelled.')} Run {green('python onboard.py')} to start again.\n")
+        print(f"\n\n  {red('Setup cancelled.')} Run {green('python3 onboard.py')} to start again.\n")
         sys.exit(0)
 
     env_vars = {**api_keys, **slack, **github}

--- a/apps/competitor-intelligence-monitor/agent/slack_bot.py
+++ b/apps/competitor-intelligence-monitor/agent/slack_bot.py
@@ -18,7 +18,7 @@ from slack_bolt.adapter.flask import SlackRequestHandler
 
 from user_prefs import load_all_prefs, save_prefs
 
-load_dotenv(override=True)
+load_dotenv(Path(__file__).parent / ".env", override=True)
 
 # ─── Load config ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes found during a full end-to-end audit of the setup flow:

- **`load_dotenv` explicit path** — `load_dotenv(override=True)` without an explicit path fails when the working directory is not the script directory (e.g. running from a symlinked or nested path on macOS). Fixed to `load_dotenv(Path(__file__).parent / ".env", override=True)` in `agent.py` and `slack_bot.py`.
- **Slack guard** — `post_slack`, `send_personalized_dms`, and `post_weekly_summary` were calling Slack APIs even when no token was configured, returning an auth error. They now skip gracefully and print findings to the terminal instead.
- **Malformed Slack blocks** — Claude occasionally returns a finding with no URL, producing `<|title>` which causes an `invalid_blocks` error. Fixed with `f"<{url}|{title}>" if url else title` in all three call sites.
- **`onboard.py` wizard** — removed unnecessary GitHub repo / PyPI package prompts from the competitor wizard; fixed `python` → `python3` throughout; corrected the automated-runs summary to reference `AGENT_SETUP.md` rather than hardcoded incorrect schedule info.
- **`agent/.gitignore`** — added to prevent accidental `.env` commits.
- **Docs (`README.md`, `AGENT_SETUP.md`)** — fixed `cd` path (missing `apps/`), `pip` → `pip3`, added `im:write` Slack scope, clarified GitHub Actions standalone repo requirement, added Railway deployment instructions, removed incorrect schedule claim.

## Test plan

- [ ] `python3 onboard.py` — wizard runs cleanly, no GitHub/PyPI prompts, correct `python3` commands in summary
- [ ] `python3 agent.py` — loads `.env` from script directory regardless of cwd
- [ ] Agent run with no Slack config — prints findings to terminal instead of erroring
- [ ] Agent run with Slack config — posts digest without `invalid_blocks` error
- [ ] `.env` not committed when running `git add .` in the agent directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)