### PR TITLE
feat(cmo-intelligence): dashboard polish + Share of AI Answer

### DIFF
--- a/snowflake/coco-skills/cmo-intelligence/CHANGELOG.md
+++ b/snowflake/coco-skills/cmo-intelligence/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to the **CMO Intelligence** Cortex Code skill are recorded here.
+The version lives in `SKILL.md` frontmatter (`version:`); this file follows
+[Keep a Changelog](https://keepachangelog.com/) and [Semantic Versioning](https://semver.org/)
+(`MAJOR.MINOR.PATCH`). Bump on every change: PATCH for fixes/copy, MINOR for new
+capability, MAJOR for a breaking change to the provisioned objects or the invocation.
+
+## [1.0.0] — 2026-07-02
+
+First versioned release. The skill provisions a complete, in-tenant digital-shelf
+intelligence app from a plain-English brief, entirely inside Snowflake.
+
+### Added
+- Conversational provisioning end to end: per-app schema, config tables (`CFG_APP` /
+  `CFG_QUERIES`), scheduled `NIMBLE_AGENT_RUN` ingestion, Cortex brand resolver,
+  analytics views, a Cortex Analyst semantic view (`SHELF_SV`), a Cortex agent, and a
+  branded Streamlit-in-Snowflake cockpit. Stays updatable after creation (add a keyword
+  = one row).
+- Cortex agent with a **live web tool** (`NIMBLE_SEARCH`) alongside `analyze_shelf`.
+- **Share of AI Answer** (`REFRESH_GEO`): real Perplexity/ChatGPT/Gemini answers via
+  Nimble's LLM agents → `GEO_ANSWERS` / `GEO_SOURCES`. Two-tier cadence — a small
+  first-setup seed (`GEO_SEED_TASK`) + a full weekly refresh (`WEEKLY_GEO_TASK`). Cockpit
+  shows a "being generated" placeholder until the first run lands.
+- **Active Alerts** (`V_ALERTS`): multi-signal — out of stock, weak content (D/F), and
+  lost page-1 rank — so alerts are meaningful at any catalog size.
+- Retailer view: **average price by brand × retailer** (on `best_price`, populated for all
+  retailers).
+- Per-app cockpit naming (unique object + brand `TITLE`); latest-*complete*-snapshot logic
+  so a mid-run day never renders an empty retailer.
+
+### Uses
+- Snowflake AISQL (`AI_COMPLETE`, latest available Sonnet + Haiku, region-probed).
+- Requires the Nimble × Snowflake integration **≥ 1.1.0** (EAI + secret + `NIMBLE_AGENT_RUN`
+  UDTF + `NIMBLE_SEARCH` UDF).

--- a/snowflake/coco-skills/cmo-intelligence/README.md
+++ b/snowflake/coco-skills/cmo-intelligence/README.md
@@ -1,5 +1,7 @@
 # CMO Intelligence — Cortex Code (CoCo) Agent Skill
 
+**Version 1.0.0** · see [`CHANGELOG.md`](CHANGELOG.md). The version lives in `SKILL.md` frontmatter and follows SemVer.
+
 A **Cortex Code Agent Skill** that conversationally provisions a complete, in-tenant
 **digital-shelf intelligence app** — a branded Streamlit cockpit + a Cortex agent + live Nimble
 web data — for any brand or category, in minutes. Nothing leaves your Snowflake account.

--- a/snowflake/coco-skills/cmo-intelligence/SKILL.md
+++ b/snowflake/coco-skills/cmo-intelligence/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: cmo-intelligence
+version: 1.0.0
 description: |
   Provisions a complete in-tenant digital-shelf / CMO intelligence app in Snowflake from live Nimble
   web data, natively in Cortex Code, end to end: a conversational intake (name a category, optionally a
@@ -210,6 +211,15 @@ and `__CORTEX_MODEL_CHEAP__` resolved in Phase 0 (2b) everywhere they appear (`_
    ```
    (Safe any time — `REFRESH_PDP` reads the cap once at the start of each run, so it only affects the
    *next* daily refresh.)
+5. **Seed Share of AI Answer — server-side, async.** Kick the one-shot GEO seed so the answer-engine
+   surfaces populate shortly, without blocking the cockpit handoff:
+   ```sql
+   EXECUTE TASK __DB__.__SCHEMA__.GEO_SEED_TASK;   -- REFRESH_GEO(-1): a small config-sized seed (CFG_APP.geo_seed_prompts)
+   ```
+   Until rows land (~3 min) the cockpit shows a "⏳ being generated…" placeholder for Share of AI
+   Answer; then the real surfaces appear. `WEEKLY_GEO_TASK` (already resumed) keeps it fresh weekly with
+   the full prompt set — answer-engine calls are slow (~12 min full run), so it's never on the daily
+   shelf cadence.
 
 ### Phase 4 — Verify & deliver
 **Object completeness gate (do this first).** The cockpit reads its views defensively — a *missing*
@@ -221,10 +231,11 @@ SELECT object_name, object_type FROM __DB__.INFORMATION_SCHEMA.OBJECTS
 WHERE object_schema = '__SCHEMA__'
   AND object_name IN ('CFG_APP','CFG_QUERIES','RAW_SERP','RAW_PDP','RAW_VOC','GEO_ANSWERS','GEO_SOURCES',
                       'BRAND_MAP','V_PRODUCT_BRAND','V_BRAND_CLASSIFIED','V_SHARE_OF_SHELF','V_CONTENT_HEALTH',
-                      'V_ALERT_OOS','V_TREND_SOS_DAILY','V_TREND_KPI','V_SENTIMENT_SUMMARY',
+                      'V_ALERT_OOS','V_ALERTS','V_TREND_SOS_DAILY','V_TREND_KPI','V_SENTIMENT_SUMMARY',
                       'V_AI_SHARE_OF_ANSWER','V_AI_TOP_SOURCES','V_NEXT_BEST_ACTIONS','SHELF_SV')
 ORDER BY object_type, object_name;
--- plus the procs (REFRESH_SHELF/REFRESH_PDP/REBUILD_BRAND_MAP), the task, the agent, the streamlit.
+-- plus the procs (REFRESH_SHELF/REFRESH_PDP/REFRESH_GEO/REBUILD_BRAND_MAP), the tasks
+-- (DAILY_SHELF_TASK, GEO_SEED_TASK, WEEKLY_GEO_TASK), the agent, the streamlit.
 ```
 > When **updating** an existing app, re-run the **entire** `views.sql` (it creates all views in one
 > pass) — never a subset, or you leave stale/missing views behind.
@@ -234,7 +245,8 @@ Then run the data checks from the README (`is_focal` not all-FALSE; `V_SHARE_OF_
 - the **cockpit** (`SHOW STREAMLITS IN SCHEMA __DB__.__SCHEMA__;` → the app URL),
 - the **agent** (`__AGENT_NAME__`, in Snowflake Intelligence → Agents),
 - the **headline** (focal share of shelf, top complaint, etc.).
-> Share of AI Answer shows 0% until the GEO backfill runs — pre-seed it for any live demo.
+> Share of AI Answer populates a few minutes after the `GEO_SEED_TASK` seed (Phase 3, step 5); until
+> then the cockpit shows a "being generated" placeholder (never a bare 0%). `WEEKLY_GEO_TASK` keeps it current.
 
 ## Lifecycle — manage the app after creation
 The skill manages a config-driven pipeline. See `references/lifecycle.md` for the SQL of each command:

--- a/snowflake/coco-skills/cmo-intelligence/assets/cockpit_template.py
+++ b/snowflake/coco-skills/cmo-intelligence/assets/cockpit_template.py
@@ -22,7 +22,12 @@ st.markdown("<style>#MainMenu,header,footer{visibility:hidden;height:0;}.block-c
             "[data-testid='stAppViewBlockContainer']{padding:0 !important;}"
             "[data-testid='stSidebar'],[data-testid='stSidebarCollapsedControl']{display:none !important;}</style>", unsafe_allow_html=True)
 session = get_active_session()
-SNAP = "(SELECT MAX(snapshot_date) FROM " + S + ".RAW_PDP)"
+# Latest COMPLETE snapshot: the day with the most retailers present in RAW_PDP (ties -> newest).
+# The daily cron fetches retailers sequentially (Target last), so a global MAX(snapshot_date)
+# can point at a half-finished run where Target has 0 rows -> the Retailer view looks empty.
+# Picking the most-complete day keeps the whole cockpit on one consistent, fully-populated date.
+SNAP = ("(SELECT snapshot_date FROM " + S + ".RAW_PDP GROUP BY snapshot_date "
+        "QUALIFY ROW_NUMBER() OVER (ORDER BY COUNT(DISTINCT retailer) DESC, snapshot_date DESC) = 1)")
 
 # Shell-first: paint a branded loading note immediately so the first (cold) load
 # isn't a blank screen with a cryptic "Running rows(...)". Cleared right before
@@ -108,19 +113,24 @@ _kpi_share = rows("SELECT retailer,"
 _kpi_unit = rows("SELECT retailer, ROUND(AVG(unit_price_amount),2) FROM " + A + ".V_BRAND_CLASSIFIED WHERE " + ff() + " AND unit_price_amount IS NOT NULL AND snapshot_date=" + SNAP + " GROUP BY ROLLUP(retailer)")
 _kpi_content = rows("SELECT retailer, ROUND(AVG(content_score),0) FROM " + A + ".V_CONTENT_HEALTH WHERE " + ff() + " AND snapshot_date=" + SNAP + " GROUP BY ROLLUP(retailer)")
 if not OVERVIEW:
-    # brand mode: V_ALERT_OOS is the single source of truth (incl. severity)
-    _kpi_oos = rows("SELECT retailer, COUNT(*) FROM " + L + ".V_ALERT_OOS WHERE snapshot_date=" + SNAP + " GROUP BY ROLLUP(retailer)")
-    _oos_rows = rows("SELECT product_name, product_image, product_url, retailer, position, best_price, severity"
-                     " FROM " + L + ".V_ALERT_OOS WHERE snapshot_date=" + SNAP + " ORDER BY position LIMIT 120")
+    # brand mode: V_ALERTS is the single source — OOS + weak content (D/F) + lost page-1 rank, with type + severity
+    _kpi_alerts = rows("SELECT retailer, COUNT(*) FROM " + L + ".V_ALERTS WHERE snapshot_date=" + SNAP + " GROUP BY ROLLUP(retailer)")
+    _alert_rows = rows("SELECT product_name, product_image, product_url, retailer, position, best_price, severity, alert_type"
+                       " FROM " + L + ".V_ALERTS WHERE snapshot_date=" + SNAP +
+                       " ORDER BY CASE severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1 WHEN 'MODERATE' THEN 2 ELSE 3 END, position LIMIT 120")
 else:
-    # overview mode: same severity buckets over the leading tier
+    # overview mode (no focal brand): V_ALERTS is is_focal-gated, so alert on OOS over the leading tier
     _ow = " AND " + ff() + " AND product_out_of_stock AND snapshot_date=" + SNAP
-    _kpi_oos = rows("SELECT retailer, COUNT(*) FROM " + A + ".V_BRAND_CLASSIFIED WHERE 1=1" + _ow + " GROUP BY ROLLUP(retailer)")
-    _oos_rows = rows("SELECT product_name, product_image, product_url, retailer, position, best_price,"
-                     " CASE WHEN position<=5 THEN 'CRITICAL' WHEN position<=24 THEN 'HIGH' WHEN position<=48 THEN 'MODERATE' ELSE 'LOW' END"
-                     " FROM " + A + ".V_BRAND_CLASSIFIED WHERE 1=1" + _ow + " ORDER BY position LIMIT 120")
+    _kpi_alerts = rows("SELECT retailer, COUNT(*) FROM " + A + ".V_BRAND_CLASSIFIED WHERE 1=1" + _ow + " GROUP BY ROLLUP(retailer)")
+    _alert_rows = rows("SELECT product_name, product_image, product_url, retailer, position, best_price,"
+                       " CASE WHEN position<=5 THEN 'CRITICAL' WHEN position<=24 THEN 'HIGH' WHEN position<=48 THEN 'MODERATE' ELSE 'LOW' END,"
+                       " 'Out of stock'"
+                       " FROM " + A + ".V_BRAND_CLASSIFIED WHERE 1=1" + _ow + " ORDER BY position LIMIT 120")
 _sos = rows("SELECT retailer, brand_tier, SUM(products_in_serp) FROM " + A + ".V_SHARE_OF_SHELF WHERE snapshot_date=" + SNAP + " GROUP BY 1,2")
-_price = rows("SELECT retailer, ROUND(AVG(IFF(" + ff() + ",unit_price_amount,NULL)),2), ROUND(AVG(IFF(NOT (" + ff() + "),unit_price_amount,NULL)),2) FROM " + A + ".V_BRAND_CLASSIFIED WHERE unit_price_amount IS NOT NULL AND snapshot_date=" + SNAP + " GROUP BY retailer")
+# Average shelf price by brand tier, per retailer. Uses best_price (the listed price),
+# always present, so every retailer renders (unit_price_amount is frequently NULL off
+# Amazon, which is why the old unit-price card showed nothing for Walmart/Target).
+_pbb = rows("SELECT retailer, brand_tier, ROUND(AVG(best_price),2) FROM " + A + ".V_BRAND_CLASSIFIED WHERE brand_tier IN " + BRANDS_IN + " AND best_price IS NOT NULL AND snapshot_date=" + SNAP + " GROUP BY 1,2")
 _grades = rows("SELECT retailer, content_grade, COUNT(*) FROM " + A + ".V_CONTENT_HEALTH WHERE " + ff() + " AND snapshot_date=" + SNAP + " GROUP BY 1,2")
 _weak = rows("SELECT product_name, product_image, product_url, retailer, content_grade, content_score, number_of_reviews FROM " + A + ".V_CONTENT_HEALTH WHERE " + ff() + " AND snapshot_date=" + SNAP + " ORDER BY content_score ASC LIMIT 120")
 
@@ -129,7 +139,7 @@ def _byret(rws):  # index ROLLUP results; the retailer-NULL row is the "All" agg
     return {(r[0] if r[0] is not None else "All"): r for r in rws}
 
 
-_si, _ui, _ci2, _oi = _byret(_kpi_share), _byret(_kpi_unit), _byret(_kpi_content), _byret(_kpi_oos)
+_si, _ui, _ci2, _oi = _byret(_kpi_share), _byret(_kpi_unit), _byret(_kpi_content), _byret(_kpi_alerts)
 
 
 def _sos_list(ret):  # share-of-shelf % by brand tier within the slice
@@ -154,8 +164,8 @@ def _prods(rws, ret, kind):
     for r in rws:
         if ret is not None and r[3] != ret:
             continue
-        if kind == "oos":
-            out.append({"name": r[0], "img": r[1], "url": r[2], "retailer": r[3], "position": int(r[4]) if r[4] is not None else None, "price": num(r[5]), "sev": r[6]})
+        if kind == "alert":
+            out.append({"name": r[0], "img": r[1], "url": r[2], "retailer": r[3], "position": int(r[4]) if r[4] is not None else None, "price": num(r[5]), "sev": r[6], "atype": r[7] if len(r) > 7 else None})
         else:
             out.append({"name": r[0], "img": r[1], "url": r[2], "retailer": r[3], "grade": r[4], "score": int(r[5]) if r[5] is not None else 0, "reviews": int(r[6]) if r[6] is not None else 0})
         if len(out) >= 9:
@@ -169,12 +179,11 @@ def slice_for(ret):
     ks = _si.get(key, [None, None, None, None]); us = _ui.get(key, [None, None])
     cs = _ci2.get(key, [None, None]); oo = _oi.get(key, [None, 0])
     b = {"kpi": {"share": num(ks[1]), "skus": int(ks[2] or 0), "sponsored": num(ks[3]), "unit_price": num(us[1]),
-                 "oos": int(oo[1] or 0), "ai": num(ai_focal) if ai_focal is not None else 0, "content": num(cs[1]),
+                 "alerts": int(oo[1] or 0), "ai": num(ai_focal) if ai_focal is not None else 0, "content": num(cs[1]),
                  "d_share": (d_share if ret is None else None), "d_sponsored": (d_sponsored if ret is None else None), "d_oos": (d_oos if ret is None else None)}}
     b["share"] = _sos_list(ret)
-    b["pricing"] = [[r[0], num(r[1]), num(r[2])] for r in _price if (ret is None or r[0] == ret)]
     b["content_grades"] = _grades_map(ret)
-    b["oos_products"] = _prods(_oos_rows, ret, "oos")
+    b["alert_products"] = _prods(_alert_rows, ret, "alert")
     b["weak_products"] = _prods(_weak, ret, "weak")
     return b
 
@@ -186,16 +195,32 @@ data["slices"] = {"All": slice_for(None)}
 for _r in _rets:
     data["slices"][_r] = slice_for(_r)
 _b0 = data["slices"]["All"]
-data["kpi"] = _b0["kpi"]; data["share"] = _b0["share"]; data["pricing"] = _b0["pricing"]
-data["content_grades"] = _b0["content_grades"]; data["oos_products"] = _b0["oos_products"]; data["weak_products"] = _b0["weak_products"]
+data["kpi"] = _b0["kpi"]; data["share"] = _b0["share"]
+data["content_grades"] = _b0["content_grades"]; data["alert_products"] = _b0["alert_products"]; data["weak_products"] = _b0["weak_products"]
 
 data["by_retailer"] = {}
 for ret, brand, pct in rows("SELECT retailer, brand_tier, share_of_shelf_pct FROM " + A + ".V_SHARE_OF_SHELF WHERE snapshot_date=" + SNAP + " AND brand_tier IN " + BRANDS_IN + " ORDER BY retailer, share_of_shelf_pct DESC"):
     data["by_retailer"].setdefault(ret, []).append([brand, num(pct)])
+data["price_matrix"] = {}
+for _pr, _pbt, _pp in _pbb:
+    data["price_matrix"].setdefault(_pr, {})[_pbt] = num(_pp)
 data["ai_share"] = [[r[0], num(r[1])] for r in rows("SELECT brand, ROUND(AVG(share_of_answer_pct),1) FROM " + A + ".V_AI_SHARE_OF_ANSWER GROUP BY 1 ORDER BY 2 DESC")]
 data["voc_pos"] = [[r[0], num(r[1])] for r in rows("SELECT theme, pct_within_sentiment FROM " + A + ".V_SENTIMENT_SUMMARY WHERE sentiment='positive' ORDER BY mentions DESC LIMIT 6")]
 data["voc_fix"] = [[r[0], num(r[1])] for r in rows("SELECT theme, pct_within_sentiment FROM " + A + ".V_SENTIMENT_SUMMARY WHERE sentiment='negative' ORDER BY mentions DESC LIMIT 6")]
 data["top_sources"] = [[r[0], num(r[1])] for r in rows("SELECT domain, share_pct FROM " + A + ".V_AI_TOP_SOURCES ORDER BY citations DESC LIMIT 8")]
+# Answer-engine surfaces (Share of AI Answer KPI, "AI visibility & sources", top sources) render
+# only when the GEO_* answer-engine data exists. The skill doesn't populate GEO_* yet (deferred
+# Phase 1b), so these hide cleanly on a fresh app and light up automatically once that backfill runs.
+data["has_ai"] = bool([r for r in data["ai_share"] if (r[1] or 0) > 0]) or bool(data["top_sources"])
+# Pending: GEO generation is scheduled (a GEO refresh task exists) but hasn't produced rows yet —
+# e.g. right after first setup while the async seed batch runs. Drives the "being generated"
+# placeholder; with no scheduled task we simply hide (not-enabled). Safe-false on any error.
+data["ai_pending"] = False
+if not data["has_ai"]:
+    try:
+        data["ai_pending"] = len(rows("SHOW TASKS LIKE '%GEO%' IN SCHEMA " + S)) > 0
+    except Exception:
+        data["ai_pending"] = False
 data["nba"] = [{"sev": r[0], "area": r[1], "head": r[2], "metric": r[3], "act": r[4]} for r in rows("SELECT severity, area, headline, metric, recommended_action FROM " + A + ".V_NEXT_BEST_ACTIONS ORDER BY priority")]
 
 # ── Per-brand review analysis (what people say about each brand) ──
@@ -248,25 +273,6 @@ data["trend_sponsored"] = [num(r[1]) for r in sp]
 data["trend_oos"] = [int(r[2]) if r[2] is not None else 0 for r in sp]
 
 
-# Exec briefing + pre-answered assistant prompts (Cortex, cached)
-def cortex(prompt):
-    try:
-        return session.sql("SELECT AI_COMPLETE('__CORTEX_MODEL__', ?)", params=[prompt]).collect()[0][0].strip()
-    except Exception:
-        return "(Cortex unavailable)"
-
-
-CTX = (BRAND + ": share of shelf " + str(data['kpi']['share']) + "% (chg " + str(d_share) + " vs prev day), share of AI answer " + str(data['kpi']['ai']) + "%, "
-       "sponsored " + str(data['kpi']['sponsored']) + "%, " + str(data['kpi']['oos']) + " out-of-stock, content " + str(data['kpi']['content']) + "/100. "
-       "Share by brand: " + "; ".join(str(b) + " " + str(p) + "%" for b, p in data["share"][:8]) + ". "
-       "Top complaints: " + ", ".join(str(t) for t, _ in data["voc_fix"][:3]) + ". "
-       "Next best actions: " + " | ".join(str(a['head']) + ": " + str(a['metric']) for a in data["nba"]))
-
-
-# NOTE: the cold-load exec briefing (4 sequential Cortex COMPLETE calls) was REMOVED for
-# performance — its output (briefing/qa) was never rendered by the HTML, so it only blocked
-# first paint by 30-80s. CTX above is still built (cheap string) for the live-chat fallback.
-
 # ── Snapshot label + raw shelf rows + totals (for D&T / Raw Data tabs) ──
 data["snap_date"] = one("SELECT TO_CHAR(MAX(snapshot_date),'Mon DD, YYYY') FROM " + S + ".RAW_PDP")[0] or ""
 data["total_skus"] = int(one("SELECT COUNT(*) FROM " + A + ".V_BRAND_CLASSIFIED WHERE snapshot_date=" + SNAP)[0] or 0)
@@ -276,10 +282,10 @@ data["raw_rows"] = [{"name": r[0], "brand": r[1], "retailer": r[2], "pos": int(r
 
 # ── AI Insights (4 cards) + week-in-three scorecard, derived from live data ──
 _ins = []
-if data["kpi"]["oos"]:
+if data["kpi"]["alerts"]:
     _ins.append({"tag": "alert", "tab": "Retailer",
-                 "headline": str(data["kpi"]["oos"]) + " " + BRAND + " SKUs out of stock on the shelf",
-                 "detail": "Out-of-stock listings in top search slots send a ready-to-buy shopper straight to a competitor. Fix availability first."})
+                 "headline": str(data["kpi"]["alerts"]) + " active " + BRAND + " alerts need action",
+                 "detail": "Focal SKUs that are out of stock, showing weak listing content, or off page 1 — the fastest shelf wins are here. Open the Retailer tab."})
 _kk = [x for x in (data["trend_focal"] or []) if x is not None]
 if len(_kk) >= 2:
     _chg = round(_kk[-1] - _kk[0], 1)
@@ -292,9 +298,10 @@ if data["voc_fix"]:
                  "headline": '"' + str(_t) + '" is the #1 complaint — ' + str(_p) + "% of negative mentions",
                  "detail": "A fixable issue quietly eroding ratings and repeat purchase — worth addressing this quarter."})
 _src = data["top_sources"][0][0] if data["top_sources"] else "retailer & review sites"
-_ins.append({"tag": "opportunity", "tab": "Brand",
-             "headline": BRAND + " in only " + str(data["kpi"]["ai"]) + "% of AI answers — upside in answer engines",
-             "detail": "ChatGPT and Perplexity lean on " + str(_src) + " and social to recommend " + CATEGORY + " — earn presence there to shape what the AI says."})
+if data["has_ai"]:
+    _ins.append({"tag": "opportunity", "tab": "Brand",
+                 "headline": BRAND + " in only " + str(data["kpi"]["ai"]) + "% of AI answers — upside in answer engines",
+                 "detail": "ChatGPT and Perplexity lean on " + str(_src) + " and social to recommend " + CATEGORY + " — earn presence there to shape what the AI says."})
 data["insights"] = _ins[:4]
 
 # Week in three cards: win / risk / invest
@@ -312,9 +319,14 @@ if data["nba"]:
     _n = data["nba"][0]
     _sc.append({"kind": "risk", "label": "Act now", "metric": _n["metric"],
                 "headline": _n["head"], "detail": _n["act"]})
-_sc.append({"kind": "invest", "label": "Invest", "metric": str(data["kpi"]["ai"]) + "%",
-            "headline": "Win the AI shelf and weak listings",
-            "detail": "Lift content on the lowest-scoring SKUs and earn citations on " + str(_src) + " to grow share of AI answer."})
+if data["has_ai"]:
+    _sc.append({"kind": "invest", "label": "Invest", "metric": str(data["kpi"]["ai"]) + "%",
+                "headline": "Win the AI shelf and weak listings",
+                "detail": "Lift content on the lowest-scoring SKUs and earn citations on " + str(_src) + " to grow share of AI answer."})
+else:
+    _sc.append({"kind": "invest", "label": "Invest", "metric": str(data["kpi"]["content"]) + "/100",
+                "headline": "Lift weak listings to win the click",
+                "detail": "Improve the lowest-scoring SKU content — titles, images and reviews — to convert the traffic you already have."})
 data["scorecard"] = _sc[:3]
 
 # Expose dynamic brand metadata for the front-end
@@ -519,13 +531,16 @@ function sec(t,s,body){return '<div class="sec"><div class="sh"><div class="stt"
 function gradeBadge(s){var g,bg,fg;if(s>=85){g="A";bg="#D1FAE5";fg="#065F46";}else if(s>=70){g="B";bg="#D1FAE5";fg="#047857";}else if(s>=55){g="C";bg="#FEF9C3";fg="#854D0E";}else if(s>=40){g="D";bg="#FFEDD5";fg="#9A3412";}else{g="F";bg="#FFE4E6";fg="#9F1239";}return '<span class="grade" style="background:'+bg+';color:'+fg+'">'+g+'</span>';}
 function kdelta(v,unit,inv){if(v==null)return '<div class="kd flat">&nbsp;</div>';if(Math.abs(v)<0.05)return '<div class="kd flat">no change vs prev</div>';var up=inv?v<0:v>0;return '<div class="kd '+(up?"up":"down")+'">'+(v>0?"▲ +":"▼ ")+v+(unit||"")+' vs prev day</div>';}
 function renderKPIs(){
+  var aiCard=DATA.has_ai
+    ?{l:"Share of AI Answer",v:K.ai+"%",s:"Across category prompts",d:'<div class="kd flat">'+ENGLBL+'</div>'}
+    :(DATA.ai_pending?{l:"Share of AI Answer",v:"⏳",s:"being generated…",d:'<div class="kd flat">check back shortly</div>'}:null);
   var cards=[
     {l:"Share of Shelf",v:K.share+"%",s:"Listing share · primary brand tier",d:kdelta(K.d_share,"pp",false)},
-    {l:"Share of AI Answer",v:K.ai+"%",s:"Across category prompts",d:'<div class="kd flat">'+ENGLBL+'</div>'},
+    aiCard,
     {l:SUBJ+" SKUs visible",v:fmtN(K.skus),s:"Across "+RETLBL,d:'<div class="kd flat">&nbsp;</div>'},
-    {l:"Active Alerts",v:fmtN(K.oos),s:"Out-of-stock listings on shelf",d:kdelta(K.d_oos,"",true),al:true},
+    {l:"Active Alerts",v:fmtN(K.alerts),s:"Focal SKUs needing action",d:'<div class="kd flat">out of stock · weak content · lost rank</div>',al:true},
     {l:"Content Score",v:K.content,s:"0–100 · listing completeness",badge:gradeBadge(K.content),d:'<div class="kd flat">open Content tab</div>'}
-  ];
+  ].filter(Boolean);
   document.getElementById("kpis").innerHTML=cards.map(function(c){return '<div class="kc'+(c.al?" al":"")+'"><div class="kt"><span class="kl">'+c.l+'</span>'+(c.badge||"")+'</div><div class="kv">'+c.v+'</div><div class="ks">'+c.s+'</div>'+c.d+'</div>';}).join("");
 }
 /* ---------- filter bar (As of + live Retailer) ---------- */
@@ -541,7 +556,7 @@ function renderFilters(){
 /* ---------- shared chart helpers ---------- */
 function hbar(rows,u){u=(u===undefined?"%":u);var max=Math.max.apply(null,rows.map(function(r){return r[1];}))||1;return '<div class="bars">'+rows.map(function(r){var kk=isKK(r[0]);return '<div class="br'+(kk?" kk":"")+'"><div class="l">'+r[0]+'</div><div class="t"><div class="f'+(kk?" kk":"")+'" style="width:'+(r[1]/max*100).toFixed(1)+'%"></div></div><div class="v">'+r[1]+u+'</div></div>';}).join("")+'</div>';}
 function donut(rows){var tot=rows.reduce(function(s,r){return s+r[1];},0)||1,R=78,C=2*Math.PI*R,off=0,s="";rows.forEach(function(r){var len=r[1]/tot*C,col=BC[r[0]]||"#ccc";s+='<circle cx="94" cy="94" r="'+R+'" fill="none" stroke="'+col+'" stroke-width="22" stroke-dasharray="'+len+' '+(C-len)+'" stroke-dashoffset="'+(-off)+'" transform="rotate(-90 94 94)"/>';off+=len;});return '<svg viewBox="0 0 188 188" width="188" height="188">'+s+'</svg>';}
-function pcards(items){var gc={CRITICAL:"crit",HIGH:"high",F:"crit",D:"high"};return '<div class="pgrid">'+items.map(function(p){var img=p.img?'<div class="iw"><img src="'+p.img+'" onerror="this.parentNode.innerHTML=\'<div class=ph>KK</div>\'"></div>':'<div class="ph">KK</div>';var ch=p.sev?'<span class="pchip '+(gc[p.sev]||"")+'">'+p.sev+'</span><span class="pchip ret">'+p.retailer+'</span><span class="pchip">pos #'+p.position+'</span><span class="pchip">$'+p.price+'</span>':'<span class="pchip '+(gc[p.grade]||"")+'">grade '+p.grade+'</span><span class="pchip ret">'+p.retailer+'</span><span class="pchip">score '+p.score+'</span><span class="pchip">'+p.reviews+' reviews</span>';var open=p.url?'<div class="popen">View on '+p.retailer+' &#8599;</div>':'';var tag=p.url?'a':'div';var href=p.url?' href="'+p.url+'" target="_blank" rel="noopener"':'';return '<'+tag+' class="pc'+(p.url?" lk":"")+'"'+href+'>'+img+'<div class="pb"><div class="pn">'+p.name+'</div><div class="pm">'+ch+'</div>'+open+'</div></'+tag+'>';}).join("")+'</div>';}
+function pcards(items){var gc={CRITICAL:"crit",HIGH:"high",F:"crit",D:"high"};return '<div class="pgrid">'+items.map(function(p){var img=p.img?'<div class="iw"><img src="'+p.img+'" onerror="this.parentNode.innerHTML=\'<div class=ph>KK</div>\'"></div>':'<div class="ph">KK</div>';var ch=p.sev?'<span class="pchip '+(gc[p.sev]||"")+'">'+p.sev+'</span>'+(p.atype?'<span class="pchip">'+p.atype+'</span>':'')+'<span class="pchip ret">'+p.retailer+'</span><span class="pchip">pos #'+p.position+'</span><span class="pchip">$'+p.price+'</span>':'<span class="pchip '+(gc[p.grade]||"")+'">grade '+p.grade+'</span><span class="pchip ret">'+p.retailer+'</span><span class="pchip">score '+p.score+'</span><span class="pchip">'+p.reviews+' reviews</span>';var open=p.url?'<div class="popen">View on '+p.retailer+' &#8599;</div>':'';var tag=p.url?'a':'div';var href=p.url?' href="'+p.url+'" target="_blank" rel="noopener"':'';return '<'+tag+' class="pc'+(p.url?" lk":"")+'"'+href+'>'+img+'<div class="pb"><div class="pn">'+p.name+'</div><div class="pm">'+ch+'</div>'+open+'</div></'+tag+'>';}).join("")+'</div>';}
 function sparkline(){
   var d=DATA.trend_dates,kk=(DATA.trend_focal||[]),comp=(DATA.trend_comp||[]);
   var W=1080,H=190,pl=10,pr=10,pt=16,pb=10,n=d.length;
@@ -580,9 +595,9 @@ var VIEWS={
    return '<div class="stack">'+tom+traj+trio+mx+'</div>';
  },
  Retailer:function(){
-   var max=Math.max.apply(null,S().pricing.map(function(p){return Math.max(p[1]||0,p[2]||0);}))||1;
-   var price='<div class="card p"><h3>Unit price — __BRAND__ vs the competitive set</h3><p class="why">A persistent premium invites switching and private-label trade-down. Price per unit normalizes across pack sizes.</p><div class="grp">'+S().pricing.map(function(p){return '<div class="c"><div class="pr"><div class="b kk" style="height:'+((p[1]||0)/max*100).toFixed(0)+'%"><span>'+(p[1]!=null?"$"+p[1]:"-")+'</span></div><div class="b cp" style="height:'+((p[2]||0)/max*100).toFixed(0)+'%"><span>'+(p[2]!=null?"$"+p[2]:"-")+'</span></div></div><div class="rl">'+p[0]+'</div></div>';}).join("")+'</div><div class="legend"><span><i style="background:#234291"></i>__BRAND__</span><span><i style="background:#CBD5E1"></i>Competitor avg</span></div></div>';
-   var oos='<div class="card p"><h3>'+K.oos+' __BRAND__ SKUs out of stock</h3><p class="why">An out-of-stock SKU in a top search slot is pure lost sell-through — the shopper is there, ready to buy, and converts to a competitor. Click a tile to open the live retailer page.</p>'+pcards(S().oos_products)+'</div>';
+   var pm=DATA.price_matrix||{},pbr=DATA.matrix_brands||[];
+   var price='<div class="card p"><h3>Average price by brand — per retailer</h3><p class="why">Average shelf price for each brand at every tracked retailer. A persistent premium invites switching and private-label trade-down.</p><div style="overflow-x:auto"><table class="mtx"><thead><tr><th class="bl">Brand</th>'+RETS.map(function(r){return '<th>'+cap(r)+'</th>';}).join("")+'</tr></thead><tbody>'+pbr.map(function(b){var kk=isKK(b);return '<tr><td class="bn'+(kk?" kk":"")+'">'+b+'</td>'+RETS.map(function(r){var v=(pm[r]||{})[b];return '<td><span class="mcell">'+(v==null?"—":"$"+v)+'</span></td>';}).join("")+'</tr>';}).join("")+'</tbody></table></div></div>';
+   var oos='<div class="card p"><h3>'+K.alerts+' active __BRAND__ alerts</h3><p class="why">Focal SKUs that need action — out of stock, weak listing content (grade D/F), or dropped off page 1. Click a tile to open the live retailer page.</p>'+pcards(S().alert_products)+'</div>';
    return sec("Retailer execution","Pricing competitiveness and on-shelf availability across "+RETLBL+".","<div class='stack'>"+price+oos+"</div>");
  },
  Brand:function(){
@@ -596,7 +611,9 @@ var VIEWS={
    var top=sec("Brand & category","__BRAND__\'s position in the __CATEGORY__ set across the selected retailer scope.","<div class='grid2'>"+dc+bars+"</div>");
    var aigrid=sec("AI visibility & sources","Answer-engine presence across the category and the domains shaping it.","<div class='stack'>"+aiC+src+"</div>");
    var revsec=sec("Voice of the customer","Per-brand review analysis — understand what people are actually saying about each brand.",rev);
-   return '<div class="stack">'+top+aigrid+revsec+'</div>';
+   var aipend='<div class="card p"><h3>Share of AI answer &nbsp;<span style="font-weight:600;color:#B45309">⏳ being generated…</span></h3><p class="why">Analyzing how AI engines (ChatGPT · Perplexity · Gemini) recommend '+CATEGORY+'. Results appear once the first analysis completes — check back shortly.</p></div>';
+   var aisec=DATA.has_ai?aigrid:(DATA.ai_pending?sec("AI visibility & sources","Answer-engine presence across the category — being generated.",aipend):"");
+   return '<div class="stack">'+top+aisec+revsec+'</div>';
  },
  Content:function(){
    var grades=["A","B","C","D","F"],gc={A:"#22c55e",B:"#86efac",C:"#E2E8F0",D:"#fbbf24",F:"#ef4444"};
@@ -662,125 +679,7 @@ var _sh=document.getElementById("subhead");if(_sh)_sh.textContent=SUBJ+" · "+RE
 renderKPIs();renderFilters();
 paint("Leadership");
 </script>"""
-# Internal-scroll iframe so the header pins and the floating Nimble Web Search
-# button stays in view (a tall non-scrolling iframe pushes fixed elements off-screen).
+# Internal-scroll iframe so the pinned header stays put (a tall non-scrolling
+# iframe would otherwise push fixed elements off-screen).
 _loading.empty()  # data assembled — drop the loading note and paint the cockpit
 components.html(HTML.replace("__DATA__", json.dumps(data)).replace("__AGENT_NAME__", AGENT_NAME), height=820, scrolling=True)
-
-# ===== Nimble Web Search — LIVE Cortex assistant =====
-# Runs as a native Streamlit element so it has a live Snowflake session for Cortex
-# (the embedded SPA iframe above is sandboxed). Primary engine: Cortex Analyst
-# text-to-SQL over the __BRAND__ semantic view, with Cortex Complete grounded in
-# today's metrics as an alternative.
-SV_FQN = DB + "." + SCHEMA + ".SHELF_SV"
-
-
-def _ground(q):
-    return cortex("You are __BRAND__'s digital-shelf analyst for the CMO. Answer in 3-5 sentences, concrete and "
-                  "specific with numbers, using ONLY the live context below. If the answer isn't in the context, "
-                  "say what you'd pull next. No jargon, no emoji.\n\nLIVE CONTEXT: " + CTX + "\n\nQUESTION: " + q)
-
-
-_FORBIDDEN = re.compile(r"\b(INSERT|UPDATE|DELETE|MERGE|CALL|CREATE|ALTER|DROP|GRANT|REVOKE|TRUNCATE|COPY)\b", re.I)
-
-
-def _safe_select(sql):
-    """Only run Analyst-generated SQL if it's a single read-only SELECT scoped to the
-    semantic view — never execute generated SQL blindly. Returns the SQL or None."""
-    s = (sql or "").strip().rstrip(";").strip()
-    if not s or ";" in s:                                    # empty or multi-statement
-        return None
-    if not re.match(r"^(SELECT|WITH)\b", s, re.I):           # read-only entry points only
-        return None
-    if _FORBIDDEN.search(s):                                 # no DDL/DML
-        return None
-    if "SHELF_SV" not in s.upper():                          # scoped to the app's semantic view
-        return None
-    return s
-
-
-def ask_live(q):
-    """Cortex Analyst (text-to-SQL over the semantic view); falls back to Cortex Complete."""
-    try:
-        import _snowflake
-        body = {"messages": [{"role": "user", "content": [{"type": "text", "text": q}]}], "semantic_view": SV_FQN}
-        resp = _snowflake.send_snow_api_request("POST", "/api/v2/cortex/analyst/message", {}, {}, body, None, 60000)
-        content = resp.get("content") if isinstance(resp, dict) else None
-        if isinstance(content, str):
-            content = json.loads(content)
-        msg = content.get("message", content) if isinstance(content, dict) else {}
-        parts = msg.get("content", []) if isinstance(msg, dict) else []
-        text, sql = "", None
-        for p in parts:
-            if not isinstance(p, dict):
-                continue
-            if p.get("type") == "text":
-                text += p.get("text", "")
-            elif p.get("type") == "sql":
-                sql = p.get("statement")
-        safe = _safe_select(sql)
-        if safe:
-            df = session.sql(safe).to_pandas()
-            if len(df) > 50:
-                df = df.head(50)
-            return {"text": (text or "Here's what the live shelf shows:"), "df": df}
-        if sql:                          # Analyst returned SQL we won't run → grounded answer instead
-            return {"text": _ground(q)}
-        if text:
-            return {"text": text}
-    except Exception:
-        pass
-    return {"text": _ground(q)}
-
-
-def _chat_panel():
-    if "live_chat" not in st.session_state:
-        st.session_state.live_chat = []
-    st.caption("Live answers from Snowflake Cortex over your __BRAND__ semantic model — ask about share, pricing, AI presence or reviews.")
-    box = st.container()
-    q = None
-    try:
-        q = st.chat_input("Ask anything about __BRAND__'s shelf…")
-    except Exception:
-        with st.form("nwsform", clear_on_submit=True):
-            _qt = st.text_input("Ask the shelf")
-            if st.form_submit_button("Ask") and _qt:
-                q = _qt
-    if q:
-        st.session_state.live_chat.append(("user", q, None))
-        with st.spinner("Cortex is analysing the live shelf…"):
-            _r = ask_live(q)
-        st.session_state.live_chat.append(("assistant", _r["text"], _r.get("df")))
-    with box:
-        if not st.session_state.live_chat:
-            st.markdown("Try: *Where am I losing share of shelf and why?* · *Compare __BRAND__ vs a competitor on price.* · *Which sources do AI engines cite most?*")
-        for _role, _txt, _df in st.session_state.live_chat:
-            try:
-                with st.chat_message(_role):
-                    st.markdown(_txt)
-                    if _df is not None and len(_df):
-                        st.dataframe(_df)
-            except Exception:
-                st.markdown(("**You:** " if _role == "user" else "**Analyst:** ") + _txt)
-
-
-# Floating launcher → opens a modal with the live chat (native button, fixed bottom-right).
-if hasattr(st, "dialog"):
-    st.markdown('<div id="nws-anchor"></div>', unsafe_allow_html=True)
-    st.markdown("""<style>
-    div:has(#nws-anchor)+div button{position:fixed;bottom:22px;right:22px;z-index:1000;border:none;border-radius:999px;
-      background:linear-gradient(135deg,#FFE066,#FFC542 55%,#FF9E1C);color:#7C3A03;font-weight:700;font-size:14px;
-      padding:11px 22px;box-shadow:0 8px 22px rgba(217,119,6,.30),0 0 0 1px rgba(180,83,9,.16);}
-    div:has(#nws-anchor)+div button:hover{box-shadow:0 12px 30px rgba(217,119,6,.36);transform:translateY(-1px);}
-    </style>""", unsafe_allow_html=True)
-
-    @st.dialog("Nimble Web Search")
-    def _nws_dialog():
-        _chat_panel()
-
-    if st.button("✦  Nimble Web Search", key="nws_open"):
-        _nws_dialog()
-else:
-    st.divider()
-    st.markdown("#### ✦  Nimble Web Search")
-    _chat_panel()

--- a/snowflake/coco-skills/cmo-intelligence/assets/cockpit_template.py
+++ b/snowflake/coco-skills/cmo-intelligence/assets/cockpit_template.py
@@ -95,7 +95,7 @@ BCMAP.setdefault("Private label", "#CBD5E1")
 
 # Global signals reused across retailer slices (defensive: views may be empty on a fresh perimeter)
 ai_focal = one("SELECT ROUND(AVG(share_of_answer_pct),0) FROM " + A + ".V_AI_SHARE_OF_ANSWER WHERE brand='" + q(FOCAL) + "'")[0]
-_dl = one("SELECT d_share, d_sponsored, d_oos FROM " + A + ".V_TREND_KPI ORDER BY snapshot_date DESC LIMIT 1", 3)
+_dl = one("SELECT d_share, d_sponsored, d_oos FROM " + A + ".V_TREND_KPI WHERE snapshot_date = " + SNAP + " LIMIT 1", 3)
 d_share, d_sponsored, d_oos = num(_dl[0]), num(_dl[1]), num(_dl[2])
 data = {}
 
@@ -274,7 +274,7 @@ data["trend_oos"] = [int(r[2]) if r[2] is not None else 0 for r in sp]
 
 
 # ── Snapshot label + raw shelf rows + totals (for D&T / Raw Data tabs) ──
-data["snap_date"] = one("SELECT TO_CHAR(MAX(snapshot_date),'Mon DD, YYYY') FROM " + S + ".RAW_PDP")[0] or ""
+data["snap_date"] = one("SELECT TO_CHAR(" + SNAP + ",'Mon DD, YYYY')")[0] or ""   # same day as SNAP (latest complete), not raw MAX
 data["total_skus"] = int(one("SELECT COUNT(*) FROM " + A + ".V_BRAND_CLASSIFIED WHERE snapshot_date=" + SNAP)[0] or 0)
 data["raw_rows"] = [{"name": r[0], "brand": r[1], "retailer": r[2], "pos": int(r[3]) if r[3] is not None else None,
                      "price": num(r[4]), "oos": bool(r[5]), "kk": bool(r[6])}

--- a/snowflake/coco-skills/cmo-intelligence/sql/config.sql
+++ b/snowflake/coco-skills/cmo-intelligence/sql/config.sql
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS __DB__.__SCHEMA__.CFG_APP (
     focal_patterns    ARRAY,                              -- brand-SKU substrings incl. spacing variants ['ACME BAR','ACMEBAR']
     geo_zip           STRING        DEFAULT '75243',      -- geography; US single-market for the first phase
     pdp_cap           NUMBER        DEFAULT 50,            -- max PDP fetches per retailer per refresh (runtime/cost guard). Seed low (~30) for a snappy first cockpit, then raise for the unattended daily run.
+    geo_seed_prompts  NUMBER        DEFAULT 15,            -- top-N answer-engine prompts for the FIRST-setup GEO seed (fast, async). The weekly REFRESH_GEO() uses the full set (~60). Mirrors the pdp_cap two-tier convention.
     refresh_cron      STRING        DEFAULT 'USING CRON 0 6 * * * America/Chicago',  -- source of truth for DAILY_SHELF_TASK
     retailer_map      OBJECT,                             -- retailer -> {pdp_agent, id_key, zip_key}; resolves SERP geo + the PDP pass (see ingest.sql)
     updated_at        TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP(),

--- a/snowflake/coco-skills/cmo-intelligence/sql/ingest.sql
+++ b/snowflake/coco-skills/cmo-intelligence/sql/ingest.sql
@@ -393,7 +393,12 @@ def run(session, prompt_limit):
                 sources = []
             ans_rows.append((eng, text, ptype, str(answer)[:16000], len(sources)))
             for s in sources:
-                u = s.get("url") or s.get("link") if isinstance(s, dict) else (s if isinstance(s, str) else None)
+                if isinstance(s, dict):
+                    u = s.get("url") or s.get("link")
+                elif isinstance(s, str):
+                    u = s
+                else:
+                    u = None
                 dom = domain_of(u) if u else None
                 if dom:
                     src[(eng, dom)] = src.get((eng, dom), 0) + 1

--- a/snowflake/coco-skills/cmo-intelligence/sql/ingest.sql
+++ b/snowflake/coco-skills/cmo-intelligence/sql/ingest.sql
@@ -3,8 +3,11 @@
  *
  * Role:        NIMBLE_ROLE (must own/run the Task; see privileges note)
  * Creates:     __DB__.__SCHEMA__.RAW_SERP, RAW_PDP        — typed raw tables
+ *              __DB__.__SCHEMA__.GEO_ANSWERS, GEO_SOURCES — answer-engine (Share of AI Answer) tables
  *              __DB__.__SCHEMA__.REFRESH_SHELF()          — one-call SERP+PDP refresh
- *              __DB__.__SCHEMA__.DAILY_SHELF_TASK         — scheduled daily refresh
+ *              __DB__.__SCHEMA__.REFRESH_GEO(prompt_limit)— answer-engine batch (Perplexity/ChatGPT/Gemini)
+ *              __DB__.__SCHEMA__.DAILY_SHELF_TASK         — scheduled daily shelf refresh
+ *              __DB__.__SCHEMA__.GEO_SEED_TASK / WEEKLY_GEO_TASK — first-setup seed + weekly GEO refresh
  * Prereq:      config.sql (CFG_APP + CFG_QUERIES) and the NIMBLE_AGENT_RUN UDTF from the
  *              Nimble × Snowflake integration (https://github.com/Nimbleway/cookbook/tree/main/snowflake).
  *
@@ -46,7 +49,7 @@ USE SCHEMA __DB__.__SCHEMA__;
 -- ---------------------------------------------------------------------------
 -- Raw tables. Typed core + a `raw` VARIANT catch-all per row (so the views can
 -- reach a field we didn't project without re-ingesting). RAW_VOC is parsed from
--- the PDP `raw` records during refresh; GEO_* are filled by a later batch step.
+-- the PDP `raw` records during refresh; GEO_* are filled by REFRESH_GEO (below).
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS __DB__.__SCHEMA__.RAW_SERP (
     retailer              STRING,
@@ -105,12 +108,14 @@ CREATE TABLE IF NOT EXISTS __DB__.__SCHEMA__.RAW_VOC (
     snapshot_date DATE
 );
 
--- Answer-engine citations (Share of AI Answer). Created empty; a later
--- async-batch step backfills them, after which V_AI_* light up. The cockpit's
--- AI-answer section degrades gracefully (0%) until then.
+-- Answer-engine citations (Share of AI Answer). Created empty; REFRESH_GEO
+-- (below) backfills them via the answer-engine agents, after which V_AI_* light
+-- up. Until then the cockpit shows a "being generated" placeholder (see has_ai /
+-- ai_pending in cockpit_template.py), not a bare 0%.
 CREATE TABLE IF NOT EXISTS __DB__.__SCHEMA__.GEO_ANSWERS (
     engine        STRING,
     prompt        STRING,
+    prompt_type   STRING,        -- template family: recommendation | comparison | sentiment | value | …
     answer        STRING,
     num_sources   INTEGER,
     snapshot_date DATE
@@ -262,6 +267,156 @@ def run(session):
 $$;
 
 -- ---------------------------------------------------------------------------
+-- REFRESH_GEO() — Share of AI Answer. Asks the answer engines (Perplexity,
+-- ChatGPT, Gemini) a deterministic set of category prompts via Nimble's LLM
+-- agents (same /v1/agents/run endpoint the SERP/PDP calls use), then writes:
+--   GEO_ANSWERS — one row per (engine, prompt): the synthesized answer text
+--                 (V_AI_SHARE_OF_ANSWER matches brand names against it)
+--   GEO_SOURCES — citations per (engine, domain), parsed from each answer's sources
+-- Concurrent (ThreadPoolExecutor) like REFRESH_PDP — it's ~prompts×3 slow LLM
+-- calls, so it runs on its OWN (weekly) cadence, not the daily shelf refresh.
+--
+-- Answer/source field names vary per engine (perplexity: answer+sources;
+-- chatgpt/gemini: text/response + links) — the getters below are tolerant.
+-- Confirm shapes on first run per engine.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE PROCEDURE __DB__.__SCHEMA__.REFRESH_GEO(prompt_limit INTEGER DEFAULT 0)
+RETURNS VARIANT
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.11'
+PACKAGES = ('requests', 'snowflake-snowpark-python')
+HANDLER = 'run'
+EXTERNAL_ACCESS_INTEGRATIONS = (NIMBLE_API_ACCESS)
+SECRETS = ('cred' = NIMBLE_INTEGRATION.TOOLS.NIMBLE_API_KEY)
+EXECUTE AS CALLER
+AS
+$$
+import _snowflake, requests, json
+from urllib.parse import urlparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from snowflake.snowpark.types import StructType, StructField, StringType, IntegerType
+from snowflake.snowpark.functions import current_date
+
+URL = "https://sdk.nimbleway.com/v1/agents/run"
+S = "__DB__.__SCHEMA__"
+ENGINES = ["perplexity", "chatgpt", "gemini"]
+GENERIC = {"other / marketplace", "private label", "other named brand", "unknown", "generic", "n/a", "other"}
+
+def g(d, *ks):
+    for k in ks:
+        x = d.get(k)
+        if x not in (None, "", [], {}): return x
+    return None
+
+def domain_of(url):
+    try:
+        net = (urlparse(url).netloc or "").lower()
+        return net[4:] if net.startswith("www.") else (net or None)
+    except Exception:
+        return None
+
+def call_engine(token, engine, prompt):
+    try:
+        r = requests.post(URL, json={"agent": engine, "params": {"prompt": prompt}},
+                          headers={"Authorization": "Bearer " + token, "Content-Type": "application/json",
+                                   "X-Client-Source": "snowflake-cortex-agent"}, timeout=180)
+        if r.status_code >= 400:
+            return None
+        ad = (r.json() or {}).get("data") or {}
+        p = ad.get("parsing")
+        if isinstance(p, list):
+            p = p[0] if p else None
+        return p if isinstance(p, dict) else None
+    except Exception:
+        return None
+
+def build_prompts(session, limit=0):
+    """Deterministic templated prompts (no LLM) so the set is stable week-over-week."""
+    app = session.sql("SELECT COALESCE(brand, ''), category FROM " + S + ".CFG_APP WHERE app_key = '__SCHEMA__'").collect()
+    focal = (app[0][0] if app else "") or ""
+    category = ((app[0][1] if app else "") or "products")
+    tiers = session.sql(
+        "SELECT brand_tier FROM " + S + ".V_SHARE_OF_SHELF "
+        "WHERE snapshot_date = (SELECT MAX(snapshot_date) FROM " + S + ".RAW_PDP) "
+        "GROUP BY 1 ORDER BY SUM(products_in_serp) DESC").collect()
+    order = [r[0] for r in tiers if r[0] and r[0].lower() not in GENERIC]
+    if not focal:
+        focal = order[0] if order else category
+    comps = [b for b in order if b != focal][:6]
+    brands = [focal] + comps
+    retailers = [r[0] for r in session.sql("SELECT DISTINCT retailer FROM " + S + ".CFG_QUERIES").collect() if r[0]]
+    occasions = ["a gift", "the holidays", "everyday use"]
+    # High-signal families first (recommendation, comparison, focal opinion/sentiment) so a small
+    # seed (prompt_limit) still captures the prompts that most drive share of AI answer; the full
+    # set (limit=0) adds the long tail across every brand.
+    high = [("What is the best " + category + "?", "recommendation")]
+    high += [("What are the best " + category + " to buy on " + r.capitalize() + "?", "recommendation") for r in retailers]
+    high += [("Compare " + focal + " and " + c + " — which is better?", "comparison") for c in comps]
+    high += [("Is " + focal + " a good " + category + "?", "brand_opinion"),
+             ("What are people saying about " + focal + "?", "sentiment")]
+    rest = []
+    for b in brands:
+        rest += [("What's a good alternative to " + b + "?", "alternative"),
+                 ("Is " + b + " worth the price?", "value"),
+                 ("Should I buy " + b + "?", "purchase"),
+                 ("Where can I buy " + b + "?", "availability")]
+        if b != focal:
+            rest += [("Is " + b + " a good " + category + "?", "brand_opinion"),
+                     ("What are people saying about " + b + "?", "sentiment")]
+    for o in occasions:
+        rest += [("What " + category + " should I buy for " + o + "?", "occasion"),
+                 ("Is " + focal + " a good choice for " + o + "?", "occasion_brand")]
+    P = high + rest
+    return P[:limit] if limit and limit > 0 else P
+
+def run(session, prompt_limit):
+    token = _snowflake.get_generic_secret_string("cred")
+    # prompt_limit: 0 = full set (weekly) · <0 = seed mode (use CFG_APP.geo_seed_prompts) · >0 = top-N
+    lim = int(prompt_limit or 0)
+    if lim < 0:
+        cap = session.sql("SELECT geo_seed_prompts FROM " + S + ".CFG_APP WHERE app_key = '__SCHEMA__'").collect()
+        lim = int(cap[0][0]) if (cap and cap[0][0]) else 15
+    prompts = build_prompts(session, lim)
+    tasks = [(eng, text, ptype) for (text, ptype) in prompts for eng in ENGINES]
+
+    ans_rows, src = [], {}   # src[(engine, domain)] = citation count
+    with ThreadPoolExecutor(max_workers=20) as ex:
+        futs = {ex.submit(call_engine, token, eng, text): (eng, text, ptype) for (eng, text, ptype) in tasks}
+        for fut in as_completed(futs):
+            eng, text, ptype = futs[fut]
+            d = fut.result()
+            if not d:
+                continue
+            answer = g(d, "answer", "text", "response", "markdown") or ""
+            sources = g(d, "sources", "links", "citations") or []
+            if not isinstance(sources, list):
+                sources = []
+            ans_rows.append((eng, text, ptype, str(answer)[:16000], len(sources)))
+            for s in sources:
+                u = s.get("url") or s.get("link") if isinstance(s, dict) else (s if isinstance(s, str) else None)
+                dom = domain_of(u) if u else None
+                if dom:
+                    src[(eng, dom)] = src.get((eng, dom), 0) + 1
+
+    session.sql("DELETE FROM " + S + ".GEO_ANSWERS  WHERE snapshot_date = CURRENT_DATE()").collect()
+    session.sql("DELETE FROM " + S + ".GEO_SOURCES WHERE snapshot_date = CURRENT_DATE()").collect()
+    if ans_rows:
+        acols = [("ENGINE", StringType()), ("PROMPT", StringType()), ("PROMPT_TYPE", StringType()),
+                 ("ANSWER", StringType()), ("NUM_SOURCES", IntegerType())]
+        (session.create_dataframe(ans_rows, schema=StructType([StructField(c, t) for c, t in acols]))
+                .with_column("SNAPSHOT_DATE", current_date())
+                .write.mode("append").save_as_table(S + ".GEO_ANSWERS", column_order="name"))
+    src_rows = [(eng, dom, cnt) for (eng, dom), cnt in src.items()]
+    if src_rows:
+        scols = [("ENGINE", StringType()), ("DOMAIN", StringType()), ("CITATIONS", IntegerType())]
+        (session.create_dataframe(src_rows, schema=StructType([StructField(c, t) for c, t in scols]))
+                .with_column("SNAPSHOT_DATE", current_date())
+                .write.mode("append").save_as_table(S + ".GEO_SOURCES", column_order="name"))
+    return {"prompts": len(prompts), "engines": len(ENGINES), "attempted": len(tasks),
+            "answers": len(ans_rows), "source_rows": len(src_rows)}
+$$;
+
+-- ---------------------------------------------------------------------------
 -- REFRESH_SHELF() — one call: ingest SERP (config-driven UDTF lateral join),
 -- run the concurrent PDP pass (REFRESH_PDP), then parse VOC. Idempotent within a
 -- day: each pass DELETEs today's rows first, so a same-day re-run REPLACEs rather
@@ -408,6 +563,31 @@ AS
     CALL __DB__.__SCHEMA__.REFRESH_SHELF();
 
 ALTER TASK __DB__.__SCHEMA__.DAILY_SHELF_TASK RESUME;
+
+-- ---------------------------------------------------------------------------
+-- Share of AI Answer (GEO) tasks — two-tier, like the PDP two-cap:
+--   GEO_SEED_TASK   — one-shot, manual (no schedule); EXECUTE'd once at first setup.
+--                     Runs REFRESH_GEO(-1) = a small config-sized seed
+--                     (CFG_APP.geo_seed_prompts) so the cockpit populates fast (~3 min).
+--   WEEKLY_GEO_TASK — full set (REFRESH_GEO()), weekly. Answer-engine data moves slowly
+--                     and the full run is ~12 min / ~180 LLM calls, so it's NOT on the
+--                     daily shelf cadence.
+-- Either task existing is the cockpit's "being generated" pending signal.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE TASK __DB__.__SCHEMA__.GEO_SEED_TASK
+    WAREHOUSE = __WAREHOUSE__
+    COMMENT   = 'One-shot Share-of-AI-Answer seed for __SCHEMA__ (run via EXECUTE TASK; no schedule)'
+AS
+    CALL __DB__.__SCHEMA__.REFRESH_GEO(-1);
+
+CREATE OR REPLACE TASK __DB__.__SCHEMA__.WEEKLY_GEO_TASK
+    WAREHOUSE = __WAREHOUSE__
+    SCHEDULE  = 'USING CRON 0 8 * * 1 America/Chicago'   -- weekly (Mon 08:00); GEO data moves slowly
+    COMMENT   = 'Weekly full Share-of-AI-Answer refresh for __SCHEMA__'
+AS
+    CALL __DB__.__SCHEMA__.REFRESH_GEO();
+
+ALTER TASK __DB__.__SCHEMA__.WEEKLY_GEO_TASK RESUME;   -- GEO_SEED_TASK has no schedule; it only runs when EXECUTE'd
 
 -- Seed the first snapshot immediately — server-side + non-blocking (don't CALL it
 -- from the session; the SERP + concurrent PDP run blocks the client):

--- a/snowflake/coco-skills/cmo-intelligence/sql/views.sql
+++ b/snowflake/coco-skills/cmo-intelligence/sql/views.sql
@@ -303,7 +303,9 @@ FROM k;
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE VIEW __DB__.__SCHEMA__.V_AI_SHARE_OF_ANSWER AS
 WITH base AS (
-    SELECT engine, LOWER(answer) a FROM __DB__.__SCHEMA__.GEO_ANSWERS WHERE answer IS NOT NULL
+    SELECT engine, LOWER(answer) a FROM __DB__.__SCHEMA__.GEO_ANSWERS
+    WHERE answer IS NOT NULL
+      AND snapshot_date = (SELECT MAX(snapshot_date) FROM __DB__.__SCHEMA__.GEO_ANSWERS)   -- latest GEO run only, not history
 ),
 brands AS (   -- focal brand + the top ~6 competitor tiers by shelf presence (bounded)
     SELECT brand AS b FROM __DB__.__SCHEMA__.CFG_APP WHERE app_key = '__SCHEMA__' AND brand IS NOT NULL
@@ -327,7 +329,9 @@ GROUP BY base.engine, brands.b;
 CREATE OR REPLACE VIEW __DB__.__SCHEMA__.V_AI_TOP_SOURCES AS
 SELECT domain, SUM(citations) citations,
     ROUND(SUM(citations) * 100.0 / NULLIF(SUM(SUM(citations)) OVER (), 0), 1) share_pct
-FROM __DB__.__SCHEMA__.GEO_SOURCES GROUP BY domain ORDER BY citations DESC;
+FROM __DB__.__SCHEMA__.GEO_SOURCES
+WHERE snapshot_date = (SELECT MAX(snapshot_date) FROM __DB__.__SCHEMA__.GEO_SOURCES)   -- latest GEO run only, not history
+GROUP BY domain ORDER BY citations DESC;
 
 -- ---------------------------------------------------------------------------
 -- V_NEXT_BEST_ACTIONS — 6 prioritized, data-driven NBAs. The focal brand name is

--- a/snowflake/coco-skills/cmo-intelligence/sql/views.sql
+++ b/snowflake/coco-skills/cmo-intelligence/sql/views.sql
@@ -5,7 +5,7 @@
  * Creates:  __DB__.__SCHEMA__.BRAND_MAP           (Cortex brand-normalization table)
  *           __DB__.__SCHEMA__.V_PRODUCT_BRAND     (focal/competitor classification)
  *           __DB__.__SCHEMA__.V_BRAND_CLASSIFIED  (the enriched shelf fact view)
- *           __DB__.__SCHEMA__.V_SHARE_OF_SHELF, V_CONTENT_HEALTH, V_ALERT_OOS,
+ *           __DB__.__SCHEMA__.V_SHARE_OF_SHELF, V_CONTENT_HEALTH, V_ALERT_OOS, V_ALERTS,
  *           V_TREND_SOS_DAILY, V_TREND_KPI, V_SENTIMENT_SUMMARY,
  *           V_AI_SHARE_OF_ANSWER, V_AI_TOP_SOURCES, V_NEXT_BEST_ACTIONS
  * Prereq:   config.sql + ingest.sql (CFG_APP/CFG_QUERIES, RAW_SERP/RAW_PDP/RAW_VOC, GEO_*)
@@ -230,6 +230,30 @@ SELECT snapshot_date, retailer, product_id, product_name, brand_tier, position, 
          ELSE 'Schedule replenishment in next standard cycle' END recommended_action,
     ROUND(best_price / NULLIF(position, 0), 4) revenue_risk_index
 FROM __DB__.__SCHEMA__.V_BRAND_CLASSIFIED WHERE is_focal AND product_out_of_stock;
+
+-- ---------------------------------------------------------------------------
+-- V_ALERTS — focal SKUs needing action across signals, one row per SKU by priority
+-- (out of stock > weak content D/F > lost page-1 rank). Backs the cockpit "Active
+-- Alerts" KPI + list so alerts stay meaningful at any catalog size — OOS alone is
+-- rare for a modest focal brand. (V_ALERT_OOS above remains the OOS-only view.)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW __DB__.__SCHEMA__.V_ALERTS AS
+SELECT b.snapshot_date, b.retailer, b.product_id, b.product_name, b.brand_tier, b.position,
+    b.sponsored, b.best_price, b.product_image, b.product_url,
+    CASE WHEN b.product_out_of_stock              THEN 'Out of stock'
+         WHEN ch.content_grade IN ('D', 'F')      THEN 'Weak content'
+         ELSE 'Off page 1' END AS alert_type,
+    CASE WHEN b.product_out_of_stock AND b.position <= 5  THEN 'CRITICAL'
+         WHEN b.product_out_of_stock AND b.position <= 24 THEN 'HIGH'
+         WHEN b.product_out_of_stock                      THEN 'MODERATE'
+         WHEN ch.content_grade = 'F'                      THEN 'HIGH'
+         ELSE 'MODERATE' END AS severity,
+    ROUND(b.best_price / NULLIF(b.position, 0), 4) AS revenue_risk_index
+FROM __DB__.__SCHEMA__.V_BRAND_CLASSIFIED b
+LEFT JOIN __DB__.__SCHEMA__.V_CONTENT_HEALTH ch
+    ON ch.retailer = b.retailer AND ch.product_id = b.product_id AND ch.snapshot_date = b.snapshot_date
+WHERE b.is_focal
+  AND (b.product_out_of_stock OR ch.content_grade IN ('D', 'F') OR b.position > 48);
 
 -- ---------------------------------------------------------------------------
 -- V_TREND_SOS_DAILY / V_TREND_KPI — share-of-shelf over time + day-over-day deltas.


### PR DESCRIPTION
## Summary

Dashboard polish for the **CMO Intelligence** Cortex Code skill, plus the answer-engine ingestion that powers **Share of AI Answer** — so a provisioned app is presentation-ready. All changes land in the skill templates, so every future app inherits them.

## Cockpit polish
- **Remove the in-cockpit web-search chat** (Cortex covers conversational Q&A). Orphaned helpers + unused import dropped.
- **Retailer pricing** — replace the unit-price "focal vs competitor" card (which renders empty for retailers that don't return a per-unit price, and mixes incomparable unit bases) with an **"average price by brand × retailer" matrix** on the listed price (`best_price`), populated for every retailer.
- **Snapshot selection** — read the latest *complete* snapshot (the day with the most retailers present) instead of the raw `MAX(snapshot_date)`, so a mid-run day doesn't render an empty retailer.

## Active Alerts (was out-of-stock only → ~0 for a modest brand)
- New **`V_ALERTS`** view: focal SKUs needing action across signals, one row per SKU by priority — **out of stock → weak content (grade D/F) → off page 1**. The KPI, Retailer card, and Leadership insight read it, with per-tile alert-type chips. Meaningful at any catalog size.

## Share of AI Answer (was created-but-never-populated)
- **`REFRESH_GEO(prompt_limit)`** — a deterministic set of templated category prompts run through Perplexity / ChatGPT / Gemini via Nimble's answer-engine agents (`NIMBLE_AGENT_RUN`), writing `GEO_ANSWERS` + `GEO_SOURCES`. Concurrent, mirroring the PDP ingestion.
- **Two-tier cadence** (mirrors the PDP seed/daily split): a small first-setup seed task for a fast first view + a full weekly refresh task.
- **Cockpit 3-state** for the AI-answer surfaces: real data → surfaces render · generation scheduled but not yet complete → a "being generated" placeholder · not enabled → hidden. No bare 0% / silent-empty.

## Versioning
- Adds `version: 1.0.0` to `SKILL.md` frontmatter + a `CHANGELOG.md` (SemVer / Keep a Changelog).

## Testing
Provisioned and validated end-to-end on a live Snowflake account (Enterprise, Cortex Agents enabled): pricing renders across all retailers, the answer-engine batch runs and both AI-answer views populate, alerts surface across the signal types, and the cockpit renders with the chat removed.

## Notes
- Brand / retailer names in examples are illustrative; the skill generalizes to any brand or category.
- Public/open-source repo — DDL, comments, and examples are product-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)