### PR TITLE
Store all config including API keys in config.json

### DIFF
--- a/apps/competitor-intelligence-monitor/agent/.gitignore
+++ b/apps/competitor-intelligence-monitor/agent/.gitignore
@@ -1,3 +1,3 @@
-.env
+config.json
 __pycache__/
 *.pyc

--- a/apps/competitor-intelligence-monitor/agent/agent.py
+++ b/apps/competitor-intelligence-monitor/agent/agent.py
@@ -1,4 +1,3 @@
-import os
 import re
 import json
 import requests
@@ -8,7 +7,6 @@ from pathlib import Path
 from typing import Annotated
 import operator
 
-from dotenv import load_dotenv
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 import anthropic
@@ -16,17 +14,17 @@ from langgraph.graph import StateGraph, START, END
 from langgraph.types import Send
 from typing_extensions import TypedDict
 
-load_dotenv(Path(__file__).parent / ".env", override=True)
-
 # ─── Load config ──────────────────────────────────────────────────────────────
 
 CONFIG_FILE = Path(__file__).parent / "config.json"
+if not CONFIG_FILE.exists():
+    raise SystemExit("config.json not found. Run: python3 onboard.py")
 with open(CONFIG_FILE) as _f:
     _CONFIG = json.load(_f)
 
-YOUR_COMPANY      = _CONFIG["your_company"]["name"]
-YOUR_COMPANY_ALIASES  = _CONFIG["your_company"]["aliases"]
-YOUR_COMPANY_DESC = _CONFIG["your_company"].get("description", "")
+YOUR_COMPANY         = _CONFIG["your_company"]["name"]
+YOUR_COMPANY_ALIASES = _CONFIG["your_company"]["aliases"]
+YOUR_COMPANY_DESC    = _CONFIG["your_company"].get("description", "")
 
 COMPETITOR_ALIASES = {}
 GITHUB_REPOS       = {}
@@ -40,13 +38,18 @@ for _c in _CONFIG["competitors"]:
 
 COMPETITOR_ALIASES[YOUR_COMPANY] = YOUR_COMPANY_ALIASES
 
-NIMBLE_API_KEY = os.getenv("NIMBLE_API_KEY")
-GITHUB_TOKEN = os.getenv("GH_API_KEY")
-SLACK_TOKEN = os.getenv("SLACK_BOT_TOKEN")
-SLACK_CHANNEL = os.getenv("SLACK_CHANNEL_ID")
+_KEYS = _CONFIG.get("api_keys", {})
+NIMBLE_API_KEY = _KEYS.get("NIMBLE_API_KEY", "")
+GITHUB_TOKEN   = _KEYS.get("GH_API_KEY", "")
+SLACK_TOKEN    = _KEYS.get("SLACK_BOT_TOKEN", "")
+SLACK_CHANNEL  = _KEYS.get("SLACK_CHANNEL_ID", "")
+
+_missing = [k for k, v in {"NIMBLE_API_KEY": NIMBLE_API_KEY, "ANTHROPIC_API_KEY": _KEYS.get("ANTHROPIC_API_KEY", "")}.items() if not v]
+if _missing:
+    raise SystemExit(f"Missing required keys in config.json: {', '.join(_missing)}\nRun: python3 onboard.py")
 
 slack_client = WebClient(token=SLACK_TOKEN)
-anthropic_client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+anthropic_client = anthropic.Anthropic(api_key=_KEYS.get("ANTHROPIC_API_KEY"))
 
 NOW = datetime.now(timezone.utc)
 WEEK_AGO = (NOW - timedelta(days=7)).strftime("%Y-%m-%d")

--- a/apps/competitor-intelligence-monitor/agent/onboard.py
+++ b/apps/competitor-intelligence-monitor/agent/onboard.py
@@ -223,6 +223,10 @@ def step_slack():
     print(dim("\n  Find this at: Slack App → Basic Information → App Credentials"))
     signing_secret = prompt("  SLACK_SIGNING_SECRET")
 
+    print(f"\n  {yellow('Important:')} In Slack, go to your channel and type:")
+    print(f"  {green('/invite @YourBotName')}")
+    print(dim("  (replace YourBotName with whatever you named your Slack app)"))
+
     return {
         "SLACK_BOT_TOKEN": slack_token,
         "SLACK_CHANNEL_ID": channel_id,
@@ -249,57 +253,41 @@ def step_github():
     return {"GH_API_KEY": gh_key}
 
 
-# ─── Write files ──────────────────────────────────────────────────────────────
+# ─── Write config ─────────────────────────────────────────────────────────────
 
-def write_config(company, competitors, base_dir):
+def write_config(company, competitors, api_keys, base_dir):
     config = {
         "your_company": company,
         "competitors": competitors,
+        "api_keys": api_keys,
     }
     path = base_dir / "config.json"
     path.write_text(json.dumps(config, indent=2))
     return path
 
 
-def write_env(env_vars, base_dir):
-    path = base_dir / ".env"
-    lines = []
-    for key, value in env_vars.items():
-        # Quote values that contain spaces or special chars
-        if " " in value or "=" in value or not value:
-            lines.append(f'{key}="{value}"')
-        else:
-            lines.append(f"{key}={value}")
-    path.write_text("\n".join(lines) + "\n")
-    return path
-
-
 # ─── Summary ─────────────────────────────────────────────────────────────────
 
-def print_summary(company, competitors, env_vars, config_path, env_path):
+def print_summary(company, competitors, api_keys, config_path):
     print(f"\n{GREEN}{BOLD}╔══════════════════════════════════════════════════════════╗")
     print(f"║                  SETUP COMPLETE!                         ║")
     print(f"╚══════════════════════════════════════════════════════════╝{RESET}\n")
 
     print(f"  {green('✓')} Company configured: {bold(company['name'])}")
     print(f"  {green('✓')} Competitors: {', '.join(c['name'] for c in competitors)}")
-    print(f"  {green('✓')} Files written:")
-    print(f"      {bold(str(config_path))}")
-    print(f"      {bold(str(env_path))}\n")
 
-    # What's configured vs skipped
     configured = []
     skipped = []
 
-    if env_vars.get("NIMBLE_API_KEY"):
+    if api_keys.get("NIMBLE_API_KEY"):
         configured.append("Nimble API (web search)")
-    if env_vars.get("ANTHROPIC_API_KEY"):
+    if api_keys.get("ANTHROPIC_API_KEY"):
         configured.append("Anthropic API (AI synthesis)")
-    if env_vars.get("SLACK_BOT_TOKEN"):
+    if api_keys.get("SLACK_BOT_TOKEN"):
         configured.append("Slack (daily digest + DMs)")
     else:
         skipped.append("Slack")
-    if env_vars.get("GH_API_KEY"):
+    if api_keys.get("GH_API_KEY"):
         configured.append("GitHub (release tracking)")
     else:
         skipped.append("GitHub")
@@ -316,7 +304,7 @@ def print_summary(company, competitors, env_vars, config_path, env_path):
     print(f"     {dim('See AGENT_SETUP.md — create a standalone repo, add secrets,')}")
     print(f"     {dim('and schedule via cron-job.org.')}\n")
     if skipped:
-        print(f"  3. {bold('Add skipped integrations')} by editing {green('.env')} and re-running.\n")
+        print(f"  3. {bold('Add skipped integrations')} by re-running {green('python3 onboard.py')}.\n")
 
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
@@ -326,43 +314,21 @@ def main():
 
     print_banner()
 
-    # Check for existing .env
-    env_path = base_dir / ".env"
-    if env_path.exists():
-        print(f"  {yellow('Warning:')} A {bold('.env')} file already exists at:\n"
-              f"  {env_path}\n")
-        overwrite = prompt_yes_no("  Overwrite it?", default_yes=False)
-        if not overwrite:
-            print(f"\n  {dim('Keeping existing .env — only config.json will be written.')}")
-            skip_env = True
-        else:
-            skip_env = False
-    else:
-        skip_env = False
-
     try:
         company = step_your_company()
         competitors = step_competitors()
-        api_keys = step_api_keys()
+        raw_keys = step_api_keys()
         slack = step_slack()
         github = step_github()
     except KeyboardInterrupt:
         print(f"\n\n  {red('Setup cancelled.')} Run {green('python3 onboard.py')} to start again.\n")
         sys.exit(0)
 
-    env_vars = {**api_keys, **slack, **github}
+    api_keys = {**raw_keys, **slack, **github}
+    config_path = write_config(company, competitors, api_keys, base_dir)
+    print(f"\n  {green('✓')} Configuration saved.")
 
-    # Write config.json always
-    config_path = write_config(company, competitors, base_dir)
-    print(f"\n  {green('✓')} Written: {config_path}")
-
-    # Write .env unless user chose to keep existing
-    if not skip_env:
-        written_env = write_env(env_vars, base_dir)
-        print(f"  {green('✓')} Written: {written_env}")
-    else:
-        written_env = env_path
-        print(f"  {dim('Skipped .env — existing file kept.')}")
+    print_summary(company, competitors, api_keys, config_path)
 
     print_summary(company, competitors, env_vars, config_path, written_env)
 

--- a/apps/competitor-intelligence-monitor/agent/slack_bot.py
+++ b/apps/competitor-intelligence-monitor/agent/slack_bot.py
@@ -11,14 +11,11 @@ import os
 import json
 from pathlib import Path
 
-from dotenv import load_dotenv
 from flask import Flask, request
 from slack_bolt import App
 from slack_bolt.adapter.flask import SlackRequestHandler
 
 from user_prefs import load_all_prefs, save_prefs
-
-load_dotenv(Path(__file__).parent / ".env", override=True)
 
 # ─── Load config ─────────────────────────────────────────────────────────────
 
@@ -26,10 +23,11 @@ _CONFIG_PATH = Path(__file__).parent / "config.json"
 with open(_CONFIG_PATH) as _f:
     _CONFIG = json.load(_f)
 YOUR_COMPANY = _CONFIG["your_company"]["name"]
+_KEYS = _CONFIG.get("api_keys", {})
 
 bolt_app = App(
-    token=os.getenv("SLACK_BOT_TOKEN"),
-    signing_secret=os.getenv("SLACK_SIGNING_SECRET"),
+    token=_KEYS.get("SLACK_BOT_TOKEN", ""),
+    signing_secret=_KEYS.get("SLACK_SIGNING_SECRET", ""),
 )
 
 


### PR DESCRIPTION
Removes .env / python-dotenv entirely. onboard.py now writes everything to config.json (company, competitors, api_keys). agent.py and slack_bot.py read keys directly from config.json — no environment variable loading needed. .gitignore updated to exclude config.json instead of .env.