### PR TITLE
Add Earnings Guidance vs Actuals app

### DIFF
--- a/apps/earnings-guidance-vs-actuals/.env.example
+++ b/apps/earnings-guidance-vs-actuals/.env.example
@@ -1,0 +1,20 @@
+# Nimble Web Search Agents
+NIMBLE_API_KEY=your_nimble_api_key
+
+# Snowflake
+SNOWFLAKE_ACCOUNT=ORGNAME-ACCOUNTNAME    # Snowsight copies it as ORGNAME.ACCOUNTNAME - replace the dot with a dash
+SNOWFLAKE_USER=your_username
+SNOWFLAKE_PASSWORD=your_password         # if your org enforces MFA, use key-pair auth instead (see ai-setup.md)
+SNOWFLAKE_PRIVATE_KEY_PATH=              # optional: path to a PKCS8 key, e.g. .keys/snowflake_rsa_key.p8
+SNOWFLAKE_ROLE=                          # optional: a role that can CREATE DATABASE (e.g. SYSADMIN)
+SNOWFLAKE_WAREHOUSE=EARNINGS_WH          # created by setup_snowflake.py if missing
+SNOWFLAKE_DATABASE=EARNINGS_DESK
+
+# Slack incoming webhook - where scorecards get posted
+SLACK_WEBHOOK_URL=
+
+# Anthropic - powers the Ask-the-Desk NL->SQL lane
+ANTHROPIC_API_KEY=
+
+# true = live agent runs; the scorecard UI reads Snowflake either way
+USE_LIVE=true

--- a/apps/earnings-guidance-vs-actuals/.gitignore
+++ b/apps/earnings-guidance-vs-actuals/.gitignore
@@ -1,0 +1,6 @@
+.env
+.venv/
+__pycache__/
+.keys/
+agents.json
+data/raw/

--- a/apps/earnings-guidance-vs-actuals/.streamlit/config.toml
+++ b/apps/earnings-guidance-vs-actuals/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[theme]
+base = "dark"
+primaryColor = "#edc602"

--- a/apps/earnings-guidance-vs-actuals/README.md
+++ b/apps/earnings-guidance-vs-actuals/README.md
@@ -1,0 +1,98 @@
+# earnings-guidance-vs-actuals — Earnings Guidance vs Actuals
+
+Ticker watchlist in, audit-grade guidance-vs-delivery scorecard out. A research agent built on [Nimble](https://nimbleway.com) Web Search Agents reconstructs what each company's management guided for every fiscal quarter — from archived earnings releases, SEC filings, and call transcripts — pairs it with what was actually reported, and grades every quarter beat / miss / inline with a citation behind every number. The ledger lives in Snowflake and grows with every run.
+
+![Built with Nimble + Snowflake](https://img.shields.io/badge/Built%20with-Nimble%20%2B%20Snowflake-edc602)
+
+## What it does
+
+1. **Research** — one Web Search Agent ("Guidance Scorecard Agent", a sell-side-analyst persona) researches each ticker's guidance and actuals, 4 quarters per run, with field-level trust claims
+2. **Backfill** — `backfill.py` batches the full watchlist (12 tickers × 8 quarters = 24 runs, 4 concurrent, resumable) so the longitudinal dataset exists on day one — no waiting for earnings season
+3. **Grade** — `ingest.py` parses guided ranges deterministically ("$26.0B–$26.5B", "±2%"), computes beat/miss/inline per metric app-side, and refuses to grade scale-mismatched comparisons (percent guidance vs dollar actuals) rather than fabricate verdicts
+4. **Store** — three Snowflake tables (runs, ledger, claims) plus a headline view that handles every guidance style: formal ranges, segment-level guidance, and outlook-only companies
+5. **Act** — scorecards post to Slack via webhook after each ticker lands
+6. **Ask** — natural-language questions answered two ways: Claude writes SQL over the ledger (LlamaIndex), or new questions go back to the live agent with the ticker's research context (multi-turn)
+
+## Stack
+
+- [Nimble Web Search Agents](https://nimbleway.com) — the research layer: cited, schema-conforming answers with per-claim trust
+- [Snowflake](https://snowflake.com) — the guidance ledger (3 tables + headline views)
+- [LlamaIndex](https://llamaindex.ai) — NL→SQL query engine over the ledger
+- [Anthropic Claude](https://anthropic.com) — powers the Ask-the-Desk SQL lane
+- [Streamlit](https://streamlit.io) — scorecard grid, company drill-down, Ask the Desk
+
+## Setup
+
+```bash
+git clone https://github.com/Nimbleway/cookbook
+cd cookbook/apps/earnings-guidance-vs-actuals
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env   # then fill in keys
+```
+
+Keys you need:
+- `NIMBLE_API_KEY` — get one at [nimbleway.com](https://nimbleway.com)
+- Snowflake account + user (a free trial works; see `.env.example` comments for the account-identifier format and MFA notes)
+- `SLACK_WEBHOOK_URL` — an incoming webhook (api.slack.com/apps → Incoming Webhooks)
+- `ANTHROPIC_API_KEY` — for the NL→SQL lane
+
+Then, in order:
+
+```bash
+python setup_agent.py      # creates the Web Search Agent (once; id saved to agents.json)
+python setup_snowflake.py  # creates warehouse, database, tables, views (idempotent)
+python backfill.py         # 24 research runs, ~60-90 min, resumable - rerun to retry failures
+python ingest.py           # parse + grade + load the ledger
+streamlit run app.py
+```
+
+## Usage
+
+Open the app → **Scorecard** shows the 12-ticker verdict grid (latest 8 quarters each). Drill into a company for per-metric guided-vs-actual rows with source links. Ask the Desk: *"Which company beat revenue guidance most often?"* runs as SQL over the ledger; *"Why did IBM defer its full-year outlook?"* goes to the live agent as new research (5–10 min).
+
+To add a quarter after the next earnings day, run `backfill.py <TICKER>` — same code path, the ledger MERGEs idempotently.
+
+## Project structure
+
+```
+├── config.py           # watchlist (with per-company guidance-style notes), paths, env
+├── setup_agent.py      # creates the Guidance Scorecard Agent (full config inline)
+├── setup_snowflake.py  # warehouse + EARNINGS_DESK.LEDGER schema + headline views
+├── wsa.py              # Web Search Agents client: start/poll/fetch with 408-retry
+├── backfill.py         # batch engine: chunked, concurrent, resumable
+├── ingest.py           # deterministic parsing, verdict grading, claim-URL repair, MERGE
+├── slack_post.py       # scorecard → Slack webhook
+├── ask.py              # Ask the Desk: LlamaIndex NL→SQL lane + live multi-turn lane
+├── app.py              # Streamlit UI (3 pages)
+└── data/sample_run/    # one verbatim agent result (MSFT) showing the output shape
+```
+
+## Output
+
+`EARNINGS_DESK.LEDGER.GUIDANCE_LEDGER` — one row per (ticker, fiscal_quarter, metric):
+
+| column | type | description |
+|---|---|---|
+| ticker, fiscal_quarter, report_date | STRING/DATE | company fiscal label + calendar report date |
+| metric, metric_raw | STRING | normalized + verbatim metric name |
+| guided_value_raw, guided_range_raw | STRING | guidance exactly as management stated it |
+| guided_low, guided_mid, guided_high | FLOAT | deterministically parsed range (NULL when guidance is qualitative) |
+| actual_value_raw, actual_value_num | STRING/FLOAT | reported result, verbatim + parsed |
+| metric_verdict | STRING | beat / miss / inline / not_guided — computed app-side |
+| quarter_verdict | STRING | the agent's own quarter-level verdict (cross-check) |
+| guidance_source_url, actual_source_url | STRING | full public URLs |
+
+Plus `RUNS` (one row per agent run, raw result as VARIANT, interaction ids for multi-turn) and `CLAIMS` (field-level provenance: JSON path, confidence, citation URL, excerpt — the audit trail).
+
+## Going further
+
+- **Change the watchlist** — edit `WATCHLIST` in `config.py`; the fiscal notes matter (companies that guide qualitatively or full-year need their style described, or runs come back thin)
+- **Different metrics** — extend the agent's `output_schema` in `setup_agent.py`
+- **Schedule the append** — run `backfill.py <TICKER>` from a scheduler after each earnings date; the production story is a Monitor-style always-current ledger
+
+## Notes
+
+- `not_guided` means "management did not guide this" — deliberately distinct from data gaps; grading qualitative commentary would be fabrication, so the app refuses
+- Live runs vary: a repeated backfill can return slightly different metric coverage per quarter; `ingest.py` flags runs with fewer than 4 quarters as degraded so they can be re-run
+- Agent effort is pinned to `high` — lower tiers fail; a 4-quarter run takes 8–16 minutes

--- a/apps/earnings-guidance-vs-actuals/ai-setup.md
+++ b/apps/earnings-guidance-vs-actuals/ai-setup.md
@@ -1,0 +1,124 @@
+# AI Setup — Earnings Guidance vs Actuals
+
+You are helping the user set up and run Earnings Guidance vs Actuals: a Nimble Web Search Agents app that builds an audit-grade guidance-vs-delivery scorecard for a stock watchlist, stores it in Snowflake, posts scorecards to Slack, and answers questions over the ledger. Follow these steps in order. Check each prerequisite before proceeding. Tell the user what you're doing at each step.
+
+---
+
+## Step 1 — Check prerequisites
+
+Run each check; help the user install anything missing.
+
+```bash
+python3 --version    # need 3.10+
+git --version
+```
+
+Account-level prerequisites — confirm with the user before continuing:
+- **Nimble API key** — from their Nimble workspace (nimbleway.com). Used for every research run.
+- **Snowflake account** — a free trial (no credit card) works, or a company account. The user needs a role that can create a database and warehouse (trial default works; on company accounts ask for SYSADMIN or similar).
+- **Slack workspace** where they can add an incoming webhook.
+- **Anthropic API key** — used only by the Ask-the-Desk SQL lane.
+
+---
+
+## Step 2 — Clone the repo
+
+```bash
+if [ -d cookbook ]; then cd cookbook && git pull; else git clone https://github.com/Nimbleway/cookbook && cd cookbook; fi
+cd apps/earnings-guidance-vs-actuals
+```
+
+---
+
+## Step 3 — Install dependencies
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Takes 1–2 minutes (Snowflake connector and LlamaIndex are the heavy ones).
+
+---
+
+## Step 4 — Get API keys
+
+For each key, tell the user where to get it and what it does in this app:
+
+1. **NIMBLE_API_KEY** — Tell the user: "This powers the research agent — every guidance/actuals run is a Nimble Web Search Agents run with per-claim citations." Get it from the Nimble dashboard.
+2. **Snowflake credentials** — Tell the user: "Snowflake holds the guidance ledger — three tables that grow with every run." Gotchas that cost real time, handle them proactively:
+   - The account identifier in Snowsight copies as `ORGNAME.ACCOUNTNAME` — the connector needs `ORGNAME-ACCOUNTNAME` (dash, not dot).
+   - If the org enforces MFA on passwords, password auth will fail with "MFA with TOTP is required". Switch to key-pair auth: generate a key (`openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out .keys/snowflake_rsa_key.p8 -nocrypt`), print the public key (`openssl rsa -in .keys/snowflake_rsa_key.p8 -pubout`), have the user run `ALTER USER <name> SET RSA_PUBLIC_KEY='<key body>';` in a Snowsight SQL sheet, and set `SNOWFLAKE_PRIVATE_KEY_PATH=.keys/snowflake_rsa_key.p8` in `.env`.
+   - On company accounts the default role often cannot create databases — set `SNOWFLAKE_ROLE=SYSADMIN` (or whatever elevated role the user has).
+3. **SLACK_WEBHOOK_URL** — Tell the user: "Scorecards get posted here — the agent acts, not just reports." Create at api.slack.com/apps → New App → Incoming Webhooks → Add to a channel; copy the `https://hooks.slack.com/services/...` URL.
+4. **ANTHROPIC_API_KEY** — Tell the user: "Claude writes SQL over the ledger for natural-language questions." From console.anthropic.com.
+
+---
+
+## Step 5 — Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and fill every non-optional line. Show the user the file and confirm each value is set before continuing.
+
+---
+
+## Step 6 — Create the agent and the ledger
+
+```bash
+python setup_agent.py      # ~5s; prints the new agent id, saved to agents.json
+python setup_snowflake.py  # ~30s; creates warehouse EARNINGS_WH, database EARNINGS_DESK, 3 tables + 2 views
+```
+
+Ask the user to confirm both ran without errors before continuing. `setup_snowflake.py` is idempotent — safe to rerun after fixing credentials.
+
+---
+
+## Step 7 — Backfill the ledger
+
+```bash
+python backfill.py
+```
+
+This is the long step: 24 research runs (12 tickers × 2 four-quarter chunks), 4 concurrent, **60–90 minutes total**. Each run prints progress. The loop is resumable — if anything fails or is interrupted, rerun the same command; completed chunks are skipped. To test the pipe quickly first, run a single ticker: `python backfill.py MSFT` (~15 min).
+
+Then load the ledger:
+
+```bash
+python ingest.py           # ~2 min; prints rows + claims per file
+```
+
+If ingest flags any file as `DEGRADED RUN`, delete that file from `data/raw/` and rerun `backfill.py <TICKER>` — some companies' guidance styles occasionally produce thin runs.
+
+---
+
+## Step 8 — Launch
+
+```bash
+streamlit run app.py
+```
+
+Opens at http://localhost:8501. Success = the Scorecard page shows a verdict grid with one row per ticker.
+
+---
+
+## Step 9 — Orient the user
+
+Walk them through:
+- **Scorecard** — the verdict grid (latest 8 quarters per ticker) and track records. Point out the honest gaps: companies like banks show n/a where they genuinely issue no numeric guidance.
+- **Company drill-down** — pick NVDA or MSFT: per-metric guided vs actual with source links; the basis label in each quarter header says how the verdict was derived. The 📣 button posts that scorecard to Slack.
+- **Ask the Desk** — suggest trying:
+  1. "Which company beat revenue guidance most often?" (SQL lane, ~30s, shows the generated SQL)
+  2. "Show MSFT's guided vs actual revenue by quarter" (SQL lane)
+  3. "What did management say about next quarter's margins?" with a ticker selected (live lane — a real research run, 5–10 minutes)
+
+---
+
+## Notes
+
+- Live agent runs vary in coverage run-to-run; the deterministic grader marks anything unverifiable as `not_guided` rather than guessing.
+- The Snowflake session self-heals on token expiry; the warehouse auto-suspends after 60s idle, so cost is minimal.
+- Backfill cost: ~24 Nimble runs at high effort. Ask-the-Desk live questions are one run each.
+- If a run fails with "array output is empty", the company's guidance style needs a better fiscal note in `config.py` — see the JNJ/AAPL entries for examples.

--- a/apps/earnings-guidance-vs-actuals/app.py
+++ b/apps/earnings-guidance-vs-actuals/app.py
@@ -143,7 +143,8 @@ def page_company():
                 slack_post.post(ticker, rows, webhook)
                 st.success("Posted.")
             except Exception as e:
-                st.error(f"Slack post failed: {e}")
+                # never echo the exception verbatim - requests errors embed the webhook URL
+                st.error(f"Slack post failed ({type(e).__name__}) - check the webhook URL and network.")
 
 
 def page_ask():

--- a/apps/earnings-guidance-vs-actuals/app.py
+++ b/apps/earnings-guidance-vs-actuals/app.py
@@ -137,10 +137,13 @@ def page_company():
         if not webhook:
             st.error("SLACK_WEBHOOK_URL is not set; configure .env to enable Slack posting.")
         else:
-            cur = live_cursor()
-            rows = slack_post.scorecard(cur, DB, ticker)
-            slack_post.post(ticker, rows, webhook)
-            st.success("Posted.")
+            try:
+                cur = live_cursor()
+                rows = slack_post.scorecard(cur, DB, ticker)
+                slack_post.post(ticker, rows, webhook)
+                st.success("Posted.")
+            except Exception as e:
+                st.error(f"Slack post failed: {e}")
 
 
 def page_ask():

--- a/apps/earnings-guidance-vs-actuals/app.py
+++ b/apps/earnings-guidance-vs-actuals/app.py
@@ -133,10 +133,14 @@ def page_company():
         st.caption("Evidence: " + " · ".join(
             f"{int(r['N'])} {r['CONFIDENCE']}-confidence claims" for _, r in claims.iterrows()))
     if st.button(f"📣 Post {ticker} scorecard to Slack"):
-        cur = live_cursor()
-        rows = slack_post.scorecard(cur, DB, ticker)
-        slack_post.post(ticker, rows, os.environ["SLACK_WEBHOOK_URL"])
-        st.success("Posted.")
+        webhook = os.getenv("SLACK_WEBHOOK_URL")
+        if not webhook:
+            st.error("SLACK_WEBHOOK_URL is not set; configure .env to enable Slack posting.")
+        else:
+            cur = live_cursor()
+            rows = slack_post.scorecard(cur, DB, ticker)
+            slack_post.post(ticker, rows, webhook)
+            st.success("Posted.")
 
 
 def page_ask():

--- a/apps/earnings-guidance-vs-actuals/app.py
+++ b/apps/earnings-guidance-vs-actuals/app.py
@@ -1,0 +1,189 @@
+"""Earnings Guidance vs Actuals — Streamlit UI over the Snowflake ledger."""
+import os
+
+import pandas as pd
+import streamlit as st
+
+import ask as ask_mod
+import config as C
+import slack_post
+from setup_snowflake import connect
+
+st.set_page_config(page_title="Earnings Guidance vs Actuals", page_icon="📊", layout="wide")
+DB = os.environ.get("SNOWFLAKE_DATABASE", "EARNINGS_DESK")
+VERDICT_ICON = {"beat": "🟢 beat", "miss": "🔴 miss", "inline": "🟡 inline", "not_guided": "⚪ n/a"}
+
+
+@st.cache_resource
+def conn():
+    return connect()
+
+
+def live_cursor():
+    try:
+        cur = conn().cursor()
+        cur.execute("SELECT 1")
+        return cur
+    except Exception:
+        conn.clear()
+        return conn().cursor()
+
+
+@st.cache_data(ttl=300)
+def q(sql, params=None):
+    try:
+        cur = conn().cursor()
+        cur.execute(sql, params or ())
+    except Exception:
+        conn.clear()  # session token expired (~4h) or connection dropped - rebuild once
+        cur = conn().cursor()
+        cur.execute(sql, params or ())
+    return pd.DataFrame(cur.fetchall(), columns=[d[0] for d in cur.description])
+
+
+def page_scorecard():
+    st.title("📊 Earnings Guidance vs Actuals")
+    st.caption("What management promised vs what landed — every number cited. "
+               "Built on Nimble Web Search Agents; the ledger grows with every run.")
+    df = q(f"""SELECT ticker, fiscal_quarter, report_date, metric_verdict
+               FROM {DB}.LEDGER.V_HEADLINE_DEDUP""")
+    if df.empty:
+        st.info("Ledger is empty — run backfill.py then ingest.py.")
+        return
+    # rank quarters per ticker (1 = most recent) so all tickers share columns
+    df = df.sort_values("REPORT_DATE", ascending=False)
+    df["QRANK"] = df.groupby("TICKER").cumcount() + 1
+    df = df[df["QRANK"] <= 8]
+    grid = df.pivot_table(index="TICKER", columns="QRANK",
+                          values="METRIC_VERDICT", aggfunc="first")
+    grid.columns = ["latest" if c == 1 else f"-{c - 1}" for c in grid.columns]
+    st.markdown("#### Revenue verdict grid (most recent quarters)")
+    st.dataframe(grid.style.map(lambda v: {
+        "beat": "background-color:#1b5e20;color:white",
+        "miss": "background-color:#b71c1c;color:white",
+        "inline": "background-color:#f9a825;color:black"}.get(v, "")), use_container_width=True)
+
+    counts = df.groupby(["TICKER", "METRIC_VERDICT"]).size().unstack(fill_value=0)
+    for v in ("beat", "miss", "inline"):
+        if v not in counts:
+            counts[v] = 0
+    counts["record"] = counts.apply(lambda r: f"{r['beat']}W-{r['miss']}L", axis=1)
+    st.markdown("#### Track records")
+    st.dataframe(counts[["beat", "miss", "inline", "record"]].sort_values("beat", ascending=False),
+                 use_container_width=True)
+
+
+def page_company():
+    tickers = q(f"SELECT DISTINCT ticker FROM {DB}.LEDGER.GUIDANCE_LEDGER ORDER BY 1")["TICKER"].tolist()
+    if not tickers:
+        st.info("Ledger is empty.")
+        return
+    ticker = st.selectbox("Company", tickers)
+    st.title(f"{ticker} — guidance vs delivery")
+    df = q(f"""SELECT fiscal_quarter, report_date, metric_raw, guided_range_raw, guided_value_raw,
+               actual_value_raw, metric_verdict, quarter_verdict, notes,
+               guidance_source_url, actual_source_url
+               FROM {DB}.LEDGER.GUIDANCE_LEDGER WHERE ticker = %s
+               ORDER BY report_date DESC, metric_raw""", (ticker,))
+    headline = q(f"""SELECT fiscal_quarter, metric_verdict, basis
+                     FROM {DB}.LEDGER.V_HEADLINE_DEDUP WHERE ticker = %s""", (ticker,))
+    hmap = {r["FISCAL_QUARTER"]: (r["METRIC_VERDICT"], r["BASIS"]) for _, r in headline.iterrows()}
+    na_share = (headline["METRIC_VERDICT"] == "not_guided").mean() if not headline.empty else 0
+    if na_share >= 0.5:
+        st.info(f"{ticker} issues little or no formal numeric guidance — verdicts appear only "
+                "where management gave a measurable outlook. The quarter notes below record what "
+                "management *did* say; grading qualitative commentary would be fabrication.")
+    for fq in df["FISCAL_QUARTER"].unique():
+        sub = df[df["FISCAL_QUARTER"] == fq]
+        head = sub.iloc[0]
+        h_verdict, h_basis = hmap.get(fq, (head["QUARTER_VERDICT"], None))
+        icon = VERDICT_ICON.get(h_verdict, "⚪")
+        title = f"{icon}  {fq} — reported {head['REPORT_DATE']}"
+        if h_basis:
+            title += f"  ·  {h_basis}"
+        with st.expander(title, expanded=False):
+            for _, r in sub.iterrows():
+                guided = r["GUIDED_RANGE_RAW"] or r["GUIDED_VALUE_RAW"]
+                if guided:
+                    if r["METRIC_VERDICT"] == "not_guided" and r["ACTUAL_VALUE_RAW"]:
+                        verdict_txt = "⚪ not comparable — directional/qualitative outlook"
+                    elif r["METRIC_VERDICT"] == "not_guided":
+                        verdict_txt = "⚪ actual not located"
+                    else:
+                        verdict_txt = VERDICT_ICON.get(r["METRIC_VERDICT"], r["METRIC_VERDICT"])
+                    st.markdown(f"**{r['METRIC_RAW']}**: guided {guided} → actual "
+                                f"{r['ACTUAL_VALUE_RAW'] or '—'}  ({verdict_txt})")
+                else:
+                    st.markdown(f"**{r['METRIC_RAW']}**: reported {r['ACTUAL_VALUE_RAW'] or '—'} "
+                                f"*(not guided)*")
+                links = []
+                if r["GUIDANCE_SOURCE_URL"]:
+                    links.append(f"[guidance source]({r['GUIDANCE_SOURCE_URL']})")
+                if r["ACTUAL_SOURCE_URL"]:
+                    links.append(f"[actual source]({r['ACTUAL_SOURCE_URL']})")
+                if links:
+                    st.caption(" · ".join(links))
+            if head["NOTES"]:
+                st.caption(f"Notes: {head['NOTES']}")
+
+    st.markdown("---")
+    claims = q(f"""SELECT confidence, COUNT(*) AS n FROM {DB}.LEDGER.CLAIMS
+                   WHERE ticker = %s GROUP BY 1""", (ticker,))
+    if not claims.empty:
+        st.caption("Evidence: " + " · ".join(
+            f"{int(r['N'])} {r['CONFIDENCE']}-confidence claims" for _, r in claims.iterrows()))
+    if st.button(f"📣 Post {ticker} scorecard to Slack"):
+        cur = live_cursor()
+        rows = slack_post.scorecard(cur, DB, ticker)
+        slack_post.post(ticker, rows, os.environ["SLACK_WEBHOOK_URL"])
+        st.success("Posted.")
+
+
+def page_ask():
+    st.title("💬 Ask the Desk")
+    st.caption("Aggregation questions are answered from the ledger (Claude writes the SQL). "
+               "Questions needing new research go back to the live agent — expect 5–10 minutes.")
+    tickers = q(f"SELECT DISTINCT ticker FROM {DB}.LEDGER.GUIDANCE_LEDGER ORDER BY 1")["TICKER"].tolist()
+    question = st.text_input("Question",
+                             placeholder="Who missed revenue guidance most often? / Why did IBM's guidance change?")
+    lane_choice = st.radio("Lane", ["auto", "ledger (SQL)", "live agent"], horizontal=True)
+    ticker = st.selectbox("Ticker (for live lane)", tickers) if tickers else None
+    if st.button("Ask", type="primary") and question:
+        lane = {"auto": ask_mod.route(question),
+                "ledger (SQL)": "ledger", "live agent": "live"}[lane_choice]
+        if lane == "ledger":
+            try:
+                with st.spinner("Claude is writing SQL and querying the ledger (~30s)…"):
+                    sql, cols, rows, answer = ask_mod.ask_ledger(question, live_cursor(), DB)
+                if answer:
+                    st.markdown(f"**{answer}**")
+                st.code(sql, language="sql")
+                if rows:
+                    st.dataframe(pd.DataFrame(rows, columns=cols), use_container_width=True)
+                else:
+                    st.info("Query ran but returned no rows — try rephrasing.")
+            except Exception as e:
+                st.error(f"Ledger lane failed ({e}) — try the live agent lane.")
+        else:
+            inter = q(f"""SELECT interaction_id FROM {DB}.LEDGER.RUNS WHERE ticker = %s
+                          ORDER BY ingested_at DESC LIMIT 1""", (ticker,))
+            iid = inter["INTERACTION_ID"].iloc[0] if not inter.empty else None
+            with st.status(f"Live research on {ticker}…", expanded=True) as status:
+                out = ask_mod.ask_live(question, ticker, iid)
+                status.update(label="Done", state="complete")
+            content = out["content"]
+            st.markdown(content if isinstance(content, str) else st.json(content) or "")
+            st.caption(f"confidence: {out['confidence']} · {out['claims']} claims")
+
+
+PAGES = {"Scorecard": page_scorecard, "Company drill-down": page_company, "Ask the Desk": page_ask}
+with st.sidebar:
+    st.markdown("## Earnings Desk")
+    st.caption("Nimble Web Search Agents")
+    page = st.radio("Navigate", list(PAGES), label_visibility="collapsed")
+    st.markdown("---")
+    if st.button("🔄 Refresh data"):
+        q.clear()
+        st.rerun()
+    st.caption(f"Mode: {'LIVE' if C.USE_LIVE else 'REPLAY'}")
+PAGES[page]()

--- a/apps/earnings-guidance-vs-actuals/app.py
+++ b/apps/earnings-guidance-vs-actuals/app.py
@@ -137,14 +137,22 @@ def page_company():
         if not webhook:
             st.error("SLACK_WEBHOOK_URL is not set; configure .env to enable Slack posting.")
         else:
+            import logging
             try:
                 cur = live_cursor()
                 rows = slack_post.scorecard(cur, DB, ticker)
-                slack_post.post(ticker, rows, webhook)
-                st.success("Posted.")
             except Exception as e:
-                # never echo the exception verbatim - requests errors embed the webhook URL
-                st.error(f"Slack post failed ({type(e).__name__}) - check the webhook URL and network.")
+                logging.exception("scorecard query failed")
+                st.error(f"Could not load the scorecard from Snowflake ({type(e).__name__}) - see app logs.")
+                rows = None
+            if rows:
+                try:
+                    slack_post.post(ticker, rows, webhook)
+                    st.success("Posted.")
+                except Exception as e:
+                    # sanitized on screen (requests errors embed the webhook URL); full detail in app logs
+                    logging.exception("slack post failed")
+                    st.error(f"Slack post failed ({type(e).__name__}) - see app logs for details.")
 
 
 def page_ask():

--- a/apps/earnings-guidance-vs-actuals/ask.py
+++ b/apps/earnings-guidance-vs-actuals/ask.py
@@ -47,16 +47,20 @@ def _sqlalchemy_engine(db):
     from cryptography.hazmat.primitives import serialization
     from snowflake.sqlalchemy import URL
     from sqlalchemy import create_engine
-    key_path = Path(__file__).parent / os.environ["SNOWFLAKE_PRIVATE_KEY_PATH"]
-    key = serialization.load_pem_private_key(key_path.read_bytes(), password=None)
-    pkb = key.private_bytes(encoding=serialization.Encoding.DER,
-                            format=serialization.PrivateFormat.PKCS8,
-                            encryption_algorithm=serialization.NoEncryption())
-    return create_engine(URL(
+    url_kwargs = dict(
         account=os.environ["SNOWFLAKE_ACCOUNT"], user=os.environ["SNOWFLAKE_USER"],
         database=db, schema="LEDGER",
         warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE"), role=os.environ.get("SNOWFLAKE_ROLE"),
-    ), connect_args={"private_key": pkb})
+    )
+    key_path_env = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+    if key_path_env:  # key-pair auth
+        key_path = Path(__file__).parent / key_path_env
+        key = serialization.load_pem_private_key(key_path.read_bytes(), password=None)
+        pkb = key.private_bytes(encoding=serialization.Encoding.DER,
+                                format=serialization.PrivateFormat.PKCS8,
+                                encryption_algorithm=serialization.NoEncryption())
+        return create_engine(URL(**url_kwargs), connect_args={"private_key": pkb})
+    return create_engine(URL(**url_kwargs, password=os.environ["SNOWFLAKE_PASSWORD"]))
 
 
 TABLE_INFO = {

--- a/apps/earnings-guidance-vs-actuals/ask.py
+++ b/apps/earnings-guidance-vs-actuals/ask.py
@@ -1,0 +1,130 @@
+"""Ask the Desk: two lanes.
+
+Lane 1 (ledger): natural language -> SQL over the Snowflake ledger via Claude
+(aggregation/trend questions the accumulated dataset already answers).
+Lane 2 (live): new research -> a fresh agent run with previous_interaction_id
+so the agent keeps the ticker's research context.
+"""
+import os
+import re
+
+import anthropic
+
+import config as C
+import wsa
+
+MODEL = "claude-sonnet-5"
+
+SCHEMA_CARD = """Snowflake tables (database {db}, schema LEDGER):
+GUIDANCE_LEDGER(ticker, fiscal_quarter, report_date, metric, guided_value_raw, guided_range_raw,
+                guided_low, guided_mid, guided_high, actual_value_raw, actual_value_num,
+                metric_verdict beat|miss|inline|not_guided, quarter_verdict, notes,
+                guidance_source_url, actual_source_url, run_id)
+CLAIMS(claim_id, run_id, ticker, json_path, confidence high|medium|low|pre_existing,
+       reasoning, citation_url, citation_title, excerpt)
+RUNS(run_id, interaction_id, ticker, quarter_window, overall_confidence, wall_clock_s)"""
+
+
+def route(question):
+    """ledger for aggregation over stored data; live for anything needing new research."""
+    q = question.lower()
+    live_markers = ("why", "what happened", "explain", "context", "call", "said",
+                    "management", "outlook", "expect", "will ", "next quarter")
+    return "live" if any(m in q for m in live_markers) else "ledger"
+
+
+def ask_ledger(question, cur, db):
+    """NL -> SQL over the ledger. LlamaIndex engine first; direct Claude as fallback."""
+    try:
+        return _ask_ledger_llamaindex(question, db)
+    except Exception:
+        return _ask_ledger_direct(question, cur, db)
+
+
+def _sqlalchemy_engine(db):
+    from pathlib import Path
+
+    from cryptography.hazmat.primitives import serialization
+    from snowflake.sqlalchemy import URL
+    from sqlalchemy import create_engine
+    key_path = Path(__file__).parent / os.environ["SNOWFLAKE_PRIVATE_KEY_PATH"]
+    key = serialization.load_pem_private_key(key_path.read_bytes(), password=None)
+    pkb = key.private_bytes(encoding=serialization.Encoding.DER,
+                            format=serialization.PrivateFormat.PKCS8,
+                            encryption_algorithm=serialization.NoEncryption())
+    return create_engine(URL(
+        account=os.environ["SNOWFLAKE_ACCOUNT"], user=os.environ["SNOWFLAKE_USER"],
+        database=db, schema="LEDGER",
+        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE"), role=os.environ.get("SNOWFLAKE_ROLE"),
+    ), connect_args={"private_key": pkb})
+
+
+TABLE_INFO = {
+    "guidance_ledger": (
+        "One row per (ticker, fiscal_quarter, metric). Guidance vs actuals.\n"
+        "- metric_verdict is PRECOMPUTED: beat|miss|inline|not_guided - use it for who-beat/missed questions.\n"
+        "- Numeric analysis (margins, deltas): use guided_low/guided_mid/guided_high and actual_value_num.\n"
+        "  These are NULL when guidance was text-only ('mid single digit growth') - ALWAYS filter\n"
+        "  'guided_mid IS NOT NULL AND actual_value_num IS NOT NULL' before arithmetic, and never\n"
+        "  ORDER BY an expression that can be NULL without filtering the NULLs out first.\n"
+        "- Beat margin pct = (actual_value_num - guided_high) / guided_high * 100 (use guided_high, not mid).\n"
+        "- For revenue questions filter metric = 'revenue'. Units are absolute dollars (e.g. 4.67e10).\n"
+        "- Round percentages to 1 decimal and alias columns with readable names.\n"
+        "- Metrics whose metric_raw mentions 'growth' or 'qualitative' carry PERCENT-scale guided\n"
+        "  values - never mix them with dollar-scale actual_value_num in one calculation; add a\n"
+        "  sanity filter like actual_value_num / NULLIF(guided_high,0) BETWEEN 0.5 AND 2."),
+    "v_headline_dedup": (
+        "One HEADLINE row per (ticker, quarter): the quarter's overall verdict in metric_verdict\n"
+        "and how it was derived in basis. Prefer this table for per-quarter or track-record questions."),
+    "claims": "Field-level citations: json_path, confidence (high|medium|low), citation_url, excerpt.",
+    "runs": "One row per agent run: ticker, quarter_window, wall_clock_s, overall_confidence.",
+}
+
+
+def _ask_ledger_llamaindex(question, db):
+    from llama_index.core import SQLDatabase, Settings
+    from llama_index.core.query_engine import NLSQLTableQueryEngine
+    from llama_index.llms.anthropic import Anthropic as LlamaAnthropic
+
+    Settings.llm = LlamaAnthropic(model=MODEL, max_tokens=1000)
+    Settings.embed_model = None
+    tables = list(TABLE_INFO)
+    sql_db = SQLDatabase(_sqlalchemy_engine(db), include_tables=tables,
+                         custom_table_info=TABLE_INFO, view_support=True)
+    engine = NLSQLTableQueryEngine(sql_database=sql_db, tables=tables,
+                                   synthesize_response=True)
+    resp = engine.query(question)
+    sql = (resp.metadata or {}).get("sql_query", "")
+    if not re.match(r"^\s*select\b", sql, re.I):
+        raise ValueError("non-SELECT SQL from engine")
+    rows = (resp.metadata or {}).get("result") or []
+    cols = (resp.metadata or {}).get("col_keys") or []
+    return sql, cols, rows, str(resp)
+
+
+def _ask_ledger_direct(question, cur, db):
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    msg = client.messages.create(
+        model=MODEL, max_tokens=500,
+        system=("Write ONE Snowflake SELECT statement answering the question. "
+                "Only SELECT - no DDL/DML. Fully qualify tables. Return only SQL, no fences.\n"
+                + SCHEMA_CARD.format(db=db)),
+        messages=[{"role": "user", "content": question}])
+    text = next(b.text for b in msg.content if getattr(b, "type", "") == "text")
+    sql = text.strip().strip("`").removeprefix("sql").strip()
+    if not re.match(r"^\s*select\b", sql, re.I) or ";" in sql.rstrip(";"):
+        raise ValueError(f"refusing non-SELECT SQL: {sql[:80]}")
+    cur.execute(sql)
+    cols = [d[0] for d in cur.description]
+    return sql, cols, cur.fetchall(), None
+
+
+def ask_live(question, ticker, interaction_id):
+    run = wsa.start_run(C.agent_id(), f"Ticker: {ticker}. {question}",
+                        previous_interaction_id=interaction_id)
+    result, run_final = wsa.wait_for_result(C.agent_id(), run["id"])
+    out = result["output"]
+    trust = out.get("trust") or {}
+    return {"content": out.get("content"), "confidence": trust.get("confidence"),
+            "claims": len(trust.get("claims") or []),
+            "interaction_id": run_final.get("interaction_id")}

--- a/apps/earnings-guidance-vs-actuals/ask.py
+++ b/apps/earnings-guidance-vs-actuals/ask.py
@@ -50,8 +50,10 @@ def _sqlalchemy_engine(db):
     url_kwargs = dict(
         account=os.environ["SNOWFLAKE_ACCOUNT"], user=os.environ["SNOWFLAKE_USER"],
         database=db, schema="LEDGER",
-        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE"), role=os.environ.get("SNOWFLAKE_ROLE"),
+        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE") or None,
+        role=os.environ.get("SNOWFLAKE_ROLE") or None,
     )
+    url_kwargs = {k: v for k, v in url_kwargs.items() if v is not None}
     key_path_env = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
     if key_path_env:  # key-pair auth
         key_path = Path(__file__).parent / key_path_env

--- a/apps/earnings-guidance-vs-actuals/ask.py
+++ b/apps/earnings-guidance-vs-actuals/ask.py
@@ -89,17 +89,36 @@ def _ask_ledger_llamaindex(question, db):
     Settings.llm = LlamaAnthropic(model=MODEL, max_tokens=1000)
     Settings.embed_model = None
     tables = list(TABLE_INFO)
-    sql_db = SQLDatabase(_sqlalchemy_engine(db), include_tables=tables,
+    sa_engine = _sqlalchemy_engine(db)
+    sql_db = SQLDatabase(sa_engine, include_tables=tables,
                          custom_table_info=TABLE_INFO, view_support=True)
-    engine = NLSQLTableQueryEngine(sql_database=sql_db, tables=tables,
-                                   synthesize_response=True)
+    # sql_only: generate WITHOUT executing, so nothing runs before validation
+    engine = NLSQLTableQueryEngine(sql_database=sql_db, tables=tables, sql_only=True)
     resp = engine.query(question)
-    sql = (resp.metadata or {}).get("sql_query", "")
-    if not re.match(r"^\s*select\b", sql, re.I):
-        raise ValueError("non-SELECT SQL from engine")
-    rows = (resp.metadata or {}).get("result") or []
-    cols = (resp.metadata or {}).get("col_keys") or []
-    return sql, cols, rows, str(resp)
+    sql = ((resp.metadata or {}).get("sql_query") or str(resp)).strip().rstrip(";")
+    if not re.match(r"^\s*(select|with)\b", sql, re.I) or ";" in sql:
+        raise ValueError(f"refusing non-SELECT SQL: {sql[:80]}")
+    from sqlalchemy import text
+    with sa_engine.connect() as conn:
+        result = conn.execute(text(sql))
+        cols = list(result.keys())
+        rows = [tuple(r) for r in result.fetchall()]
+    answer = _summarize(question, sql, cols, rows)
+    return sql, cols, rows, answer
+
+
+def _summarize(question, sql, cols, rows):
+    """One short synthesized answer over the (already safely executed) result."""
+    try:
+        client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        msg = client.messages.create(
+            model=MODEL, max_tokens=300,
+            system="Answer the question in 1-3 plain sentences using only the query result given.",
+            messages=[{"role": "user", "content":
+                       f"Question: {question}\nSQL: {sql}\nColumns: {cols}\nRows (first 20): {rows[:20]}"}])
+        return next(b.text for b in msg.content if getattr(b, "type", "") == "text")
+    except Exception:
+        return None
 
 
 def _ask_ledger_direct(question, cur, db):

--- a/apps/earnings-guidance-vs-actuals/backfill.py
+++ b/apps/earnings-guidance-vs-actuals/backfill.py
@@ -1,0 +1,62 @@
+"""Backfill the 8-quarter ledger: 24 runs (12 tickers x 2 chunks), 4 concurrent, resumable.
+
+Re-running skips any (ticker, chunk) whose raw JSON already exists in data/raw/.
+Usage: python backfill.py [TICKER ...]   (no args = full watchlist)
+"""
+import json
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date
+
+import config as C
+import wsa
+
+
+def run_input(ticker, name, fiscal_note, window):
+    return (f"Ticker: {ticker} ({name}). Build the guidance-vs-actuals record for the "
+            f"{C.CHUNKS[window]} as of today ({date.today().isoformat()}), most recent first. "
+            f"For each quarter: the guidance management issued with the prior quarter's results "
+            f"(revenue, gross margin, opex, EPS if guided; forward outlook metrics if no formal "
+            f"quarterly guidance), the actually reported values for those metrics, and a verdict. "
+            f"{fiscal_note}").strip()
+
+
+def one_chunk(agent_id, ticker, name, note, window):
+    out = C.RAW_DIR / f"{ticker}_{window}.json"
+    if out.exists():
+        return ticker, window, "skipped (exists)", 0
+    for attempt in (1, 2, 3):
+        t0 = time.time()
+        try:
+            run = wsa.start_run(agent_id, run_input(ticker, name, note, window))
+            result, run_final = wsa.wait_for_result(agent_id, run["id"])
+            out.write_text(json.dumps({"run_id": run["id"],
+                                       "interaction_id": run_final.get("interaction_id"),
+                                       "ticker": ticker, "window": window,
+                                       "wall_clock_s": int(time.time() - t0),
+                                       "result": result}, indent=1))
+            return ticker, window, "ok", int(time.time() - t0)
+        except Exception as e:  # RunFailed, HTTP 422s from the result endpoint, transient network
+            print(f"  ! {ticker}/{window} attempt {attempt} failed: {e}", flush=True)
+            time.sleep(10)
+    return ticker, window, "FAILED after 3 attempts", 0
+
+
+def main():
+    agent_id = C.agent_id()
+    tickers = sys.argv[1:] or [t for t, _, _ in C.WATCHLIST]
+    jobs = [(t, n, f, w) for t, n, f in C.WATCHLIST if t in tickers for w in C.CHUNKS]
+    print(f"{len(jobs)} chunks over {len(tickers)} tickers (4 concurrent)")
+    done = 0
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(one_chunk, agent_id, t, n, f, w) for t, n, f, w in jobs]
+        for fut in as_completed(futures):
+            ticker, window, status, secs = fut.result()
+            done += 1
+            print(f"[{done}/{len(jobs)}] {ticker}/{window}: {status} ({secs}s)", flush=True)
+    print("backfill pass complete - rerun to retry any FAILED chunks")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/earnings-guidance-vs-actuals/config.py
+++ b/apps/earnings-guidance-vs-actuals/config.py
@@ -1,0 +1,51 @@
+"""Shared config for Earnings Guidance vs Actuals."""
+import json
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+APP_DIR = Path(__file__).parent
+load_dotenv(APP_DIR / ".env")
+
+BASE_URL = "https://sdk.nimbleway.com/v1"
+NIMBLE_API_KEY = os.getenv("NIMBLE_API_KEY", "")
+USE_LIVE = os.getenv("USE_LIVE", "true").lower() == "true"
+
+RAW_DIR = APP_DIR / "data" / "raw"
+RAW_DIR.mkdir(parents=True, exist_ok=True)
+SAMPLE_DIR = APP_DIR / "data" / "sample_run"
+AGENTS_FILE = APP_DIR / "agents.json"
+
+# Mixed 12: 8 big tech + 4 fresh Q2 reporters (Gate 1, 2026-07-16)
+WATCHLIST = [
+    ("AAPL", "Apple", "Apple's fiscal year ends late September. Apple gives no formal revenue "
+     "guidance since FY2020 - guidance is delivered qualitatively on earnings calls "
+     "(revenue growth direction, gross margin range, opex range, tax rate); capture those "
+     "call outlooks per quarter rather than expecting formal ranges. Cover every requested "
+     "quarter even when guidance is sparse."),
+    ("MSFT", "Microsoft", "Microsoft's fiscal year ends June 30."),
+    ("GOOGL", "Alphabet", ""),
+    ("AMZN", "Amazon", ""),
+    ("META", "Meta Platforms", ""),
+    ("NVDA", "NVIDIA", "NVIDIA's fiscal year ends late January."),
+    ("TSLA", "Tesla", "Tesla gives no formal quarterly revenue/EPS guidance - capture delivery growth, margin and capex outlooks."),
+    ("NFLX", "Netflix", ""),
+    ("JPM", "JPMorgan Chase", "Banks guide full-year NII and expenses rather than quarterly EPS - capture those outlooks."),
+    ("GS", "Goldman Sachs", "Banks rarely give formal quarterly guidance - capture whatever forward outlook management gave."),
+    ("JNJ", "Johnson & Johnson", "J&J guides FULL-YEAR sales and EPS, updated with each quarterly report. "
+     "For each requested quarter, produce a row whose guidance_metrics are the full-year outlook "
+     "as restated with the PRIOR quarter's results (label metrics 'FY sales (outlook)', 'FY adjusted EPS (outlook)'), "
+     "and whose actual_metrics are that quarter's reported sales and adjusted EPS. "
+     "Never return an empty row set - every requested quarter gets a row."),
+    ("IBM", "IBM", ""),
+]
+
+CHUNKS = {
+    "last4": "last 4 REPORTED fiscal quarters",
+    "q5to8": "5th through 8th most recently reported fiscal quarters",
+}
+
+
+def agent_id():
+    return json.loads(AGENTS_FILE.read_text())["scorecard_agent"]

--- a/apps/earnings-guidance-vs-actuals/data/sample_run/MSFT_last4.json
+++ b/apps/earnings-guidance-vs-actuals/data/sample_run/MSFT_last4.json
@@ -1,0 +1,3792 @@
+{
+ "run_id": "task_run_33581da5615348879695456705ec6741",
+ "interaction_id": "task_run_33581da5615348879695456705ec6741",
+ "ticker": "MSFT",
+ "window": "last4",
+ "wall_clock_s": 538,
+ "result": {
+  "run": {
+   "id": "task_run_33581da5615348879695456705ec6741",
+   "interaction_id": "task_run_33581da5615348879695456705ec6741",
+   "status": "completed",
+   "is_active": false,
+   "effort": "high",
+   "prompt": "Ticker: MSFT (Microsoft). Build the guidance-vs-actuals record for the last 4 REPORTED fiscal quarters as of today (2026-07-16), most recent first. For each quarter: the guidance management issued with the prior quarter's results (revenue, gross margin, opex, EPS if guided; forward outlook metrics if no formal quarterly guidance), the actually reported values for those metrics, and a verdict. Microsoft's fiscal year ends June 30.",
+   "created_at": "2026-07-16T14:20:22.664560Z",
+   "workspace_id": "42b80cc0-b6df-41e5-a21d-f53effb725cb",
+   "web_search_agent_id": "wsa_4957f859ca49453aba7aff70fa0e2201",
+   "started_at": "2026-07-16T14:20:23.015579Z",
+   "completed_at": "2026-07-16T14:29:15.354627Z",
+   "error": null
+  },
+  "output": {
+   "type": "json",
+   "content": [
+    {
+     "notes": "Q4 FY2026 (June 2026 quarter) not yet reported as of 2026-07-16; the Q3 FY26 earnings call on Apr 29 2026 provided a Q4 outlook, confirming Q4 FY26 had not been reported. Microsoft does not guide EPS directly; the EPS actual is reported but not formally guided. Revenue guidance was a total-company range; segment guidance was also given (PBP $34.25-$34.55B, actual $35.0B; IC $34.1-$34.4B, actual $34.7B; MPC $12.3-$12.8B, actual $13.2B \u2014 all segments beat the high end). Microsoft Cloud gross margin guided ~65%.",
+     "verdict": "beat",
+     "report_date": "2026-04-29",
+     "actual_metrics": [
+      {
+       "metric": "revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+       "actual_value": "$82.9 billion ($82,886 million)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/income-statements",
+       "actual_value": "$26,828 million"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/income-statements",
+       "actual_value": "$17,660 million (R&D $8,915M + S&M $6,814M + G&A $1,931M)"
+      },
+      {
+       "metric": "diluted EPS (GAAP)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/income-statements",
+       "actual_value": "$4.27 (GAAP); $4.27 (non-GAAP)"
+      },
+      {
+       "metric": "operating income",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/income-statements",
+       "actual_value": "$38,398 million"
+      },
+      {
+       "metric": "gross margin",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/income-statements",
+       "actual_value": "$56,058 million (67.6% of revenue)"
+      }
+     ],
+     "fiscal_quarter": "Q3 FY2026",
+     "guidance_metrics": [
+      {
+       "metric": "revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+       "guided_range": "$80.65B-$81.75B",
+       "guided_value": "$81.2 billion (midpoint of $80.65B-$81.75B)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+       "guided_range": "$26.65B-$26.85B",
+       "guided_value": "$26.75 billion (midpoint of $26.65B-$26.85B)"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+       "guided_range": "$17.8B-$17.9B",
+       "guided_value": "$17.85 billion (midpoint of $17.8B-$17.9B)"
+      },
+      {
+       "metric": "other income and expense (ex-OpenAI)",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+       "guided_range": null,
+       "guided_value": "approximately $700 million"
+      },
+      {
+       "metric": "effective tax rate (adjusted)",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+       "guided_range": null,
+       "guided_value": "approximately 19%"
+      }
+     ]
+    },
+    {
+     "notes": "Revenue guidance was a total-company range; segment guidance also given (PBP $33.3-$33.6B, actual $34.1B; IC $32.25-$32.55B, actual $32.9B; MPC $13.95-$14.45B, actual $14.3B \u2014 PBP and IC beat high end; MPC within range). Microsoft does not guide EPS directly; EPS actual reported but not formally guided. GAAP EPS $5.16 includes a large mark-to-market gain on OpenAI equity investment (non-GAAP OpenAI adjustment of $(7,583)M / $(1.02) per share), so non-GAAP EPS $4.14 is the more comparable profitability figure.",
+     "verdict": "beat",
+     "report_date": "2026-01-28",
+     "actual_metrics": [
+      {
+       "metric": "revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q2/income-statements",
+       "actual_value": "$81.3 billion ($81,273 million)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q2/income-statements",
+       "actual_value": "$25,978 million"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q2/income-statements",
+       "actual_value": "$17,020 million (R&D $8,504M + S&M $6,584M + G&A $1,932M)"
+      },
+      {
+       "metric": "diluted EPS (GAAP)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+       "actual_value": "$5.16 (GAAP); $4.14 (non-GAAP)"
+      },
+      {
+       "metric": "operating income",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q2/income-statements",
+       "actual_value": "$38,275 million"
+      }
+     ],
+     "fiscal_quarter": "Q2 FY2026",
+     "guidance_metrics": [
+      {
+       "metric": "revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+       "guided_range": "$79.5B-$80.6B",
+       "guided_value": "$80.05 billion (midpoint of $79.5B-$80.6B)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+       "guided_range": "$26.35B-$26.55B",
+       "guided_value": "$26.45 billion (midpoint of $26.35B-$26.55B)"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+       "guided_range": "$17.3B-$17.4B",
+       "guided_value": "$17.35 billion (midpoint of $17.3B-$17.4B)"
+      },
+      {
+       "metric": "other income and expense (ex-OpenAI)",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+       "guided_range": null,
+       "guided_value": "approximately $100 million"
+      },
+      {
+       "metric": "effective tax rate",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+       "guided_range": null,
+       "guided_value": "approximately 19%"
+      }
+     ]
+    },
+    {
+     "notes": "Microsoft did NOT provide a total-company revenue range for Q1 FY26; guidance was segment-only. The three segment ranges sum to an implied total of ~$74.7B-$75.8B (PBP $32.2-$32.5B + IC $30.1-$30.4B + MPC $12.4-$12.9B). Actual total revenue $77.7B exceeded this implied range; actual segment results were PBP $33.0B, IC $30.9B, MPC $13.8B \u2014 all three beat the high end of their guided ranges. Microsoft does not guide EPS directly. Full-year FY26 outlook also given: double-digit revenue and operating income growth, operating margins relatively unchanged year-over-year, FY26 effective tax rate 19%-20%.",
+     "verdict": "beat",
+     "report_date": "2025-10-29",
+     "actual_metrics": [
+      {
+       "metric": "revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q1/income-statements",
+       "actual_value": "$77.7 billion ($77,673 million)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q1/income-statements",
+       "actual_value": "$24,043 million"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q1/income-statements",
+       "actual_value": "$15,669 million (R&D $8,146M + S&M $5,717M + G&A $1,806M)"
+      },
+      {
+       "metric": "diluted EPS (GAAP)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+       "actual_value": "$3.72 (GAAP); $4.13 (non-GAAP)"
+      },
+      {
+       "metric": "operating income",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q1/income-statements",
+       "actual_value": "$37,961 million"
+      }
+     ],
+     "fiscal_quarter": "Q1 FY2026",
+     "guidance_metrics": [
+      {
+       "metric": "Productivity and Business Processes revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+       "guided_range": "$32.2B-$32.5B",
+       "guided_value": "$32.35 billion (midpoint of $32.2B-$32.5B)"
+      },
+      {
+       "metric": "Intelligent Cloud revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+       "guided_range": "$30.1B-$30.4B",
+       "guided_value": "$30.25 billion (midpoint of $30.1B-$30.4B)"
+      },
+      {
+       "metric": "More Personal Computing revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+       "guided_range": "$12.4B-$12.9B",
+       "guided_value": "$12.65 billion (midpoint of $12.4B-$12.9B)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+       "guided_range": "$24.3B-$24.5B",
+       "guided_value": "$24.4 billion (midpoint of $24.3B-$24.5B)"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+       "guided_range": "$15.7B-$15.8B",
+       "guided_value": "$15.75 billion (midpoint of $15.7B-$15.8B)"
+      },
+      {
+       "metric": "other income and expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+       "guided_range": null,
+       "guided_value": "approximately negative $1.3 billion"
+      },
+      {
+       "metric": "effective tax rate",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+       "guided_range": null,
+       "guided_value": "19%-20%"
+      }
+     ]
+    },
+    {
+     "notes": "Microsoft did NOT provide a total-company revenue range for Q4 FY25; guidance was segment-only (constant-currency growth for segments, with the FX impact disclosed separately). The three segment ranges sum to an implied total of ~$73.15B-$74.25B (PBP $32.05-$32.35B + IC $28.75-$29.05B + MPC $12.35-$12.85B). Actual total revenue $76.4B exceeded this implied range; actual segment results were PBP $33.1B, IC $29.9B, MPC $13.5B \u2014 all three beat the high end of their guided ranges. Microsoft does not guide EPS directly. Management also guided Microsoft Cloud gross margin ~67% and reaffirmed full-year FY25 operating margins up slightly year-over-year.",
+     "verdict": "beat",
+     "report_date": "2025-07-30",
+     "actual_metrics": [
+      {
+       "metric": "revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$76.4 billion ($76,441 million)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$24,014 million"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$18,104 million (R&D $8,829M + S&M $7,285M + G&A $1,990M)"
+      },
+      {
+       "metric": "diluted EPS (GAAP)",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$3.65 (GAAP)"
+      },
+      {
+       "metric": "operating income",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$34,323 million"
+      },
+      {
+       "metric": "Productivity and Business Processes revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$33,112 million"
+      },
+      {
+       "metric": "Intelligent Cloud revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$29,878 million"
+      },
+      {
+       "metric": "More Personal Computing revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+       "actual_value": "$13,451 million"
+      }
+     ],
+     "fiscal_quarter": "Q4 FY2025",
+     "guidance_metrics": [
+      {
+       "metric": "Productivity and Business Processes revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+       "guided_range": "$32.05B-$32.35B",
+       "guided_value": "$32.2 billion (midpoint of $32.05B-$32.35B)"
+      },
+      {
+       "metric": "Intelligent Cloud revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+       "guided_range": "$28.75B-$29.05B",
+       "guided_value": "$28.9 billion (midpoint of $28.75B-$29.05B)"
+      },
+      {
+       "metric": "More Personal Computing revenue",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+       "guided_range": "$12.35B-$12.85B",
+       "guided_value": "$12.6 billion (midpoint of $12.35B-$12.85B)"
+      },
+      {
+       "metric": "cost of goods sold (COGS)",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+       "guided_range": "$23.6B-$23.8B",
+       "guided_value": "$23.7 billion (midpoint of $23.6B-$23.8B)"
+      },
+      {
+       "metric": "operating expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+       "guided_range": "$18.0B-$18.1B",
+       "guided_value": "$18.05 billion (midpoint of $18.0B-$18.1B)"
+      },
+      {
+       "metric": "other income and expense",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+       "guided_range": null,
+       "guided_value": "approximately negative $1.2 billion"
+      },
+      {
+       "metric": "effective tax rate",
+       "source_url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+       "guided_range": null,
+       "guided_value": "approximately 19%"
+      }
+     ]
+    }
+   ],
+   "trust": {
+    "claims": [
+     {
+      "path": "$[0].fiscal_quarter",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+        "title": "FY26 Q3 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 April 29, 2026 \u2014 Microsoft Corp. today announced the following results for the quarter ended March 31, 2026"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].report_date",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+        "title": "FY26 Q3 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 April 29, 2026 \u2014 Microsoft Corp. today announced the following results for the quarter ended March 31, 2026"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect revenue of $80.65 to $81.75 billion or growth of 15% to %17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[0].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect revenue of $80.65 to $81.75 billion or growth of 15% to %17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[0].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect revenue of $80.65 to $81.75 billion or growth of 15% to %17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "Now, moving to our Q3 outlook... We expect revenue of $80.65 to $81.75 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.65 to $26.85 billion, or growth of 22% to 23%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[1].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.65 to $26.85 billion, or growth of 22% to 23%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[1].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.65 to $26.85 billion, or growth of 22% to 23%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.65 to $26.85 billion, or growth of 22% to 23%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.8 to $17.9 billion or growth of 10% to 11%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[2].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.8 to $17.9 billion or growth of 10% to 11%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[2].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.8 to $17.9 billion or growth of 10% to 11%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.8 to $17.9 billion or growth of 10% to 11%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "Excluding any impact from our investments in OpenAI, other income and expense is expected to be roughly $700 million"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[3].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "Excluding any impact from our investments in OpenAI, other income and expense is expected to be roughly $700 million"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[3].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "other income and expense is expected to be roughly $700 million"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "Excluding any impact from our investments in OpenAI, other income and expense is expected to be roughly $700 million"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our adjusted Q3 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[4].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our adjusted Q3 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[4].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our adjusted Q3 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].guidance_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our adjusted Q3 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+        "title": "FY26 Q3 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue was $82.9 billion and increased 18%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[0].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Total revenue | 82,886 | 70,066"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+        "title": "FY26 Q3 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 April 29, 2026 \u2014 Microsoft Corp. today announced the following results for the quarter ended March 31, 2026"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 26,828 | 21,919"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[1].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 26,828 | 21,919"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 26,828 | 21,919"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Research and development | 8,915; Sales and marketing | 6,814; General and administrative | 1,931"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[2].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Research and development | 8,915; Sales and marketing | 6,814; General and administrative | 1,931"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Research and development | 8,915; Sales and marketing | 6,814; General and administrative | 1,931"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+        "title": "FY26 Q3 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted earnings per share was $4.27 and increased 23% on a GAAP basis"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[3].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Diluted | $ 4.27 | $ 3.46"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Diluted | $ 4.27 | $ 3.46"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+        "title": "FY26 Q3 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Operating income was $38.4 billion and increased 20%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[4].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Operating income | 38,398 | 32,000"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Operating income | 38,398 | 32,000"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[5].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Gross margin | 56,058 | 48,147"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[5].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Gross margin | 56,058 | 48,147"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].actual_metrics[5].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+        "excerpts": [
+         "Gross margin | 56,058 | 48,147"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].verdict",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q3",
+        "title": "Microsoft Fiscal Year 2026 Third Quarter Earnings ...",
+        "excerpts": [
+         "We delivered results that exceeded expectations across revenue, operating income, and earnings per share driven by strong demand and execution."
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].notes",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $34.25 to $34.55 billion... For Intelligent Cloud, we expect revenue of $34.1 to $34.4 billion... In More Personal Computing, we expect revenue to be $12.3 to $12.8 billion."
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       },
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+        "title": "FY26 Q3 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue in Productivity and Business Processes was $35.0 billion... Revenue in Intelligent Cloud was $34.7 billion... Revenue in More Personal Computing was $13.2 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[0].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Total revenue | 81,273 | 69,632"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+        "title": "FY26 Q2 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue was $81.3 billion and increased 17%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Total revenue | 81,273 | 69,632"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[1].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 25,978 | 21,799"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 25,978 | 21,799"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 25,978 | 21,799"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[2].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Research and development | 8,504; Sales and marketing | 6,584; General and administrative | 1,932"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Research and development | 8,504; Sales and marketing | 6,584; General and administrative | 1,932"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Research and development | 8,504; Sales and marketing | 6,584; General and administrative | 1,932"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[3].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Diluted | $ 5.16 | $ 3.23"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+        "title": "FY26 Q2 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted earnings per share on a GAAP basis was $5.16 and increased 60%, and on a non-GAAP basis was $4.14 and increased 24%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+        "title": "FY26 Q2 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted earnings per share on a GAAP basis was $5.16 and increased 60%, and on a non-GAAP basis was $4.14 and increased 24%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[4].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Operating income | 38,275 | 31,653"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+        "title": "FY26 Q2 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Operating income was $38.3 billion and increased 21%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].actual_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+        "excerpts": [
+         "Operating income | 38,275 | 31,653"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].fiscal_quarter",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+        "title": "FY26 Q2 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 January 28, 2026 \u2014 Microsoft Corp. today announced the following results for the quarter ended December 31, 2025"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[0].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect revenue of $79.5 to $80.6 billion or growth of 14% to 16%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[0].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect revenue of $79.5 to $80.6 billion or growth of 14% to 16%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect revenue of $79.5 to $80.6 billion or growth of 14% to 16%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "Starting with the total company. We expect revenue of $79.5 to $80.6 billion or growth of 14% to 16%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[1].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.35 to $26.55 billion, or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[1].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.35 to $26.55 billion, or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.35 to $26.55 billion, or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $26.35 to $26.55 billion, or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[2].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.3 to $17.4 billion or growth of 7% to 8%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[2].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.3 to $17.4 billion or growth of 7% to 8%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.3 to $17.4 billion or growth of 7% to 8%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $17.3 to $17.4 billion or growth of 7% to 8%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[3].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "in Q2, other income and expense is estimated to be roughly $100 million"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[3].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "in Q2, other income and expense is estimated to be roughly $100 million as interest income will more than offset interest expense"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "On that basis, in Q2, other income and expense is estimated to be roughly $100 million"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "On that basis, in Q2, other income and expense is estimated to be roughly $100 million"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[4].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q2 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[4].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q2 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q2 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].guidance_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q2 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].notes",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+        "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $33.3 to $33.6 billion... For Intelligent Cloud, we expect revenue of $32.25 to $32.55 billion... In More Personal Computing, we expect revenue to be in the $13.95 to $14.45 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       },
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+        "title": "FY26 Q2 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue in Productivity and Business Processes was $34.1 billion... Revenue in Intelligent Cloud was $32.9 billion... Revenue in More Personal Computing was $14.3 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].report_date",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+        "title": "FY26 Q2 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 January 28, 2026 \u2014 Microsoft Corp. today announced the following results for the quarter ended December 31, 2025"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].verdict",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+        "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+        "excerpts": [
+         "we again exceeded expectations across revenue, operating income and earnings per share, while investing to fuel long-term growth."
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[0].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Total revenue | 77,673 | 65,585"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue was $77.7 billion and increased 18%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Total revenue | 77,673 | 65,585"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[1].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 24,043 | 20,099"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 24,043 | 20,099"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Total cost of revenue | 24,043 | 20,099"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[2].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Research and development | 8,146; Sales and marketing | 5,717; General and administrative | 1,806"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Research and development | 8,146; Sales and marketing | 5,717; General and administrative | 1,806"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Research and development | 8,146; Sales and marketing | 5,717; General and administrative | 1,806"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[3].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Diluted | $ 3.72 | $ 3.30"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted earnings per share, on a GAAP basis, was $3.72 and increased 13%, and on a non-GAAP basis was $4.13 and increased 23%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted earnings per share, on a GAAP basis, was $3.72 and increased 13%, and on a non-GAAP basis was $4.13 and increased 23%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[4].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Operating income | 37,961 | 30,552"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Operating income was $38.0 billion and increased 24%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].actual_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+        "excerpts": [
+         "Operating income | 37,961 | 30,552"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].fiscal_quarter",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 October 29, 2025 \u2014 Microsoft Corp. today announced the following results for the quarter ended September 30, 2025"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[0].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.2 to $32.5 billion, or growth of 14% to 15%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[0].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.2 to $32.5 billion, or growth of 14% to 15%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.2 to $32.5 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.2 to $32.5 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[1].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $30.1 to $30.4 billion, or growth of 25% to 26%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[1].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $30.1 to $30.4 billion, or growth of 25% to 26%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $30.1 to $30.4 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $30.1 to $30.4 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[2].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.4 to $12.9 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[2].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.4 to $12.9 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.4 to $12.9 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.4 to $12.9 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[3].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $24.3 to $24.5 billion or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[3].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $24.3 to $24.5 billion or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $24.3 to $24.5 billion or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $24.3 to $24.5 billion or growth of 21% to 22%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[4].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $15.7 to $15.8 billion or growth of 5% to 6%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[4].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $15.7 to $15.8 billion or growth of 5% to 6%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $15.7 to $15.8 billion or growth of 5% to 6%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $15.7 to $15.8 billion or growth of 5% to 6%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[5].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is estimated to be negative $1.3 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[5].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is estimated to be negative $1.3 billion primarily due to investments accounted for under the equity method"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[5].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is estimated to be negative $1.3 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[5].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is estimated to be negative $1.3 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[6].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q1 effective tax rate to be between 19% and 20%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[6].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q1 effective tax rate to be between 19% and 20%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[6].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q1 effective tax rate to be between 19% and 20%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].guidance_metrics[6].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q1 effective tax rate to be between 19% and 20%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].notes",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.2 to $32.5 billion... For Intelligent Cloud we expect revenue of $30.1 to $30.4 billion... In More Personal Computing, we expect revenue to be $12.4 to $12.9 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       },
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue in Productivity and Business Processes was $33.0 billion... Revenue in Intelligent Cloud was $30.9 billion... Revenue in More Personal Computing was $13.8 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].report_date",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 October 29, 2025 \u2014 Microsoft Corp. today announced the following results for the quarter ended September 30, 2025"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].verdict",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+        "title": "FY26 Q1 - Press Releases - Investor Relations",
+        "excerpts": [
+         "We delivered a strong start to the fiscal year, exceeding expectations across revenue, operating income, and earnings per share"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[0].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Total revenue | 76,441 | 64,727"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue was $76.4 billion and increased 18%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 July 30, 2025 \u2014 Microsoft Corp. today announced the following results for the quarter ended June 30, 2025"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[1].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Total cost of revenue | 24,014 | 19,684"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Total cost of revenue | 24,014 | 19,684"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Total cost of revenue | 24,014 | 19,684"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[2].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Research and development | 8,829; Sales and marketing | 7,285; General and administrative | 1,990"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Research and development | 8,829; Sales and marketing | 7,285; General and administrative | 1,990"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Research and development | 8,829; Sales and marketing | 7,285; General and administrative | 1,990"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[3].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted | $3.65 | $2.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted earnings per share was $3.65 and increased 24%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Diluted | $3.65 | $2.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[4].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Operating income | 34,323 | 27,925"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Operating income was $34.3 billion and increased 23%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Operating income | 34,323 | 27,925"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[5].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Productivity and Business Processes | $33,112"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[5].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue in Productivity and Business Processes was $33.1 billion and increased 16%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[5].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Productivity and Business Processes | $33,112"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[6].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Intelligent Cloud | $29,878"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[6].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue in Intelligent Cloud was $29.9 billion and increased 26%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[6].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Intelligent Cloud | $29,878"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[7].actual_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "More Personal Computing | $13,451"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[7].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue in More Personal Computing was $13.5 billion and increased 9%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].actual_metrics[7].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "More Personal Computing | $13,451"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].fiscal_quarter",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 July 30, 2025 \u2014 Microsoft Corp. today announced the following results for the quarter ended June 30, 2025"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[0].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.05 to $32.35 billion, or growth of 11% to 12% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[0].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.05 to $32.35 billion, or growth of 11% to 12% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[0].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.05 to $32.35 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[0].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.05 to $32.35 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[1].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $28.75 to $29.05 billion or growth of 20% to 22% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[1].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $28.75 to $29.05 billion or growth of 20% to 22% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[1].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $28.75 to $29.05 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[1].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "For Intelligent Cloud we expect revenue of $28.75 to $29.05 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[2].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.35 to $12.85 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[2].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.35 to $12.85 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[2].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.35 to $12.85 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[2].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In More Personal Computing, we expect revenue to be $12.35 to $12.85 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[3].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $23.6 to $23.8 billion or growth of 19% to 20% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[3].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $23.6 to $23.8 billion or growth of 19% to 20% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[3].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $23.6 to $23.8 billion or growth of 19% to 20% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[3].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "We expect COGS of $23.6 to $23.8 billion or growth of 19% to 20% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[4].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $18 to $18.1 billion or growth of approximately 5% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[4].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $18 to $18.1 billion or growth of approximately 5% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[4].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $18 to $18.1 billion or growth of approximately 5% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[4].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "operating expense of $18 to $18.1 billion or growth of approximately 5% in constant currency"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[5].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is expected to be roughly negative $1.2 billion primarily driven by investments accounted for under the equity method"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[5].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is expected to be roughly negative $1.2 billion primarily driven by investments accounted for under the equity method"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[5].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is expected to be roughly negative $1.2 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[5].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "Other income and expense is expected to be roughly negative $1.2 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[6].guided_range",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q4 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Information absence is supported by cited evidence",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[6].guided_value",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q4 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[6].metric",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q4 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].guidance_metrics[6].source_url",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "we expect our Q4 effective tax rate to be approximately 19%"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].notes",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+        "excerpts": [
+         "In Productivity and Business Processes we expect revenue of $32.05 to $32.35 billion... For Intelligent Cloud we expect revenue of $28.75 to $29.05 billion... In More Personal Computing, we expect revenue to be $12.35 to $12.85 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       },
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "Revenue in Productivity and Business Processes was $33.1 billion... Revenue in Intelligent Cloud was $29.9 billion... Revenue in More Personal Computing was $13.5 billion"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].report_date",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "excerpts": [
+         "REDMOND, Wash. \u2014 July 30, 2025 \u2014 Microsoft Corp. today announced the following results for the quarter ended June 30, 2025"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].verdict",
+      "citations": [
+       {
+        "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+        "excerpts": [
+         "in our largest quarter of the year, we significantly exceeded expectations with strong execution by our sales and partner teams"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     }
+    ],
+    "sources": [
+     {
+      "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+      "type": "primary",
+      "title": "FY26 Q3 - Press Releases - Investor Relations",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q2",
+      "type": "primary",
+      "title": "Microsoft FY26 Second Quarter Earnings Conference Call",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+      "type": "primary",
+      "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q3/income-statements",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q3",
+      "type": "primary",
+      "title": "Microsoft Fiscal Year 2026 Third Quarter Earnings ...",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+      "type": "primary",
+      "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q2/income-statements",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q2/press-release-webcast",
+      "type": "primary",
+      "title": "FY26 Q2 - Press Releases - Investor Relations",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/events/fy-2026/earnings-fy-2026-q1",
+      "type": "primary",
+      "title": "Microsoft FY26 First Quarter Earnings Conference Call",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+      "type": "primary",
+      "title": "https://www.microsoft.com/en-us/Investor/earnings/fy-2026-q1/income-statements",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/earnings/fy-2026-q1/press-release-webcast",
+      "type": "primary",
+      "title": "FY26 Q1 - Press Releases - Investor Relations",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+      "type": "primary",
+      "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+      "type": "primary",
+      "title": "FY25 Q4 - Press Releases - Investor Relations",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
+      "type": "primary",
+      "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     }
+    ],
+    "reasoning": "High confidence - cells fill rate is 96% and trust per claim ratio is 100%",
+    "confidence": "high"
+   }
+  }
+ }
+}

--- a/apps/earnings-guidance-vs-actuals/ingest.py
+++ b/apps/earnings-guidance-vs-actuals/ingest.py
@@ -142,22 +142,23 @@ def rows_from_file(path):
             continue
         actual_list = [n for n in (norm_obj(m) for m in q.get("actual_metrics") or []) if n and n.get("metric")]
         guidance_list = [n for n in (norm_obj(m) for m in q.get("guidance_metrics") or []) if n and n.get("metric")]
-        actuals = {norm_metric(m["metric"]): m for m in actual_list}
+        actuals = {norm_metric(m["metric"]): (m, mi) for mi, m in enumerate(actual_list)}
         seen_keys = set()
         for gi, g in enumerate(guidance_list):
             key = norm_metric(g["metric"])
-            act = actuals.get(key)
+            act, act_i = actuals.get(key, (None, None))
             if key in seen_keys:  # e.g. quarterly capex + full-year capex in one quarter
                 key = str(g["metric"]).strip().lower()
             seen_keys.add(key)
             low, mid, high = parse_range(g.get("guided_value"), g.get("guided_range"))
-            actual_num = parse_money(act["actual_value"]) if act else None
+            actual_num = parse_money(act.get("actual_value")) if act else None
             verdict = metric_verdict(low, high, actual_num)
             if verdict == "not_guided" and low is not None and actual_num is not None:
                 # scale mismatch (e.g. percent guidance on a dollar metric): the raw
                 # strings keep the record, but numeric columns must not enable bogus math
                 low = mid = high = None
             gpath = f"$[{qi}].guidance_metrics[{gi}].guided_value"
+            apath = f"$[{qi}].actual_metrics[{act_i}].actual_value" if act_i is not None else gpath
             ledger_rows.append({
                 "ticker": d["ticker"], "fiscal_quarter": q["fiscal_quarter"],
                 "report_date": q.get("report_date"), "metric": key, "metric_raw": g["metric"],
@@ -168,7 +169,7 @@ def rows_from_file(path):
                 "metric_verdict": verdict,
                 "quarter_verdict": q.get("verdict"), "notes": q.get("notes"),
                 "guidance_source_url": repaired_url(g.get("source_url"), gpath),
-                "actual_source_url": repaired_url(act.get("source_url"), gpath) if act else None,
+                "actual_source_url": repaired_url(act.get("source_url"), apath) if act else None,
                 "run_id": d["run_id"],
             })
         # keep actuals that had no guidance partner (e.g. total revenue reported

--- a/apps/earnings-guidance-vs-actuals/ingest.py
+++ b/apps/earnings-guidance-vs-actuals/ingest.py
@@ -1,0 +1,266 @@
+"""Ingest raw backfill JSONs into the Snowflake ledger (idempotent MERGEs).
+
+Usage: python ingest.py            # ingest everything in data/raw/
+       python ingest.py NVDA_last4 # specific files
+"""
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+
+import config as C
+from setup_snowflake import connect
+
+DB = None  # set in main from env
+
+MULT = {"k": 1e3, "m": 1e6, "b": 1e9, "t": 1e12,
+        "thousand": 1e3, "million": 1e6, "billion": 1e9, "trillion": 1e12}
+
+
+_YEAR_TOKENS = re.compile(r"\b(?:fy\s*)?(?:19|20)\d{2}\b")
+
+
+def _strip_years(t):
+    """Calendar years in labels ('full-year 2024', 'FY2026') must never parse as values."""
+    return _YEAR_TOKENS.sub(" ", t)
+
+
+def parse_money(text):
+    """'$26.0B', '$45.0 billion', '68.9', '23,5' -> float or None. Deterministic, no LLM."""
+    if not text:
+        return None
+    t = _strip_years(str(text).lower().replace(",", "")).strip()
+    m = re.search(r"(-?\d+(?:\.\d+)?)\s*(?:(k|m|b|t|thousand|million|billion|trillion)\b)?", t)
+    if not m:
+        return None
+    val = float(m.group(1))
+    if m.group(2):
+        val *= MULT[m.group(2)]
+    if "%" in t:
+        return val  # percentages stay as the raw number
+    return val
+
+
+def parse_range(guided_value, guided_range):
+    """Return (low, mid, high) from the guided strings."""
+    src = guided_range or guided_value or ""
+    t = _strip_years(str(src).lower().replace(",", ""))
+    # range dashes ("46.5%-47.5%", "$26.0b–$26.5b") must not read as negative signs
+    t = re.sub(r"(?<=[\d%kmbt])\s*[-–—]\s*(?=\$?\d)", " to ", t)
+    pm = re.search(r"(-?\d+(?:\.\d+)?)\s*(k|m|b|t|thousand|million|billion|trillion)?\s*(?:%|percent)?\s*(?:,)?\s*(?:plus or minus|\+/-|±)\s*(\d+(?:\.\d+)?)\s*%", t)
+    if pm:
+        mid = float(pm.group(1)) * (MULT.get(pm.group(2)) or 1)
+        pct = float(pm.group(3)) / 100
+        return mid * (1 - pct), mid, mid * (1 + pct)
+    nums = re.findall(r"(-?\d+(?:\.\d+)?)\s*(?:(k|m|b|t|thousand|million|billion|trillion)\b)?", t)
+    vals = [float(n) * (MULT.get(u) or 1) for n, u in nums if n]
+    if len(vals) >= 2 and any(sep in t for sep in ("-", "–", " to ")):
+        lo, hi = min(vals[0], vals[1]), max(vals[0], vals[1])
+        return lo, (lo + hi) / 2, hi
+    v = parse_money(guided_value) or (vals[0] if vals else None)
+    return (v, v, v) if v is not None else (None, None, None)
+
+
+def norm_metric(name):
+    n = re.sub(r"\(.*?\)", "", str(name)).strip().lower()
+    n = n.replace("total ", "")
+    return {"revenues": "revenue", "net revenue": "revenue", "sales": "revenue"}.get(n, n)
+
+
+def metric_verdict(low, high, actual):
+    if actual is None or low is None:
+        return "not_guided"
+    # units guard: percent-scale guidance ("+2.5% YoY growth") vs dollar-scale actual
+    # (or vice versa) cannot be graded - magnitudes off by >1000x are a scale mismatch
+    ref = max(abs(low), abs(high or low))
+    if ref > 0 and abs(actual) > 0 and (abs(actual) / ref > 50 or ref / abs(actual) > 50):
+        return "not_guided"
+    if actual > high:
+        return "beat"
+    if actual < low:
+        return "miss"
+    return "inline"
+
+
+def unwrap(v):
+    """Annotated-output form: {'@value': x, '@citation': [...]} -> x."""
+    return v.get("@value") if isinstance(v, dict) and "@value" in v else v
+
+
+def norm_obj(m):
+    """Normalize a metric entry: JSON-encoded strings and @value/@citation wrappers.
+    Returns a plain dict or None if unparseable."""
+    if isinstance(m, str):
+        try:
+            m = json.loads(m)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    if not isinstance(m, dict):
+        return None
+    out, cite_url = {}, None
+    for k, v in m.items():
+        if isinstance(v, dict) and "@value" in v:
+            out[k] = v["@value"]
+            cits = v.get("@citation") or []
+            cite_url = cite_url or next(
+                (c.get("url") for c in cits if str(c.get("url", "")).startswith("https://")), None)
+        else:
+            out[k] = v
+    if cite_url and not str(out.get("source_url", "")).startswith("https://"):
+        out["source_url"] = cite_url
+    return out
+
+
+def rows_from_file(path):
+    d = json.loads(path.read_text())
+    result = d["result"]
+    content = result["output"]["content"]
+    trust = result["output"].get("trust") or {}   # NOTE: trust lives under output
+    claims = trust.get("claims") or []
+
+    # claim lookup by json path -> best citation url + excerpt
+    claim_by_path = {}
+    for cl in claims:
+        cits = cl.get("citations") or []
+        url = next((c.get("url") for c in cits if str(c.get("url", "")).startswith("https://")), None)
+        claim_by_path[cl.get("path", "")] = {
+            "confidence": cl.get("confidence"), "reasoning": cl.get("reasoning"),
+            "url": url, "title": (cits[0].get("title") if cits else None),
+            "excerpt": (cits[0].get("excerpts") or [None])[0] if cits and isinstance(cits[0].get("excerpts"), list) else None,
+        }
+
+    def repaired_url(in_schema_url, path):
+        if str(in_schema_url or "").startswith("https://"):
+            return in_schema_url
+        cl = claim_by_path.get(path)
+        return (cl and cl["url"]) or in_schema_url
+
+    ledger_rows, claim_rows = [], []
+    for qi, q in enumerate(content):
+        if not isinstance(q, dict):
+            continue
+        actual_list = [n for n in (norm_obj(m) for m in q.get("actual_metrics") or []) if n and n.get("metric")]
+        guidance_list = [n for n in (norm_obj(m) for m in q.get("guidance_metrics") or []) if n and n.get("metric")]
+        actuals = {norm_metric(m["metric"]): m for m in actual_list}
+        seen_keys = set()
+        for gi, g in enumerate(guidance_list):
+            key = norm_metric(g["metric"])
+            act = actuals.get(key)
+            if key in seen_keys:  # e.g. quarterly capex + full-year capex in one quarter
+                key = str(g["metric"]).strip().lower()
+            seen_keys.add(key)
+            low, mid, high = parse_range(g.get("guided_value"), g.get("guided_range"))
+            actual_num = parse_money(act["actual_value"]) if act else None
+            verdict = metric_verdict(low, high, actual_num)
+            if verdict == "not_guided" and low is not None and actual_num is not None:
+                # scale mismatch (e.g. percent guidance on a dollar metric): the raw
+                # strings keep the record, but numeric columns must not enable bogus math
+                low = mid = high = None
+            gpath = f"$[{qi}].guidance_metrics[{gi}].guided_value"
+            ledger_rows.append({
+                "ticker": d["ticker"], "fiscal_quarter": q["fiscal_quarter"],
+                "report_date": q.get("report_date"), "metric": key, "metric_raw": g["metric"],
+                "guided_value_raw": g.get("guided_value"), "guided_range_raw": g.get("guided_range"),
+                "guided_low": low, "guided_mid": mid, "guided_high": high,
+                "actual_value_raw": act.get("actual_value") if act else None,
+                "actual_value_num": actual_num,
+                "metric_verdict": verdict,
+                "quarter_verdict": q.get("verdict"), "notes": q.get("notes"),
+                "guidance_source_url": repaired_url(g.get("source_url"), gpath),
+                "actual_source_url": repaired_url(act.get("source_url"), gpath) if act else None,
+                "run_id": d["run_id"],
+            })
+        # keep actuals that had no guidance partner (e.g. total revenue reported
+        # against segment-level guidance) - the headline view pairs them
+        guided_keys = {norm_metric(g["metric"]) for g in guidance_list}
+        for ai, a in enumerate(actual_list):
+            key = norm_metric(a["metric"])
+            if key in guided_keys:
+                continue
+            if key in seen_keys:
+                key = str(a["metric"]).strip().lower()
+            seen_keys.add(key)
+            apath = f"$[{qi}].actual_metrics[{ai}].actual_value"
+            ledger_rows.append({
+                "ticker": d["ticker"], "fiscal_quarter": q["fiscal_quarter"],
+                "report_date": q.get("report_date"), "metric": key, "metric_raw": a["metric"],
+                "guided_value_raw": None, "guided_range_raw": None,
+                "guided_low": None, "guided_mid": None, "guided_high": None,
+                "actual_value_raw": a.get("actual_value"),
+                "actual_value_num": parse_money(a.get("actual_value")),
+                "metric_verdict": "not_guided",
+                "quarter_verdict": q.get("verdict"), "notes": q.get("notes"),
+                "guidance_source_url": None,
+                "actual_source_url": repaired_url(a.get("source_url"), apath),
+                "run_id": d["run_id"],
+            })
+    for cl_path, cl in claim_by_path.items():
+        claim_rows.append({
+            "claim_id": hashlib.md5(f"{d['run_id']}|{cl_path}".encode()).hexdigest(),
+            "run_id": d["run_id"], "ticker": d["ticker"], "json_path": cl_path,
+            "confidence": cl["confidence"], "reasoning": cl["reasoning"],
+            "citation_url": cl["url"], "citation_title": cl["title"], "excerpt": cl["excerpt"],
+        })
+    run_row = {
+        "run_id": d["run_id"], "interaction_id": d.get("interaction_id"),
+        "ticker": d["ticker"], "quarter_window": d["window"], "status": "completed",
+        "effort": "high", "overall_confidence": trust.get("confidence"),
+        "completed_at": datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat(),
+        "wall_clock_s": d.get("wall_clock_s"), "raw_result": json.dumps(result),
+    }
+    return run_row, ledger_rows, claim_rows
+
+
+def merge(cur, table, rows, key_cols):
+    """Batch MERGE: executemany into a temp table, then one MERGE statement."""
+    if not rows:
+        return
+    cols = list(rows[0].keys())
+    tmp = f"TMP_{table}"
+    cur.execute(f"CREATE TEMPORARY TABLE IF NOT EXISTS {DB}.LEDGER.{tmp} LIKE {DB}.LEDGER.{table}")
+    cur.execute(f"TRUNCATE TABLE {DB}.LEDGER.{tmp}")
+    select_cols = ", ".join(
+        f"PARSE_JSON(column{i+1})" if c == "raw_result" else f"column{i+1}"
+        for i, c in enumerate(cols))
+    placeholders = ", ".join(["%s"] * len(cols))
+    cur.executemany(
+        f"INSERT INTO {DB}.LEDGER.{tmp} ({', '.join(cols)}) "
+        f"SELECT {select_cols} FROM VALUES ({placeholders})",
+        [[row[c] for c in cols] for row in rows])
+    on = " AND ".join(f"EQUAL_NULL(t.{k}, s.{k})" for k in key_cols)
+    sets = ", ".join(f"t.{c} = s.{c}" for c in cols if c not in key_cols)
+    cur.execute(f"MERGE INTO {DB}.LEDGER.{table} t USING {DB}.LEDGER.{tmp} s ON {on} "
+                f"WHEN MATCHED THEN UPDATE SET {sets} "
+                f"WHEN NOT MATCHED THEN INSERT ({', '.join(cols)}) "
+                f"VALUES ({', '.join('s.' + c for c in cols)})")
+
+
+def main():
+    global DB
+    import os
+    DB = os.environ.get("SNOWFLAKE_DATABASE", "EARNINGS_DESK")
+    names = sys.argv[1:]
+    files = sorted(C.RAW_DIR.glob("*.json"))
+    if names:
+        files = [f for f in files if f.stem in names]
+    conn = connect()
+    cur = conn.cursor()
+    total_l = total_c = 0
+    for f in files:
+        run_row, ledger_rows, claim_rows = rows_from_file(f)
+        quarters = {r["fiscal_quarter"] for r in ledger_rows}
+        if len(quarters) < 4 or not ledger_rows:
+            print(f"!! {f.stem}: DEGRADED RUN ({len(quarters)} quarters, {len(ledger_rows)} rows) "
+                  f"- delete data/raw/{f.stem}.json and re-run backfill for this chunk")
+        merge(cur, "RUNS", [run_row], ["run_id"])
+        merge(cur, "GUIDANCE_LEDGER", ledger_rows, ["ticker", "fiscal_quarter", "metric"])
+        merge(cur, "CLAIMS", claim_rows, ["claim_id"])
+        total_l += len(ledger_rows); total_c += len(claim_rows)
+        print(f"{f.stem}: {len(ledger_rows)} ledger rows, {len(claim_rows)} claims")
+    conn.commit(); conn.close()
+    print(f"done: {total_l} ledger rows, {total_c} claims across {len(files)} files")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/earnings-guidance-vs-actuals/requirements.txt
+++ b/apps/earnings-guidance-vs-actuals/requirements.txt
@@ -1,0 +1,7 @@
+requests
+python-dotenv
+snowflake-connector-python
+streamlit
+anthropic
+llama-index-core
+llama-index-llms-anthropic

--- a/apps/earnings-guidance-vs-actuals/requirements.txt
+++ b/apps/earnings-guidance-vs-actuals/requirements.txt
@@ -1,6 +1,8 @@
 requests
 python-dotenv
 snowflake-connector-python
+sqlalchemy
+snowflake-sqlalchemy
 streamlit
 anthropic
 llama-index-core

--- a/apps/earnings-guidance-vs-actuals/setup_agent.py
+++ b/apps/earnings-guidance-vs-actuals/setup_agent.py
@@ -1,0 +1,142 @@
+"""Create the Guidance Scorecard Agent (idempotent - reuses agents.json if present)."""
+import json
+
+import requests
+
+import config as C
+
+DOMAIN_EXPERTISE = """# Earnings Guidance vs Actuals — Domain Expertise
+
+You are a sell-side equity research analyst reconstructing a public company's
+guidance-vs-delivery track record from archived public sources.
+
+## Task shape
+Given a ticker and a set of fiscal quarters, produce one row per quarter containing:
+1. What management GUIDED for that quarter — issued on the PRIOR quarter's earnings
+   call or release: revenue, EPS, gross margin, opex, and any segment or full-year
+   outlooks restated at that time.
+2. What the company ACTUALLY reported for that quarter (earnings release / 10-Q / 10-K).
+3. A verdict: beat, miss, inline, or not_guided.
+
+## Where to search
+- Company investor relations press-release archives (outlook/guidance sections).
+- SEC EDGAR: 8-K earnings releases and exhibits, 10-Q, 10-K.
+- Earnings call transcripts: The Motley Fool, Seeking Alpha, company IR.
+- Financial press coverage of guidance: Reuters, CNBC, Bloomberg.
+
+## Rules
+- Guidance for quarter N is issued with quarter N-1 results — attribute it to the
+  correct target quarter.
+- Report guided ranges as strings exactly as stated, e.g. "$26.0B–$26.5B" or
+  "$45.0 billion, plus or minus 2%".
+- Some companies (banks, Tesla) do not issue formal quarterly revenue/EPS guidance —
+  capture whatever forward outlook management DID give (e.g. full-year NII, expense
+  targets, delivery growth) and mark strictly quarterly metrics not_guided.
+- Never invent a number — omit rather than guess. Distinguish "not guided"
+  (management did not guide this metric) from "not found" (guidance may exist but
+  was not located); record which case applies in notes.
+- Every numeric value must be traceable to the cited source_url, and source_url
+  must be the full public https:// URL of the document — never an internal,
+  cached, or relative path.
+- Use the company's own fiscal calendar labels (e.g. NVIDIA Q1 FY2027) plus the
+  calendar report_date (ISO 8601).
+"""
+
+GOALS = [
+    "For every requested quarter, capture the guidance issued with the prior quarter's results for revenue and at least one profitability metric (EPS or gross margin), each with a full public source_url",
+    "Capture the actually reported value for each guided metric from the earnings release, 10-Q, or 10-K, each with a full public source_url",
+    "Score a verdict of exactly beat, miss, inline, or not_guided per quarter, judged on revenue vs the guided range (inline = within the range)",
+    "Never invent numbers - omit rather than guess, and distinguish 'not guided' from 'not found' in notes",
+    "Report guided ranges as strings exactly as stated by management (e.g. '$26.0B-$26.5B')",
+    "For companies without formal quarterly guidance, capture the forward outlook management did give (full-year NII, expense targets, delivery growth) rather than returning empty guidance_metrics",
+]
+
+SOURCES = {
+    "allow": [
+        {"title": "SEC EDGAR", "domains": ["sec.gov", "www.sec.gov", "efts.sec.gov"], "order": 0},
+        {"title": "Company Investor Relations Pages", "domains": [], "order": 1},
+        {"title": "Earnings Call Transcripts", "domains": ["fool.com", "www.fool.com", "seekingalpha.com", "www.seekingalpha.com"], "order": 2},
+        {"title": "Financial Press", "domains": ["reuters.com", "www.reuters.com", "cnbc.com", "www.cnbc.com", "bloomberg.com", "www.bloomberg.com"], "order": 3},
+        {"title": "Financial Data Aggregators", "domains": ["finance.yahoo.com", "macrotrends.net", "www.macrotrends.net"], "order": 4},
+    ],
+    "block": [],
+    "avoid": "forums, message boards, and unsourced blog commentary",
+    "prioritize": "official earnings releases and SEC filings for actuals; earnings call transcripts and IR releases for guidance",
+}
+
+OUTPUT_SCHEMA = {
+    "type": "array",
+    "description": "One row per requested fiscal quarter, most recent first.",
+    "items": {
+        "type": "object",
+        "required": ["fiscal_quarter", "report_date", "guidance_metrics", "actual_metrics", "verdict"],
+        "properties": {
+            "fiscal_quarter": {"type": "string", "description": "Company fiscal label, e.g. 'Q1 FY2027'"},
+            "report_date": {"type": "string", "description": "ISO 8601 calendar date results were reported"},
+            "guidance_metrics": {
+                "type": "array",
+                "description": "Metrics management guided for this quarter (issued with the prior quarter's results)",
+                "items": {
+                    "type": "object",
+                    "required": ["metric", "guided_value", "source_url"],
+                    "properties": {
+                        "metric": {"type": "string", "description": "e.g. revenue, EPS (non-GAAP), gross margin (non-GAAP)"},
+                        "guided_value": {"type": "string", "description": "Point value or range midpoint, as a string"},
+                        "guided_range": {"type": ["string", "null"], "description": "Full range as stated, e.g. '$26.0B-$26.5B'; null if point guidance"},
+                        "source_url": {"type": "string", "description": "Full public https:// URL - never an internal or relative path"},
+                    },
+                    "additionalProperties": True,
+                },
+            },
+            "actual_metrics": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["metric", "actual_value", "source_url"],
+                    "properties": {
+                        "metric": {"type": "string", "description": "Must reuse the exact metric name from guidance_metrics when the same metric"},
+                        "actual_value": {"type": "string"},
+                        "source_url": {"type": "string", "description": "Full public https:// URL - never an internal or relative path"},
+                    },
+                    "additionalProperties": True,
+                },
+            },
+            "verdict": {"type": "string", "enum": ["beat", "miss", "inline", "not_guided"]},
+            "notes": {"type": "string", "description": "Context; must state 'not guided' vs 'not found' where applicable"},
+        },
+        "additionalProperties": True,
+    },
+}
+
+SUGGESTED_QUESTIONS = [
+    "NVDA - guidance vs actuals for the last 4 reported fiscal quarters",
+    "Build the 8-quarter guidance-vs-delivery scorecard for MSFT",
+    "JPM - did management deliver on its NII outlook over the last 4 quarters?",
+    "TSLA quarters 5-8 back - what did management promise and what landed?",
+]
+
+
+def main():
+    if C.AGENTS_FILE.exists():
+        print(f"agents.json exists - reusing {C.agent_id()}")
+        return
+    r = requests.post(f"{C.BASE_URL}/task-agents", headers={"Authorization": f"Bearer {C.NIMBLE_API_KEY}"}, json={
+        "display_name": "Guidance Scorecard Agent",
+        "description": "Reconstructs a public company's guidance-vs-actuals record per fiscal quarter from archived earnings releases, SEC filings, and call transcripts.",
+        "icon": "📊",
+        "use_case": "research",
+        "effort": "high",
+        "domain_expertise": DOMAIN_EXPERTISE,
+        "goals": GOALS,
+        "sources": SOURCES,
+        "output_schema": OUTPUT_SCHEMA,
+        "suggested_questions": SUGGESTED_QUESTIONS,
+    }, timeout=120)
+    r.raise_for_status()
+    agent = r.json()
+    C.AGENTS_FILE.write_text(json.dumps({"scorecard_agent": agent["id"]}, indent=2))
+    print(f"created {agent['id']} -> agents.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/earnings-guidance-vs-actuals/setup_snowflake.py
+++ b/apps/earnings-guidance-vs-actuals/setup_snowflake.py
@@ -130,13 +130,16 @@ DDL = [
 ]
 
 
-def connect():
+def connect(warehouse="__env__"):
+    if warehouse == "__env__":
+        warehouse = os.environ.get("SNOWFLAKE_WAREHOUSE", "EARNINGS_WH")
     kwargs = dict(
         account=os.environ["SNOWFLAKE_ACCOUNT"],
         user=os.environ["SNOWFLAKE_USER"],
-        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE", "COMPUTE_WH"),
         role=os.environ.get("SNOWFLAKE_ROLE") or None,
     )
+    if warehouse:
+        kwargs["warehouse"] = warehouse
     key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
     if key_path:  # key-pair auth (no MFA prompts); path relative to the app dir
         from pathlib import Path
@@ -156,7 +159,7 @@ def connect():
 def main():
     db = os.environ.get("SNOWFLAKE_DATABASE", "EARNINGS_DESK")
     wh = os.environ.get("SNOWFLAKE_WAREHOUSE", "EARNINGS_WH")
-    conn = connect()
+    conn = connect(warehouse=None)  # the warehouse may not exist yet on first run
     cur = conn.cursor()
     cur.execute(f"""CREATE WAREHOUSE IF NOT EXISTS {wh}
         WAREHOUSE_SIZE = XSMALL AUTO_SUSPEND = 60 AUTO_RESUME = TRUE INITIALLY_SUSPENDED = TRUE""")

--- a/apps/earnings-guidance-vs-actuals/setup_snowflake.py
+++ b/apps/earnings-guidance-vs-actuals/setup_snowflake.py
@@ -1,0 +1,172 @@
+"""Create the EARNINGS_DESK database + ledger tables (idempotent)."""
+import os
+
+import snowflake.connector
+
+import config  # noqa: F401  (loads .env)
+
+DDL = [
+    "CREATE DATABASE IF NOT EXISTS {db}",
+    "CREATE SCHEMA IF NOT EXISTS {db}.LEDGER",
+    """CREATE TABLE IF NOT EXISTS {db}.LEDGER.RUNS (
+        run_id STRING PRIMARY KEY,
+        interaction_id STRING,
+        ticker STRING,
+        quarter_window STRING,
+        status STRING,
+        effort STRING,
+        overall_confidence STRING,
+        started_at TIMESTAMP_NTZ,
+        completed_at TIMESTAMP_NTZ,
+        wall_clock_s INTEGER,
+        raw_result VARIANT,
+        ingested_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+    )""",
+    """CREATE TABLE IF NOT EXISTS {db}.LEDGER.GUIDANCE_LEDGER (
+        ticker STRING,
+        fiscal_quarter STRING,
+        report_date DATE,
+        metric STRING,
+        metric_raw STRING,
+        guided_value_raw STRING,
+        guided_range_raw STRING,
+        guided_low FLOAT,
+        guided_mid FLOAT,
+        guided_high FLOAT,
+        actual_value_raw STRING,
+        actual_value_num FLOAT,
+        metric_verdict STRING,
+        quarter_verdict STRING,
+        notes STRING,
+        guidance_source_url STRING,
+        actual_source_url STRING,
+        run_id STRING,
+        ingested_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+        PRIMARY KEY (ticker, fiscal_quarter, metric)
+    )""",
+    """CREATE OR REPLACE VIEW {db}.LEDGER.V_HEADLINE AS
+    WITH rev AS (
+        SELECT ticker, fiscal_quarter, report_date, guided_range_raw, guided_value_raw,
+               actual_value_raw, metric_verdict, 'total revenue' AS basis
+        FROM {db}.LEDGER.GUIDANCE_LEDGER WHERE metric = 'revenue' AND guided_low IS NOT NULL
+    ), rev_actual_only AS (
+        SELECT ticker, fiscal_quarter, report_date, actual_value_raw, actual_value_num
+        FROM {db}.LEDGER.GUIDANCE_LEDGER
+        WHERE metric = 'revenue' AND guided_low IS NULL AND actual_value_num IS NOT NULL
+    ), seg AS (
+        SELECT ticker, fiscal_quarter, report_date,
+               SUM(guided_low) AS glow, SUM(guided_high) AS ghigh,
+               SUM(actual_value_num) AS act,
+               COUNT(*) AS n, COUNT(actual_value_num) AS n_act
+        FROM {db}.LEDGER.GUIDANCE_LEDGER
+        WHERE metric LIKE '%revenue%' AND metric != 'revenue'
+        GROUP BY 1, 2, 3
+    ), main AS (
+    SELECT * FROM rev
+    UNION ALL
+    SELECT s.ticker, s.fiscal_quarter, s.report_date,
+           'segments summed: $' || ROUND(s.glow / 1e9, 1) || 'B-$' || ROUND(s.ghigh / 1e9, 1) || 'B',
+           NULL,
+           '$' || ROUND(s.act / 1e9, 1) || 'B (' || s.n || ' segments)',
+           CASE WHEN s.act > s.ghigh THEN 'beat'
+                WHEN s.act < s.glow THEN 'miss' ELSE 'inline' END,
+           'segment sum (' || s.n || ')'
+    FROM seg s
+    WHERE s.n_act = s.n AND s.glow IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM rev r
+                      WHERE r.ticker = s.ticker AND r.fiscal_quarter = s.fiscal_quarter)
+    UNION ALL
+    SELECT s.ticker, s.fiscal_quarter, s.report_date,
+           'segments guided: $' || ROUND(s.glow / 1e9, 1) || 'B-$' || ROUND(s.ghigh / 1e9, 1) || 'B',
+           NULL,
+           a.actual_value_raw,
+           CASE WHEN a.actual_value_num > s.ghigh THEN 'beat'
+                WHEN a.actual_value_num < s.glow THEN 'miss' ELSE 'inline' END,
+           'segments vs total'
+    FROM seg s
+    JOIN rev_actual_only a
+      ON a.ticker = s.ticker AND a.fiscal_quarter = s.fiscal_quarter
+    WHERE s.glow IS NOT NULL AND s.n_act < s.n
+      AND NOT EXISTS (SELECT 1 FROM rev r
+                      WHERE r.ticker = s.ticker AND r.fiscal_quarter = s.fiscal_quarter)
+    )
+    SELECT * FROM main
+    UNION ALL
+    -- catch-all: any (ticker, quarter) not covered above (outlook-style guiders:
+    -- banks, TSLA, JNJ) — headline = the agent's quarter verdict over the guided outlook
+    SELECT g.ticker, g.fiscal_quarter, MAX(g.report_date),
+           MAX(g.guided_range_raw), MAX(g.guided_value_raw), MAX(g.actual_value_raw),
+           CASE
+             WHEN SUM(IFF(g.metric_verdict = 'beat', 1, 0)) > SUM(IFF(g.metric_verdict = 'miss', 1, 0))
+                  AND SUM(IFF(g.metric_verdict IN ('beat','miss','inline'), 1, 0)) > 0 THEN 'beat'
+             WHEN SUM(IFF(g.metric_verdict = 'miss', 1, 0)) > SUM(IFF(g.metric_verdict = 'beat', 1, 0)) THEN 'miss'
+             WHEN SUM(IFF(g.metric_verdict IN ('beat','miss','inline'), 1, 0)) > 0 THEN 'inline'
+             ELSE 'not_guided'
+           END,
+           'outlook majority (' || SUM(IFF(g.metric_verdict IN ('beat','miss','inline'), 1, 0))
+               || '/' || COUNT(*) || ' graded)'
+    FROM {db}.LEDGER.GUIDANCE_LEDGER g
+    WHERE NOT EXISTS (SELECT 1 FROM main m
+                      WHERE m.ticker = g.ticker AND m.fiscal_quarter = g.fiscal_quarter)
+    GROUP BY g.ticker, g.fiscal_quarter""",
+    """CREATE OR REPLACE VIEW {db}.LEDGER.V_HEADLINE_DEDUP AS
+    SELECT * FROM {db}.LEDGER.V_HEADLINE
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY ticker, report_date
+        ORDER BY CASE WHEN basis LIKE 'total%' THEN 0
+                      WHEN basis LIKE 'segment%' THEN 1 ELSE 2 END) = 1""",
+    """CREATE TABLE IF NOT EXISTS {db}.LEDGER.CLAIMS (
+        claim_id STRING PRIMARY KEY,
+        run_id STRING,
+        ticker STRING,
+        json_path STRING,
+        confidence STRING,
+        reasoning STRING,
+        citation_url STRING,
+        citation_title STRING,
+        excerpt STRING,
+        ingested_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+    )""",
+]
+
+
+def connect():
+    kwargs = dict(
+        account=os.environ["SNOWFLAKE_ACCOUNT"],
+        user=os.environ["SNOWFLAKE_USER"],
+        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE", "COMPUTE_WH"),
+        role=os.environ.get("SNOWFLAKE_ROLE") or None,
+    )
+    key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+    if key_path:  # key-pair auth (no MFA prompts); path relative to the app dir
+        from pathlib import Path
+
+        from cryptography.hazmat.primitives import serialization
+        p = Path(__file__).parent / key_path
+        key = serialization.load_pem_private_key(p.read_bytes(), password=None)
+        kwargs["private_key"] = key.private_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption())
+    else:
+        kwargs["password"] = os.environ["SNOWFLAKE_PASSWORD"]
+    return snowflake.connector.connect(**kwargs)
+
+
+def main():
+    db = os.environ.get("SNOWFLAKE_DATABASE", "EARNINGS_DESK")
+    wh = os.environ.get("SNOWFLAKE_WAREHOUSE", "EARNINGS_WH")
+    conn = connect()
+    cur = conn.cursor()
+    cur.execute(f"""CREATE WAREHOUSE IF NOT EXISTS {wh}
+        WAREHOUSE_SIZE = XSMALL AUTO_SUSPEND = 60 AUTO_RESUME = TRUE INITIALLY_SUSPENDED = TRUE""")
+    cur.execute(f"USE WAREHOUSE {wh}")
+    for stmt in DDL:
+        cur.execute(stmt.format(db=db))
+    cur.execute(f"SELECT COUNT(*) FROM {db}.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='LEDGER'")
+    print(f"connected as {os.environ['SNOWFLAKE_USER']}; {cur.fetchone()[0]} ledger tables ready in {db}")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/earnings-guidance-vs-actuals/slack_post.py
+++ b/apps/earnings-guidance-vs-actuals/slack_post.py
@@ -1,0 +1,56 @@
+"""Post a ticker's scorecard summary to Slack (the 'agents act' layer).
+
+Usage: python slack_post.py NVDA [MSFT ...]   # or no args = all ingested tickers
+"""
+import os
+import sys
+
+import requests
+
+import config  # noqa: F401
+from setup_snowflake import connect
+
+VERDICT_EMOJI = {"beat": "🟢", "miss": "🔴", "inline": "🟡", "not_guided": "⚪"}
+
+
+def scorecard(cur, db, ticker):
+    cur.execute(f"""
+        SELECT fiscal_quarter, basis, guided_range_raw, guided_value_raw,
+               actual_value_raw, metric_verdict
+        FROM {db}.LEDGER.V_HEADLINE_DEDUP
+        WHERE ticker = %s
+        ORDER BY report_date DESC""", (ticker,))
+    return cur.fetchall()
+
+
+def post(ticker, rows, webhook):
+    lines = [f"*{ticker} — guidance vs actuals* (revenue, most recent first)"]
+    for fq, _metric, grange, gval, aval, verdict in rows[:8]:
+        emoji = VERDICT_EMOJI.get(verdict, "⚪")
+        lines.append(f"{emoji} *{fq}*: guided {grange or gval or 'n/a'} → actual {aval or 'n/a'} ({verdict})")
+    beats = sum(1 for r in rows if r[5] == "beat")
+    misses = sum(1 for r in rows if r[5] == "miss")
+    lines.append(f"_Track record: {beats} beats / {misses} misses over {len(rows)} quarters. "
+                 f"Every number cited — full audit trail in the Earnings Desk app._")
+    r = requests.post(webhook, json={"text": "\n".join(lines)}, timeout=30)
+    r.raise_for_status()
+
+
+def main():
+    webhook = os.environ["SLACK_WEBHOOK_URL"]
+    db = os.environ.get("SNOWFLAKE_DATABASE", "EARNINGS_DESK")
+    conn = connect(); cur = conn.cursor()
+    tickers = sys.argv[1:]
+    if not tickers:
+        cur.execute(f"SELECT DISTINCT ticker FROM {db}.LEDGER.GUIDANCE_LEDGER")
+        tickers = [r[0] for r in cur.fetchall()]
+    for t in sorted(tickers):
+        rows = scorecard(cur, db, t)
+        if rows:
+            post(t, rows, webhook)
+            print(f"posted {t} ({len(rows)} quarters)")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/earnings-guidance-vs-actuals/slack_post.py
+++ b/apps/earnings-guidance-vs-actuals/slack_post.py
@@ -37,7 +37,9 @@ def post(ticker, rows, webhook):
 
 
 def main():
-    webhook = os.environ["SLACK_WEBHOOK_URL"]
+    webhook = os.getenv("SLACK_WEBHOOK_URL")
+    if not webhook:
+        raise SystemExit("SLACK_WEBHOOK_URL is not set; configure .env to enable Slack posting.")
     db = os.environ.get("SNOWFLAKE_DATABASE", "EARNINGS_DESK")
     conn = connect(); cur = conn.cursor()
     tickers = sys.argv[1:]

--- a/apps/earnings-guidance-vs-actuals/wsa.py
+++ b/apps/earnings-guidance-vs-actuals/wsa.py
@@ -1,0 +1,65 @@
+"""Thin client for Nimble Web Search Agents runs."""
+import time
+
+import requests
+
+import config as C
+
+H = {"Authorization": f"Bearer {C.NIMBLE_API_KEY}"}
+
+
+class RunFailed(Exception):
+    def __init__(self, msg, payload=None):
+        super().__init__(msg)
+        self.payload = payload
+
+
+def start_run(agent_id, input_text, previous_interaction_id=None):
+    body = {"input": input_text, "effort": "high"}  # never below high (planner bug)
+    if previous_interaction_id:
+        body["previous_interaction_id"] = previous_interaction_id
+    r = requests.post(f"{C.BASE_URL}/task-agents/{agent_id}/runs", json=body, headers=H, timeout=120)
+    r.raise_for_status()
+    return r.json()
+
+
+def poll_run(agent_id, run_id):
+    r = requests.get(f"{C.BASE_URL}/task-agents/{agent_id}/runs/{run_id}", headers=H, timeout=60)
+    r.raise_for_status()
+    return r.json()
+
+
+def fetch_result(agent_id, run_id):
+    r = requests.get(f"{C.BASE_URL}/task-agents/{agent_id}/runs/{run_id}/result", headers=H, timeout=120)
+    if r.status_code == 408:
+        return None
+    r.raise_for_status()
+    return r.json()
+
+
+def wait_for_result(agent_id, run_id, on_tick=None, poll_seconds=20, timeout_seconds=1500):
+    t0 = time.time()
+    while True:
+        run = poll_run(agent_id, run_id)
+        elapsed = int(time.time() - t0)
+        if on_tick:
+            on_tick(elapsed, run["status"])
+        if not run["is_active"]:
+            break
+        if elapsed > timeout_seconds:
+            raise RunFailed(f"run {run_id} timed out after {elapsed}s")
+        time.sleep(poll_seconds)
+
+    # the result endpoint can still 408 briefly after the run turns terminal
+    result = fetch_result(agent_id, run_id)
+    for _ in range(5):
+        if result is not None:
+            break
+        time.sleep(15)
+        result = fetch_result(agent_id, run_id)
+    if run["status"] != "completed":
+        msg = (run.get("error") or {}).get("message") or run["status"]
+        raise RunFailed(f"run {run['status']}: {msg}", payload=result)
+    if result is None:
+        raise RunFailed(f"run {run_id} completed but the result never became available")
+    return result, run


### PR DESCRIPTION
Ticker watchlist in → audit-grade guidance-vs-delivery scorecard out. Built on Nimble Web Search Agents (research use case, per-claim trust) + Snowflake ledger + LlamaIndex NL→SQL + Slack actions + Streamlit.

- One production agent (sell-side-analyst persona), 24-run resumable backfill builds 8 quarters × 12 tickers on day one
- Deterministic app-side grading (beat/miss/inline) with scale-mismatch refusal; agent verdicts stored as cross-check
- 3-table ledger + headline views covering every guidance style (formal ranges / segment guidance / outlook-only)
- ai-setup.md tested literally in a clean directory; carries the corporate-Snowflake setup gotchas (account-id format, MFA→key-pair, roles, warehouse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)