### PR TITLE
Add Assortment Gap Finder app

### DIFF
--- a/apps/assortment-gap-finder/.env.example
+++ b/apps/assortment-gap-finder/.env.example
@@ -1,0 +1,18 @@
+# Nimble Web Search Agents
+NIMBLE_API_KEY=your_nimble_api_key
+
+# Databricks (Free Edition works; company workspace needs a catalog you can create schemas in)
+DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
+DATABRICKS_TOKEN=your_personal_access_token       # Settings > Developer > Access tokens
+DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/your_id  # SQL Warehouses > warehouse > Connection details
+DATABRICKS_CATALOG=main                            # Unity Catalog name the app may create a schema in
+
+# Linear - verified gaps get filed as issues
+LINEAR_API_KEY=lin_api_your_key                   # Settings > Security & access > Personal API keys
+LINEAR_TEAM_KEY=GAP                               # the team's issue prefix; pick a clean one
+
+# Anthropic - powers the gap-synthesis agent loop
+ANTHROPIC_API_KEY=
+
+# true = live agent runs; false = replay cached data
+USE_LIVE=true

--- a/apps/assortment-gap-finder/.gitignore
+++ b/apps/assortment-gap-finder/.gitignore
@@ -1,0 +1,5 @@
+.env
+.venv/
+__pycache__/
+agents.json
+data/raw/

--- a/apps/assortment-gap-finder/.streamlit/config.toml
+++ b/apps/assortment-gap-finder/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[theme]
+base = "dark"
+primaryColor = "#edc602"

--- a/apps/assortment-gap-finder/README.md
+++ b/apps/assortment-gap-finder/README.md
@@ -1,0 +1,93 @@
+# assortment-gap-finder — Assortment Gap Finder
+
+Retail category in, verified assortment gaps out — filed as Linear tickets a merchandiser can act on. Three research agents built on [Nimble](https://nimbleway.com) Web Search Agents discover the full catalog of a category (300+ SKUs), mine customer reviews for verbatim complaint themes, and verify every hypothesized gap against a retailer's live shelf before anything gets filed. The catalog lives in Databricks Delta tables; a Claude agent loop owns the judgment.
+
+![Built with Nimble + Databricks](https://img.shields.io/badge/Built%20with-Nimble%20%2B%20Databricks-edc602)
+
+## What it does
+
+1. **Discover** — a dataset_building agent enumerates the category on a retailer, chunked by subcategory (6 runs → 300+ distinct SKUs after dedup); a hard source whitelist keeps every run on-shelf
+2. **Map whitespace** — pure SQL over the catalog: a subcategory × price-band grid exposing empty cells (assortment gaps) and cells where nothing is well-rated (quality gaps) — zero API calls
+3. **Mine demand** — an enrichment agent reads customer reviews for the top products around flagged cells and returns recurring complaint/praise themes with verbatim quotes and review-page URLs
+4. **Synthesize & verify** — a Claude agent loop (OpenAI Agent SDK + LiteLLM) proposes gap hypotheses where the math and the complaints agree, then a max-effort research agent searches the retailer's live shelf for counterexamples: one in-stock counterexample refutes the gap
+5. **Act** — confirmed and partial gaps are filed as Linear issues with the demand quotes, the live-shelf evidence, and the closest existing products
+6. **Learn** — merchandising rules taught in the UI PATCH the verifier agent permanently and steer the synthesis loop
+
+## Stack
+
+- [Nimble Web Search Agents](https://nimbleway.com) — three agents: catalog discovery (dataset_building), review mining (enrichment), whitespace verification (research)
+- [Databricks](https://databricks.com) — Delta tables for the catalog, themes, gaps, and run checkpoints
+- [OpenAI Agent SDK](https://github.com/openai/openai-agents-python) + [LiteLLM](https://litellm.ai) — the synthesis loop, running [Claude](https://anthropic.com)
+- [Linear](https://linear.app) — where verified gaps land as tickets
+- [Streamlit](https://streamlit.io) — catalog, gap board, customer evidence, teach page
+
+## Setup
+
+```bash
+git clone https://github.com/Nimbleway/cookbook
+cd cookbook/apps/assortment-gap-finder
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env   # then fill in keys
+```
+
+Keys you need: `NIMBLE_API_KEY` ([nimbleway.com](https://nimbleway.com)), Databricks host + personal access token + SQL warehouse HTTP path, a Linear API key + team key, and `ANTHROPIC_API_KEY`. See `.env.example` comments for where each lives.
+
+Then, in order:
+
+```bash
+python setup_agents.py   # creates the 3 Web Search Agents (once; ids in agents.json)
+python delta.py          # creates the Delta schema + 5 tables (idempotent)
+python discover.py       # 6 discovery runs, ~50 min, resumable -> 300+ SKU catalog
+python gaps.py           # whitespace report (instant, no API calls)
+python mine.py           # review mining on flagged cells, ~15-25 min
+python synth.py          # the agent loop: verify gaps live + file Linear tickets, ~30-60 min
+streamlit run app.py
+```
+
+## Usage
+
+Open the app → **Catalog & whitespace** shows the SKU table and the gap grid. **Customer evidence** shows the verbatim complaints behind each flagged cell. **Gap board** shows every verdict — confirmed/partial gaps link to their Linear tickets; refuted hypotheses show the counterexample that killed them. **Teach the analyst** adds a merchandising rule that permanently updates the verifier agent.
+
+To point it at a different category, change `CATEGORY` and `CHUNKS` in `config.py` and rerun the pipeline.
+
+## Project structure
+
+```
+├── config.py          # category, chunk matrix, price bands, env
+├── setup_agents.py    # creates the 3 agents (full smoke-validated configs inline)
+├── wsa.py             # Web Search Agents client (poll + 408-retry + per-run source overrides)
+├── delta.py           # Databricks connection, schema DDL, insert/query helpers
+├── discover.py        # chunked catalog discovery: resumable, deduped by canonical product id
+├── gaps.py            # whitespace math over the catalog (SQL only)
+├── mine.py            # targeted review mining for flagged cells
+├── synth.py           # Claude agent loop: synthesize -> verify live -> file tickets
+├── linear_client.py   # Linear GraphQL: issue creation with full evidence body
+├── app.py             # Streamlit UI (5 pages)
+└── data/sample_run/   # verbatim agent results: one discovery chunk + one live verification
+```
+
+## Output
+
+`<catalog>.assortment_gap_finder` Delta tables:
+
+| table | contents |
+|---|---|
+| `catalog` | one row per distinct SKU: name, brand, subcategory, parsed price/rating/reviews + verbatim strings, URLs, provenance |
+| `review_themes` | one row per (product, theme): kind, theme, verbatim quote, review-page URL |
+| `gaps` | one row per verified hypothesis: statement, verdict, demand evidence, live-shelf evidence, closest matches, Linear issue id/URL, interaction id |
+| `discovery_runs` | run checkpoints (the resumable loop reads this) |
+| `merch_rules` | taught rules, timestamped |
+
+## Going further
+
+- **Multi-retailer discovery** — the discovery agent takes per-run source overrides; add Walmart/Target chunks to `config.CHUNKS` with their own whitelists
+- **Follow-up questions** — each gap stores its verification `interaction_id`; run follow-ups on the verifier agent with `previous_interaction_id` to interrogate a verdict
+- **Different category** — the agents are category-agnostic; only `config.py` changes
+
+## Notes
+
+- Verification is deliberately adversarial: the verifier is instructed that a single in-stock counterexample refutes a gap, and to distinguish "not found after thorough search" from "confirmed absent"
+- Dataset_building runs occasionally fail with "array output is empty" — the discovery loop retries; rerunning `discover.py` skips completed chunks
+- `litellm[proxy]` is required even though the app never runs a proxy: LiteLLM's tool-calling path imports proxy modules it does not declare
+- Databricks returns lowercase column names (Snowflake uppercases) — the app normalizes to uppercase internally

--- a/apps/assortment-gap-finder/ai-setup.md
+++ b/apps/assortment-gap-finder/ai-setup.md
@@ -1,0 +1,125 @@
+# AI Setup — Assortment Gap Finder
+
+You are helping the user set up and run Assortment Gap Finder: a Nimble Web Search Agents app that builds a 300+ SKU retail catalog in Databricks, finds assortment gaps where catalog math and customer complaints agree, verifies each gap against a retailer's live shelf, and files the survivors as Linear tickets. Follow these steps in order. Check each prerequisite before proceeding. Tell the user what you're doing at each step.
+
+---
+
+## Step 1 — Check prerequisites
+
+```bash
+python3 --version    # need 3.10+
+git --version
+```
+
+Account-level prerequisites — confirm with the user:
+- **Nimble API key** (nimbleway.com) — powers all three research agents.
+- **Databricks workspace** — Free Edition works; on a company workspace the user needs a Unity Catalog they can create schemas in.
+- **Linear workspace** — free plan works. Suggest a dedicated team so demo tickets stay contained, and a clean team key (the issue prefix, e.g. GAP).
+- **Anthropic API key** — drives the synthesis agent loop.
+
+---
+
+## Step 2 — Clone the repo
+
+```bash
+if [ -d cookbook ]; then cd cookbook && git pull; else git clone https://github.com/Nimbleway/cookbook && cd cookbook; fi
+cd apps/assortment-gap-finder
+```
+
+---
+
+## Step 3 — Install dependencies
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+2–3 minutes; `databricks-sql-connector` and `litellm[proxy]` are the heavy ones. (`litellm[proxy]` looks odd but is required: LiteLLM's tool-calling path imports proxy modules it does not declare.)
+
+---
+
+## Step 4 — Get credentials
+
+For each, tell the user where it lives and what it does in this app:
+
+1. **NIMBLE_API_KEY** — "All three agents run on this: catalog discovery, review mining, live-shelf verification." From the Nimble dashboard.
+2. **Databricks** — "The catalog, quotes, and verdicts live in Delta tables."
+   - `DATABRICKS_HOST`: the workspace URL up through `.databricks.com`.
+   - `DATABRICKS_TOKEN`: avatar → Settings → Developer → Access tokens → Generate.
+   - `DATABRICKS_HTTP_PATH`: SQL Warehouses → pick one → Connection details → HTTP path.
+   - `DATABRICKS_CATALOG`: a Unity Catalog the user can create a schema in (`main` on fresh workspaces).
+3. **Linear** — "Verified gaps get filed here as tickets - the agent acts, not just reports."
+   - `LINEAR_API_KEY`: Settings → Security & access → Personal API keys.
+   - `LINEAR_TEAM_KEY`: the team's issue prefix (Settings → Teams → Identifier). Warn the user: Linear auto-generates keys from the team name and the result can be unfortunate - have them pick the identifier deliberately (e.g. GAP).
+4. **ANTHROPIC_API_KEY** — "Claude runs the synthesis loop: proposing gaps, deciding what to verify, filing tickets." From console.anthropic.com.
+
+---
+
+## Step 5 — Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Fill every line; show the user the file and confirm before continuing.
+
+---
+
+## Step 6 — Create the agents and the tables
+
+```bash
+python setup_agents.py   # ~10s; creates 3 agents, ids saved to agents.json
+python delta.py          # ~30s; creates the schema + 5 Delta tables
+```
+
+Ask the user to confirm both ran clean. Both are idempotent.
+
+---
+
+## Step 7 — Build the catalog
+
+```bash
+python discover.py
+```
+
+6 chunked discovery runs, 3 concurrent, **~50 minutes**, resumable (rerun skips completed chunks; a failed chunk retries automatically). Success = the final line reports 300+ distinct SKUs. Then:
+
+```bash
+python gaps.py           # instant: the whitespace grid + flagged candidate cells
+```
+
+---
+
+## Step 8 — Mine demand and run the synthesis loop
+
+```bash
+python mine.py           # ~15-25 min: verbatim review quotes for flagged cells
+python synth.py          # ~30-60 min: Claude proposes gaps, verifies each on a live shelf, files tickets
+```
+
+`synth.py` prints a final summary table: hypotheses, verdicts, filed ticket ids. Refuted hypotheses are normal and good — they mean the verifier found real counterexamples. Expect 2–4 filed tickets.
+
+---
+
+## Step 9 — Launch and orient the user
+
+```bash
+streamlit run app.py
+```
+
+Walk them through, in this order (it's the narrative arc):
+1. **Catalog & whitespace** — 300+ SKUs and the gap grid
+2. **Customer evidence** — verbatim complaints grouped by flagged cell
+3. **Gap board** — verdicts with evidence and Linear ticket links
+4. **Their Linear team** — open a filed ticket; the full evidence body is in it
+5. **Teach the analyst** — add a rule (e.g. "always name a capacity in gap statements"); it PATCHes the verifier agent permanently
+
+---
+
+## Notes
+
+- Live runs vary: chunk yields and verdicts differ run to run; the deterministic parts (dedup, whitespace math) do not
+- Delta writes go through parameterized inserts; the app normalizes Databricks' lowercase column names internally
+- Cost: full pipeline ≈ 14 agent runs (6 discovery, 2-3 mining, ~5 verification)
+- If a discovery chunk fails twice with "array output is empty", split it by price band in `config.CHUNKS` (e.g. "espresso machines under $150" / "over $150")

--- a/apps/assortment-gap-finder/app.py
+++ b/apps/assortment-gap-finder/app.py
@@ -1,0 +1,161 @@
+"""Assortment Gap Finder — Streamlit UI over the Delta catalog."""
+import json
+import os
+
+import pandas as pd
+import requests
+import streamlit as st
+
+import config as C
+import delta
+import gaps as gaps_mod
+
+st.set_page_config(page_title="Assortment Gap Finder", page_icon="🧭", layout="wide")
+
+
+@st.cache_data(ttl=300)
+def q(sql, params=None):
+    cols, rows = delta.query(sql, params)
+    # Databricks returns lowercase column names; normalize like Snowflake for consistency
+    return pd.DataFrame(rows, columns=[c.upper() for c in cols])
+
+
+def page_catalog():
+    st.title("🧭 Assortment Gap Finder")
+    st.caption(f"The digital shelf for {C.CATEGORY}: full catalog, whitespace math, "
+               "verified gaps. Built on Nimble Web Search Agents.")
+    stats = q(f"""SELECT COUNT(*) AS skus, COUNT(DISTINCT brand) AS brands,
+                  ROUND(AVG(rating),2) AS avg_rating
+                  FROM {C.DBX_SCHEMA}.catalog""")
+    if stats.empty or not stats.iloc[0]["SKUS"]:
+        st.info("Catalog is empty — run discover.py first.")
+        return
+    c1, c2, c3 = st.columns(3)
+    c1.metric("SKUs", int(stats.iloc[0]["SKUS"]))
+    c2.metric("Brands", int(stats.iloc[0]["BRANDS"]))
+    c3.metric("Avg rating", stats.iloc[0]["AVG_RATING"])
+
+    st.markdown("#### Whitespace grid (products / rated 4.2+)")
+    grid = q(f"""SELECT {gaps_mod.normalize_subcat_sql()} AS subcat, {gaps_mod.BAND_SQL} AS band,
+                 COUNT(*) AS n, SUM(CASE WHEN rating >= 4.2 THEN 1 ELSE 0 END) AS wr
+                 FROM {C.DBX_SCHEMA}.catalog WHERE price_usd IS NOT NULL GROUP BY 1, 2""")
+    if not grid.empty:
+        pivot = grid.assign(CELL=grid["N"].astype(str) + " / " + grid["WR"].astype(str)) \
+                    .pivot_table(index="SUBCAT", columns="BAND", values="CELL", aggfunc="first")
+        band_order = [b for _, _, b in C.PRICE_BANDS if b in pivot.columns]
+        st.dataframe(pivot[band_order], use_container_width=True)
+
+    st.markdown("#### Catalog")
+    df = q(f"""SELECT product_name, brand, subcategory, price_raw AS price, rating_raw AS rating,
+               review_count_raw AS reviews, product_url
+               FROM {C.DBX_SCHEMA}.catalog ORDER BY review_count DESC NULLS LAST""")
+    st.dataframe(df, use_container_width=True, height=420,
+                 column_config={"PRODUCT_URL": st.column_config.LinkColumn()})
+
+
+def page_gaps():
+    st.title("🎯 Gap board")
+    df = q(f"""SELECT gap_statement, verdict, demand_evidence, evidence_summary,
+               closest_matches, linear_issue_id, linear_issue_url, created_at
+               FROM {C.DBX_SCHEMA}.gaps ORDER BY created_at DESC""")
+    if df.empty:
+        st.info("No gaps yet — run synth.py after discovery + mining.")
+        return
+    icon = {"confirmed": "🟢", "partial": "🟡", "refuted": "🔴"}
+    for _, r in df.iterrows():
+        with st.expander(f"{icon.get(r['VERDICT'], '⚪')} {r['GAP_STATEMENT']}", expanded=False):
+            if r["LINEAR_ISSUE_URL"]:
+                st.markdown(f"**Ticket:** [{r['LINEAR_ISSUE_ID']}]({r['LINEAR_ISSUE_URL']})")
+            st.markdown(f"**Customer demand:** {r['DEMAND_EVIDENCE']}")
+            st.markdown(f"**Live-shelf verification:** {r['EVIDENCE_SUMMARY']}")
+            try:
+                for m in json.loads(r["CLOSEST_MATCHES"] or "[]")[:5]:
+                    st.caption(f"closest: {m.get('product_name')} — {m.get('price_usd')} — "
+                               f"{m.get('why_close_but_not_matching') or ''} {m.get('product_url')}")
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+
+def page_evidence():
+    st.title("🗣 Customer evidence")
+    st.caption("Why these products: the whitespace math flagged thin or badly-rated cells in the "
+               "catalog. These are the MOST-REVIEWED products in and around those cells — their "
+               "reviews are the customer-demand evidence behind each gap hypothesis. Every quote "
+               "is verbatim from a real review; the synthesis agent only proposed gaps where "
+               "these complaints and the catalog math pointed the same way.")
+    df = q(f"""SELECT t.product_name, t.kind, t.theme, t.quote, t.quote_source_url,
+               {gaps_mod.normalize_subcat_sql().replace('subcategory', 'c.subcategory').replace('chunk_id', 'c.chunk_id')} AS subcat,
+               CASE WHEN c.price_usd < 50 THEN '<$50' WHEN c.price_usd < 150 THEN '$50-150'
+                    WHEN c.price_usd < 400 THEN '$150-400' ELSE '$400+' END AS band
+               FROM {C.DBX_SCHEMA}.review_themes t
+               LEFT JOIN {C.DBX_SCHEMA}.catalog c ON c.sku_key = t.sku_key
+               WHERE t.found = true ORDER BY subcat, t.product_name, t.kind""")
+    if df.empty:
+        st.info("No mined themes yet — run mine.py.")
+        return
+    cand = {c["subcat"]: c for c in gaps_mod.candidate_cells()}
+    for subcat in df["SUBCAT"].dropna().unique():
+        block = df[df["SUBCAT"] == subcat]
+        c = cand.get(subcat)
+        header = f"#### {subcat}"
+        if c:
+            header += f" — flagged cell: {c['band']} ({c['kind']}: {c['detail']})"
+        st.markdown(header)
+        for name in block["PRODUCT_NAME"].unique():
+            sub = block[block["PRODUCT_NAME"] == name]
+            band = sub["BAND"].iloc[0]
+            with st.expander(f"{name}  ·  {band or ''}"):
+                for _, r in sub.iterrows():
+                    badge = "🔴" if r["KIND"] == "complaint" else "🟢"
+                    st.markdown(f"{badge} **{r['THEME']}** — \"{r['QUOTE']}\"")
+                    if r["QUOTE_SOURCE_URL"]:
+                        st.caption(r["QUOTE_SOURCE_URL"])
+
+
+def page_teach():
+    st.title("🎓 Teach the analyst")
+    st.caption("Merchandising rules PATCH the whitespace-verifier agent permanently and "
+               "steer the synthesis loop — the self-learning layer, audited below.")
+    rule = st.text_area("New merchandising rule",
+                        placeholder="Treat sub-$100 espresso as a distinct segment; never propose gaps without a rating threshold.")
+    if st.button("Teach", type="primary") and rule:
+        agent_id = C.agent_id("whitespace_verifier")
+        H = {"Authorization": f"Bearer {C.NIMBLE_API_KEY}"}
+        cur_agent = requests.get(f"{C.BASE_URL}/task-agents/{agent_id}", headers=H, timeout=60).json()
+        updated = cur_agent["domain_expertise"].rstrip() + f"\n- {rule.strip()}"
+        r = requests.patch(f"{C.BASE_URL}/task-agents/{agent_id}",
+                           headers={**H, "Content-Type": "application/json-patch+json"},
+                           data=json.dumps([{"op": "replace", "path": "/domain_expertise",
+                                             "value": updated}]), timeout=60)
+        r.raise_for_status()
+        from datetime import datetime, timezone
+        delta.insert_rows("merch_rules", [{"rule": rule.strip(),
+                                           "taught_at": datetime.now(timezone.utc)}])
+        st.success("The analyst learned it — the rule is now part of the verifier agent.")
+    rules = q(f"SELECT rule, taught_at FROM {C.DBX_SCHEMA}.merch_rules ORDER BY taught_at DESC")
+    if not rules.empty:
+        st.markdown("#### What the analyst has learned")
+        for _, r in rules.iterrows():
+            st.markdown(f"- **{r['RULE']}**")
+            st.caption(str(r["TAUGHT_AT"]))
+
+
+def page_ops():
+    st.title("⚙️ Runs")
+    df = q(f"""SELECT chunk_id, run_id, status, item_count, wall_clock_s, completed_at
+               FROM {C.DBX_SCHEMA}.discovery_runs ORDER BY completed_at DESC""")
+    st.dataframe(df, use_container_width=True)
+
+
+PAGES = {"Catalog & whitespace": page_catalog, "Gap board": page_gaps,
+         "Customer evidence": page_evidence, "Teach the analyst": page_teach, "Runs": page_ops}
+with st.sidebar:
+    st.markdown("## Assortment Gap Finder")
+    st.caption("Nimble Web Search Agents")
+    page = st.radio("Navigate", list(PAGES), label_visibility="collapsed")
+    st.markdown("---")
+    if st.button("🔄 Refresh data"):
+        q.clear()
+        st.rerun()
+    st.caption(f"Mode: {'LIVE' if C.USE_LIVE else 'REPLAY'}")
+PAGES[page]()

--- a/apps/assortment-gap-finder/app.py
+++ b/apps/assortment-gap-finder/app.py
@@ -119,19 +119,25 @@ def page_teach():
     rule = st.text_area("New merchandising rule",
                         placeholder="Treat sub-$100 espresso as a distinct segment; never propose gaps without a rating threshold.")
     if st.button("Teach", type="primary") and rule:
-        agent_id = C.agent_id("whitespace_verifier")
-        H = {"Authorization": f"Bearer {C.NIMBLE_API_KEY}"}
-        cur_agent = requests.get(f"{C.BASE_URL}/task-agents/{agent_id}", headers=H, timeout=60).json()
-        updated = cur_agent["domain_expertise"].rstrip() + f"\n- {rule.strip()}"
-        r = requests.patch(f"{C.BASE_URL}/task-agents/{agent_id}",
-                           headers={**H, "Content-Type": "application/json-patch+json"},
-                           data=json.dumps([{"op": "replace", "path": "/domain_expertise",
-                                             "value": updated}]), timeout=60)
-        r.raise_for_status()
-        from datetime import datetime, timezone
-        delta.insert_rows("merch_rules", [{"rule": rule.strip(),
-                                           "taught_at": datetime.now(timezone.utc)}])
-        st.success("The analyst learned it — the rule is now part of the verifier agent.")
+        import logging
+        try:
+            agent_id = C.agent_id("whitespace_verifier")
+            H = {"Authorization": f"Bearer {C.NIMBLE_API_KEY}"}
+            resp = requests.get(f"{C.BASE_URL}/task-agents/{agent_id}", headers=H, timeout=60)
+            resp.raise_for_status()
+            updated = resp.json()["domain_expertise"].rstrip() + f"\n- {rule.strip()}"
+            r = requests.patch(f"{C.BASE_URL}/task-agents/{agent_id}",
+                               headers={**H, "Content-Type": "application/json-patch+json"},
+                               data=json.dumps([{"op": "replace", "path": "/domain_expertise",
+                                                 "value": updated}]), timeout=60)
+            r.raise_for_status()
+            from datetime import datetime, timezone
+            delta.insert_rows("merch_rules", [{"rule": rule.strip(),
+                                               "taught_at": datetime.now(timezone.utc)}])
+            st.success("The analyst learned it — the rule is now part of the verifier agent.")
+        except Exception as e:
+            logging.exception("teach failed")
+            st.error(f"Teaching failed ({type(e).__name__}) - the agent was not updated; see app logs.")
     rules = q(f"SELECT rule, taught_at FROM {C.DBX_SCHEMA}.merch_rules ORDER BY taught_at DESC")
     if not rules.empty:
         st.markdown("#### What the analyst has learned")

--- a/apps/assortment-gap-finder/config.py
+++ b/apps/assortment-gap-finder/config.py
@@ -44,6 +44,8 @@ DBX_HOST = os.getenv("DATABRICKS_HOST", "").replace("https://", "")
 DBX_HTTP_PATH = os.getenv("DATABRICKS_HTTP_PATH", "")
 DBX_TOKEN = os.getenv("DATABRICKS_TOKEN", "")
 DBX_CATALOG = os.getenv("DATABRICKS_CATALOG", "main")
+if not __import__("re").match(r"^[A-Za-z0-9_]+$", DBX_CATALOG):
+    raise ValueError(f"DATABRICKS_CATALOG must be a plain identifier, got: {DBX_CATALOG!r}")
 DBX_SCHEMA = f"{DBX_CATALOG}.assortment_gap_finder"
 
 

--- a/apps/assortment-gap-finder/config.py
+++ b/apps/assortment-gap-finder/config.py
@@ -1,0 +1,51 @@
+"""Shared config for Assortment Gap Finder."""
+import json
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+APP_DIR = Path(__file__).parent
+load_dotenv(APP_DIR / ".env")
+
+BASE_URL = "https://sdk.nimbleway.com/v1"
+NIMBLE_API_KEY = os.getenv("NIMBLE_API_KEY", "")
+USE_LIVE = os.getenv("USE_LIVE", "true").lower() == "true"
+
+RAW_DIR = APP_DIR / "data" / "raw"
+RAW_DIR.mkdir(parents=True, exist_ok=True)
+SAMPLE_DIR = APP_DIR / "data" / "sample_run"
+AGENTS_FILE = APP_DIR / "agents.json"
+
+CATEGORY = "coffee makers"
+
+# Gate-1 simplified: Amazon-only discovery, 6 subcategory chunks -> 300+ SKUs after dedup.
+# Walmart/Target participate at the verification stage (live-shelf counterexample search).
+CHUNKS = [
+    ("amz-drip", "drip coffee makers", 50),
+    ("amz-espresso", "espresso machines", 50),
+    ("amz-single-serve", "single-serve and pod coffee makers", 50),
+    ("amz-specialty", "french press, pour-over, and moka pot coffee makers", 40),
+    ("amz-cold-brew", "cold brew and iced coffee makers", 40),
+    ("amz-combo", "grind-and-brew combo machines and dual coffee makers", 40),
+]
+
+AMAZON_SOURCES = {
+    "allow": [{"title": "Amazon", "domains": ["amazon.com", "www.amazon.com"], "order": 0}],
+    "block": [],
+    "avoid": "third-party price aggregators and review blogs",
+    "prioritize": "retailer category browse pages, search results, and best-seller lists",
+}
+
+PRICE_BANDS = [(0, 50, "<$50"), (50, 150, "$50-150"), (150, 400, "$150-400"), (400, 10**9, "$400+")]
+
+# Databricks
+DBX_HOST = os.getenv("DATABRICKS_HOST", "").replace("https://", "")
+DBX_HTTP_PATH = os.getenv("DATABRICKS_HTTP_PATH", "")
+DBX_TOKEN = os.getenv("DATABRICKS_TOKEN", "")
+DBX_CATALOG = os.getenv("DATABRICKS_CATALOG", "main")
+DBX_SCHEMA = f"{DBX_CATALOG}.assortment_gap_finder"
+
+
+def agent_id(name):
+    return json.loads(AGENTS_FILE.read_text())[name]

--- a/apps/assortment-gap-finder/data/sample_run/discover_amz-specialty.json
+++ b/apps/assortment-gap-finder/data/sample_run/discover_amz-specialty.json
@@ -1,0 +1,5818 @@
+{
+ "run_id": "task_run_c18a0ca0ddf1483296b083464999d81b",
+ "chunk_id": "amz-specialty",
+ "wall_clock_s": 951,
+ "result": {
+  "run": {
+   "id": "task_run_c18a0ca0ddf1483296b083464999d81b",
+   "interaction_id": "task_run_c18a0ca0ddf1483296b083464999d81b",
+   "status": "completed",
+   "is_active": false,
+   "effort": "high",
+   "prompt": "french press, pour-over, and moka pot coffee makers on amazon.com - at least 40 distinct products. Cover the whole price range and paginate beyond the first results page. Category context: coffee makers.",
+   "created_at": "2026-07-17T11:25:05.918072Z",
+   "workspace_id": "42b80cc0-b6df-41e5-a21d-f53effb725cb",
+   "web_search_agent_id": "wsa_3992143ba46548ba8be13fb9747b4776",
+   "started_at": "2026-07-17T11:25:06.158722Z",
+   "completed_at": "2026-07-17T11:40:40.426989Z",
+   "error": null
+  },
+  "output": {
+   "type": "json",
+   "content": [
+    {
+     "brand": "Veken",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "24.98",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Veken-Touching-Borosilicate-Stainless-Accessories/dp/B0FDQJFRYS",
+     "subcategory": "french-press",
+     "product_name": "Veken French Press Coffee Maker 34oz, No Plastic Touching Cafe, Thickened Glass Stainless Steel Brewer, Cold Brew Cafetera Tea pot for Kitchen Travel Camping, Gifts, Decor, Bar Accessories, Dark Pewter",
+     "review_count": "17,713"
+    },
+    {
+     "brand": "Secura",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "25.69",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Secura-Stainless-French-Coffee-Screen/dp/B00JE36GLQ",
+     "subcategory": "french-press",
+     "product_name": "Secura French Press Coffee Maker, 304 Grade Stainless Steel Insulated Coffee Press with 2 Extra Screens, 34oz (1 Litre), Silver",
+     "review_count": "35,837"
+    },
+    {
+     "brand": "Bodum",
+     "rating": "4.6",
+     "retailer": "amazon",
+     "price_usd": "39.69",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Bodum-Chambord-French-Coffee-Chrome/dp/B00008XEWG",
+     "subcategory": "french-press",
+     "product_name": "Bodum 34oz Chambord French Press Coffee Maker, High-Heat Borosilicate Glass, Polished Stainless Steel \u2013 Made in Portugal",
+     "review_count": "28,683"
+    },
+    {
+     "brand": "Utopia Kitchen",
+     "rating": "4.4",
+     "retailer": "amazon",
+     "price_usd": "14.24",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Utopia-Kitchen-Espresso-Stainless-Resistant/dp/B01N78X92P",
+     "subcategory": "french-press",
+     "product_name": "Utopia Kitchen Borosilicate Glass French Press Coffee Maker 34 Oz, Heat-Resistant Cafetiere & Tea Maker, Thickened Glass Coffee Press for Travel and Camping, Black",
+     "review_count": "11,539"
+    },
+    {
+     "brand": "Bodum",
+     "rating": "4.5",
+     "retailer": "amazon",
+     "price_usd": "19.99",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Bodum-Brazil-French-Press-Coffee/dp/B000KEM4TQ",
+     "subcategory": "french-press",
+     "product_name": "Bodum 34oz Brazil French Press Coffee Maker, High-Heat Borosilicate Glass, Black - Made in Portugal",
+     "review_count": "19,905"
+    },
+    {
+     "brand": "AeroPress",
+     "rating": "4.6",
+     "retailer": "amazon",
+     "price_usd": "39.95",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/AeroPress-Original-Coffee-Press-Bitterness/dp/B0047BIWSK",
+     "subcategory": "french-press",
+     "product_name": "AeroPress Original Coffee Press - All-in-One French Press, Pour-Over & Espresso Style Manual Brewer, 2 Min Brew for Less Bitterness, More Flavor, Small Portable Coffee Maker, Travel & Camping",
+     "review_count": "26,127"
+    },
+    {
+     "brand": "MuellerLiving",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "54.99",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Mueller-Insulated-Stainless-Filtration-Dishwasher/dp/B07JGBK6XV",
+     "subcategory": "french-press",
+     "product_name": "MuellerLiving French Press Coffee Maker 34oz, Stainless Steel French Press Coffee, 4 Filter Heat Resistant Double Insulated, Rust-Free, Food Grade, Dishwasher Safe Coffee Pot",
+     "review_count": "35,225"
+    },
+    {
+     "brand": "STANLEY",
+     "rating": "4.4",
+     "retailer": "amazon",
+     "price_usd": "54.63",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Stanley-Stay-Hot-Insulated-Stainless-BPA-Free/dp/B0D856ZPMB",
+     "subcategory": "french-press",
+     "product_name": "STANLEY Classic Stay-Hot French Press Coffee Maker 48 oz | 5 Minute Brew, 4 Hours Hot | Insulated Stainless Steel French Press | BPA-Free | Black 2.0",
+     "review_count": "6,513"
+    },
+    {
+     "brand": "ESPRO",
+     "rating": "4.2",
+     "retailer": "amazon",
+     "price_usd": "39.94",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/ESPRO-P3-French-Press-Micro-Filtered/dp/B011WTM622",
+     "subcategory": "french-press",
+     "product_name": "ESPRO Light P3 French Press Coffee Maker \u2013 Patented Double Micro-Filter for Grit-Free Brew, Heat Resistant thicker Borosilicate Glass Coffee press (Black, 32 oz)",
+     "review_count": "3,081"
+    },
+    {
+     "brand": "ESPRO",
+     "rating": "4.4",
+     "retailer": "amazon",
+     "price_usd": "144.99",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Espro-Coffee-Insulated-Brushed-Stainless/dp/B011WTMV1I",
+     "subcategory": "french-press",
+     "product_name": "ESPRO Pro P7 Brushed Stainless Steel 304 French Press Coffee Maker, Patented Double Walled Micro-Filter, Insulated Grit-Free Brew, 32oz",
+     "review_count": "1,857"
+    },
+    {
+     "brand": "Le Creuset",
+     "rating": "4.6",
+     "retailer": "amazon",
+     "price_usd": "89.95",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Creuset-Stoneware-French-Press-Salt/dp/B0GT8R2KZS",
+     "subcategory": "french-press",
+     "product_name": "Le Creuset Stoneware French Press, 34 oz., Sea Salt",
+     "review_count": "465"
+    },
+    {
+     "brand": "YETI",
+     "rating": "4.6",
+     "retailer": "amazon",
+     "price_usd": "110.00",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/YETI-Rambler-French-Coffee-GroundsControl/dp/B0D1RKR153",
+     "subcategory": "french-press",
+     "product_name": "YETI Rambler 34 oz. French Press Coffee Maker, with GroundsControl Filter, Navy",
+     "review_count": "175"
+    },
+    {
+     "brand": "Frieling",
+     "rating": "4.6",
+     "retailer": "amazon",
+     "price_usd": "139.95",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Frieling-Stainless-Patented-Frustration-Packaging/dp/B00ZZ99VLA",
+     "subcategory": "french-press",
+     "product_name": "Frieling Double-Walled Stainless Steel French Press Coffee Maker - 36 oz Polished & Insulated Press Pot",
+     "review_count": "1,046"
+    },
+    {
+     "brand": "Bodum",
+     "rating": "4.5",
+     "retailer": "amazon",
+     "price_usd": "38.99",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Bodum-COLUMBIA-Coffee-Thermal-Stainless/dp/B002AJ9JII",
+     "subcategory": "french-press",
+     "product_name": "Bodum 17 oz Columbia Thermal French Press Coffee Maker, Insulated Double Wall Stainless Steel, Chrome",
+     "review_count": "4,268"
+    },
+    {
+     "brand": "Bialetti",
+     "rating": "4.4",
+     "retailer": "amazon",
+     "price_usd": "42.71",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Bialetti-Preziosa-French-Coffee-Stainless/dp/B006BMBLW2",
+     "subcategory": "french-press",
+     "product_name": "Bialetti Coffeepress French Press Coffee Maker, 8 Cup, Preziosa Stainless Steel (06852)",
+     "review_count": "6,568"
+    },
+    {
+     "brand": "AeroPress",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "49.95",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/AeroPress-Portable-Travel-Coffee-Press/dp/B07YVL8SF3",
+     "subcategory": "french-press",
+     "product_name": "AeroPress Go, Extra Small Portable Coffee Maker Kit, Travel, Hiking & Camping, All-in-One French Press, Pour-Over & Espresso Style Manual Brewer",
+     "review_count": "12,961"
+    },
+    {
+     "brand": "Coffee Gator",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "36.79",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Coffee-Gator-Insulated-Stainless-Canister/dp/B08RCHQ2CJ",
+     "subcategory": "french-press",
+     "product_name": "Coffee Gator 304 Grade Stainless Steel French Press Coffee Maker 34 oz, Double Wall Insulated with 4-Level Filtration System, Include Travel Jar Canister, Black",
+     "review_count": "12,865"
+    },
+    {
+     "brand": "Amazon Basics",
+     "rating": "4.6",
+     "retailer": "amazon",
+     "price_usd": "14.90",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Amazon-Basics-French-Coffee-Borosilicate/dp/B0DYT2QL81",
+     "subcategory": "french-press",
+     "product_name": "Amazon Basics French Coffee Press, 34 oz., Borosilicate Glass, BPA-Free, Triple Filtration System, Dishwasher-Safe Parts",
+     "review_count": "208"
+    },
+    {
+     "brand": "AeroPress",
+     "rating": "4.0",
+     "retailer": "amazon",
+     "price_usd": "199.95",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/AeroPress-Stainless-Pour-Over-Espresso-Style-bitterness/dp/B0FRX2WCJ8",
+     "subcategory": "french-press",
+     "product_name": "AeroPress Premium Coffee Press, Glass, Stainless Steel & Aluminum Coffee Maker, all-in-One French Press, Pour-Over & Espresso-Style manual brewer (White)",
+     "review_count": "138"
+    },
+    {
+     "brand": "POLIVIAR",
+     "rating": "4.5",
+     "retailer": "amazon",
+     "price_usd": "39.99",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/POLIVIAR-Insulation-Dual-Filter-Stainless-Flatland/dp/B08FBTGJRF",
+     "subcategory": "french-press",
+     "product_name": "POLIVIAR French Press Coffee Maker, 34 oz Coffee Press with Real Wood Handle, Double Wall Insulation & Dual-Filter Screen, Food Grade Stainless Steel (Flatland)",
+     "review_count": "5,108"
+    },
+    {
+     "brand": "Bodum",
+     "rating": "4.5",
+     "retailer": "amazon",
+     "price_usd": "19.99",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Coffee-High-Heat-Borosilicate-Reusable-Stainless/dp/B07KQVW6RR",
+     "subcategory": "pour-over",
+     "product_name": "Bodum 34oz Pour Over Coffee Maker, High-Heat Borosilicate Glass with Reusable Stainless Steel Filter and Cork Grip - Made in Portugal",
+     "review_count": "11,597"
+    },
+    {
+     "brand": "Chemex",
+     "rating": "4.8",
+     "retailer": "amazon",
+     "price_usd": "40.58",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Chemex-Classic-Pour-over-Glass-Coffeemaker/dp/B000I1WP7W",
+     "subcategory": "pour-over",
+     "product_name": "Chemex Pour-Over Glass Coffeemaker - Classic Series - 8-Cup - Exclusive Packaging",
+     "review_count": "8,690"
+    },
+    {
+     "brand": "OXO",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "14.99",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/OXO-Single-Coffee-Dripper-Auto-Drip/dp/B01ENK41Q6",
+     "subcategory": "pour-over",
+     "product_name": "OXO Brew Single Serve Pour-Over Coffee Maker",
+     "review_count": "10,246"
+    },
+    {
+     "brand": "Hario",
+     "rating": "4.8",
+     "retailer": "amazon",
+     "price_usd": "29.00",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Hario-Ceramic-Coffee-Dripper-White/dp/B000P4D5HG",
+     "subcategory": "pour-over",
+     "product_name": "Hario V60 Ceramic Coffee Dripper, 02, White",
+     "review_count": "11,899"
+    },
+    {
+     "brand": "Cosori",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "29.39",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/cosori-pour-over-resistance-transparent/dp/B0821DTMGT",
+     "subcategory": "pour-over",
+     "product_name": "Cosori Pour Over Coffee Maker with Double Layer Stainless Steel Filter, 8-Cup, 34oz, Drip Coffee Maker",
+     "review_count": "6,682"
+    },
+    {
+     "brand": "Chemex",
+     "rating": "4.8",
+     "retailer": "amazon",
+     "price_usd": "47.95",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Chemex-Classic-Pour-over-Glass-Coffeemaker/dp/B0000YWF5E",
+     "subcategory": "pour-over",
+     "product_name": "Chemex Pour-Over Glass Coffeemaker - Classic Series - 6-Cup - Exclusive Packaging",
+     "review_count": "6,944"
+    },
+    {
+     "brand": "Hario",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "31.35",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Dripper-servings-coffee-extract-dripper/dp/B07NS2SV3W",
+     "subcategory": "pour-over",
+     "product_name": "Hario \"Switch\" Immersion Dripper, Size 02",
+     "review_count": "2,375"
+    },
+    {
+     "brand": "Hario",
+     "rating": "4.8",
+     "retailer": "amazon",
+     "price_usd": "12.48",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Hario-Plastic-Coffee-Dripper-Clear/dp/B0BWHKPCLJ",
+     "subcategory": "pour-over",
+     "product_name": "Hario V60 Plastic Coffee Dripper, 02, Clear",
+     "review_count": "3,428"
+    },
+    {
+     "brand": "Kalita",
+     "rating": "4.5",
+     "retailer": "amazon",
+     "price_usd": "19.98",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Kalita-Wave/dp/B004W5KPSQ",
+     "subcategory": "pour-over",
+     "product_name": "Kalita Wave Pour Over Coffee Dripper, Size 185, Makes 16-26oz, Single Cup Maker, Heat-Resistant Glass, black",
+     "review_count": "1,371"
+    },
+    {
+     "brand": "Melitta",
+     "rating": "4.7",
+     "retailer": "amazon",
+     "price_usd": "7.45",
+     "source_url": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+     "observed_at": "2026-07-17T00:00:00Z",
+     "product_url": "https://www.amazon.com/Melitta/dp/B0014CVEH6",
+     "subcategory": "pour-over",
+     "product_name": "Melitta Filter Coffee Maker, Single Cup Pour-Over Brewer, Black, 1 Count (640007)",
+     "review_count": "4,949"
+    }
+   ],
+   "trust": {
+    "claims": [
+     {
+      "path": "$[0].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Veken French Press Coffee Maker 34oz, No Plastic Touching Cafe,Thickened Glass Stainless Steel Brewer"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Veken French Press Coffee Maker 34oz"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B0FDQJFRYS"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Veken-Touching-Borosilicate-Stainless-Accessories/dp/B0FDQJFRYS"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$24.98"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 17,713 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[0].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 17,713 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Secura French Press Coffee Maker, 304 Grade Stainless Steel Insulated Coffee Press with 2 Extra Screens, 34oz"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Secura French Press Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B00JE36GLQ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Secura-Stainless-French-Coffee-Screen/dp/B00JE36GLQ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$25.69"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 35,837 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[1].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 35,837 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Bodum 34oz Chambord French Press Coffee Maker, High-Heat Borosilicate Glass, Polished Stainless Steel \u2013 Made in Portugal"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Bodum 34oz Chambord French Press Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B00008XEWG"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Bodum-Chambord-French-Coffee-Chrome/dp/B00008XEWG"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$39.69"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 28,683 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[2].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 28,683 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Utopia Kitchen Borosilicate Glass French Press Coffee Maker 34 Oz, Heat-Resistant Cafetiere & Tea Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Utopia Kitchen Borosilicate Glass French Press Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B01N78X92P"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Utopia-Kitchen-Espresso-Stainless-Resistant/dp/B01N78X92P"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$14.24"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.4 out of 5 stars, 11,539 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[3].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.4 out of 5 stars, 11,539 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Bodum 34oz Brazil French Press Coffee Maker, High-Heat Borosilicate Glass, Black - Made in Portugal"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Bodum 34oz Brazil French Press Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B000KEM4TQ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Bodum-Brazil-French-Press-Coffee/dp/B000KEM4TQ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$19.99"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.5 out of 5 stars, 19,905 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[4].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.5 out of 5 stars, 19,905 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "AeroPress Original Coffee Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$39.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "AeroPress Original Coffee Press - All-in-One French Press, Pour-Over & Espresso Style Manual Brewer, 2 Min Brew for Less Bitterness, More Flavor, Small Portable Coffee Maker, Travel & Camping"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/AeroPress-Original-Coffee-Press-Bitterness/dp/B0047BIWSK"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 26,127 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 26,127 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B0047BIWSK"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[5].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "MuellerLiving French Press Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$54.99"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "MuellerLiving French Press Coffee Maker 34oz, Stainless Steel French Press Coffee, 4 Filter Heat Resistant Double Insulated, Rust-Free, Food Grade, Dishwasher Safe Coffee Pot"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Mueller-Insulated-Stainless-Filtration-Dishwasher/dp/B07JGBK6XV"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 35,225 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 35,225 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B07JGBK6XV"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[6].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "STANLEY Classic Stay-Hot French Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$54.63"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "STANLEY Classic Stay-Hot French Press Coffee Maker 48 oz | 5 Minute Brew, 4 Hours Hot | Mesh Filter for Coffee Grounds | Insulated Stainless Steel French Press | BPA-Free | Black 2.0"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Stanley-Stay-Hot-Insulated-Stainless-BPA-Free/dp/B0D856ZPMB"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.4 out of 5 stars, 6,513 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.4 out of 5 stars, 6,513 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B0D856ZPMB"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[7].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "ESPRO Light P3 French Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$39.94"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "ESPRO Light P3 French Press Coffee Maker \u2013 Patented Double Micro-Filter for Grit-Free Brew, Heat Resistant thicker Borosilicate Glass Coffee press \u2013 (Black, 32 oz)"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/ESPRO-P3-French-Press-Micro-Filtered/dp/B011WTM622"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.2 out of 5 stars, 3,081 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.2 out of 5 stars, 3,081 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B011WTM622"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[8].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "ESPRO Pro P7 Brushed Stainless Steel"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$144.99"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "ESPRO Pro P7 Brushed Stainless Steel 304 French Press Coffee Maker, Patented Double Walled Micro-Filter, Insulated Grit-Free Brew, Heat Resistant BPA Free, 32oz"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Espro-Coffee-Insulated-Brushed-Stainless/dp/B011WTMV1I"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.4 out of 5 stars, 1,857 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.4 out of 5 stars, 1,857 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B011WTMV1I"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[9].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Le Creuset Stoneware French Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$89.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Le Creuset Stoneware French Press, 34 oz., Sea Salt"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Creuset-Stoneware-French-Press-Salt/dp/B0GT8R2KZS"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 465 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 465 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B0GT8R2KZS"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[10].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "YETI Rambler 34 oz. French Press Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "$110.00"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "YETI Rambler 34 oz. French Press Coffee Maker, with GroundsControl Filter, Navy"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "https://www.amazon.com/YETI-Rambler-French-Coffee-GroundsControl/dp/B0D1RKR153"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.6 out of 5 stars, 175 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.6 out of 5 stars, 175 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "amazon.com ... /dp/B0D1RKR153"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[11].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Frieling Double-Walled Stainless Steel French Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "$139.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Frieling Double-Walled Stainless Steel French Press Coffee Maker - 36 oz Polished & Insulated Press Pot - Stainless Steel Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "https://www.amazon.com/Frieling-Stainless-Patented-Frustration-Packaging/dp/B00ZZ99VLA"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.6 out of 5 stars, 1,046 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.6 out of 5 stars, 1,046 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "amazon.com ... /dp/B00ZZ99VLA"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[12].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Bodum 17 oz Columbia Thermal French Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "$38.99"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Bodum 17 oz Columbia Thermal French Press Coffee Maker, Insulated Double Wall Stainless Steel, Chrome"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "https://www.amazon.com/Bodum-COLUMBIA-Coffee-Thermal-Stainless/dp/B002AJ9JII"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.5 out of 5 stars, 4,268 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.5 out of 5 stars, 4,268 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "amazon.com ... /dp/B002AJ9JII"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[13].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Bialetti Coffeepress French Press Coffee Maker, 8 Cup, Preziosa"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "$42.71"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Bialetti Coffeepress French Press Coffee Maker, 8 Cup, Preziosa Stainless Steel (06852)"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "https://www.amazon.com/Bialetti-Preziosa-French-Coffee-Stainless/dp/B006BMBLW2"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.4 out of 5 stars, 6,568 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.4 out of 5 stars, 6,568 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "amazon.com ... /dp/B006BMBLW2"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[14].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "AeroPress Go, Extra Small Portable Coffee Maker Kit"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$49.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "AeroPress Go, Extra Small Portable Coffee Maker Kit, Travel, Hiking & Camping, All-in-One French Press, Pour-Over & Espresso Style Manual Brewer"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/AeroPress-Portable-Travel-Coffee-Press/dp/B07YVL8SF3"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 12,961 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 12,961 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B07YVL8SF3"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[15].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Coffee Gator 304 Grade Stainless Steel French Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$36.79"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Coffee Gator 304 Grade Stainless Steel French Press Coffee Maker 34 oz, Double Wall Insulated Hot Cold Brew Teapot with 4-Level Filtration System, Include Travel Jar Canister, Rust-Free, Travel, Black"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Coffee-Gator-Insulated-Stainless-Canister/dp/B08RCHQ2CJ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 12,865 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.7 out of 5 stars, 12,865 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B08RCHQ2CJ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[16].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Amazon Basics French Coffee Press"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$14.90"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Amazon Basics French Coffee Press, 34 oz., Borosilicate Glass, BPA-Free, Triple Filtration System, Dishwasher-Safe Parts"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/Amazon-Basics-French-Coffee-Borosilicate/dp/B0DYT2QL81"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 208 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.6 out of 5 stars, 208 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B0DYT2QL81"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[17].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "AeroPress Premium Coffee Press, Glass, Stainless Steel & Aluminum"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "$199.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "AeroPress Premium Coffee Press, Glass, Stainless Steel & Aluminum Coffee Maker, all-in-One French Press, Pour-Over & Espresso-Style manual brewer (White)"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "https://www.amazon.com/AeroPress-Stainless-Pour-Over-Espresso-Style-bitterness/dp/B0FRX2WCJ8"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.0 out of 5 stars, 138 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "4.0 out of 5 stars, 138 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "amazon.com ... /dp/B0FRX2WCJ8"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[18].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "POLIVIAR French Press Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "$39.99"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "POLIVIAR French Press Coffee Maker, 34 oz Coffee Press with Real Wood Handle, Double Wall Insulation & Dual-Filter Screen, Food Grade Stainless Steel for Good Coffe and Tea (Flatland)"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "https://www.amazon.com/POLIVIAR-Insulation-Dual-Filter-Stainless-Flatland/dp/B08FBTGJRF"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.5 out of 5 stars, 5,108 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "4.5 out of 5 stars, 5,108 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "amazon.com ... /dp/B08FBTGJRF"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[19].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+        "title": "Amazon Best Sellers: Best Coffee Presses",
+        "excerpts": [
+         "Best Sellers in Coffee Presses"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Bodum 34oz Pour Over Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$19.99"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Bodum 34oz Pour Over Coffee Maker, High-Heat Borosilicate Glass with Reusable Stainless Steel Filter and Cork Grip - Made in Portugal"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Coffee-High-Heat-Borosilicate-Reusable-Stainless/dp/B07KQVW6RR"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.5 out of 5 stars, 11,597 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.5 out of 5 stars, 11,597 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B07KQVW6RR"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[20].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Chemex Pour-Over Glass Coffeemaker - Classic Series - 8-Cup"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$40.58"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Chemex Pour-Over Glass Coffeemaker - Classic Series - 8-Cup - Exclusive Packaging"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Chemex-Classic-Pour-over-Glass-Coffeemaker/dp/B000I1WP7W"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 8,690 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 8,690 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B000I1WP7W"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[21].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "OXO Brew Single Serve Pour-Over Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$14.99"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "OXO Brew Single Serve Pour-Over Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/OXO-Single-Coffee-Dripper-Auto-Drip/dp/B01ENK41Q6"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 10,246 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 10,246 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B01ENK41Q6"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[22].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Hario, V60 Dripper 02 White"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$29.00"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Hario, V60 Dripper 02 White"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Hario-Ceramic-Coffee-Dripper-White/dp/B000P4D5HG"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 11,899 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 11,899 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B000P4D5HG"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[23].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Cosori Pour Over Coffee Maker"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$29.39"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Cosori Pour Over Coffee Maker with Double Layer Stainless Steel Filter, 8-Cup, 34oz, Drip Coffee Maker, Coffee Dripper Brewer, High Heat Resistant Carafe"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Cosori-Pour-over-resistance-transparent-dp-b0821dtmgt/dp/B0821DTMGT"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 6,682 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 6,682 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B0821DTMGT"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[24].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Chemex Pour-Over Glass Coffeemaker - Classic Series - 6-Cup"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$47.95"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Chemex Pour-Over Glass Coffeemaker - Classic Series - 6-Cup - Exclusive Packaging"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Chemex-Classic-Pour-over-Glass-Coffeemaker/dp/B0000YWF5E"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 6,944 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 6,944 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B0000YWF5E"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[25].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Hario \"Switch\" Immersion Dripper, Size 02"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$31.35"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Hario \"Switch\" Immersion Dripper, Size 02"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Dripper-servings-coffee-extract-dripper/dp/B07NS2SV3W"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 2,375 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 2,375 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B07NS2SV3W"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[26].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Hario V60 Plastic Coffee Dripper, 02, Clear"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$12.48"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Hario V60 Plastic Coffee Dripper, 02, Clear"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Hario-Plastic-Coffee-Dripper-Clear/dp/B0BWHKPCLJ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 3,428 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.8 out of 5 stars, 3,428 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B0BWHKPCLJ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[27].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Kalita Wave Pour Over Coffee Dripper, Size 185"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$19.98"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Kalita Wave Pour Over Coffee Dripper, Size 185, Makes 16-26oz, Single Cup Maker, Heat-Resistant Glass, Patented & Portable, black"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Kalita-Wave-Pour-Over-Coffee/dp/B004W5KPSQ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.5 out of 5 stars, 1,371 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.5 out of 5 stars, 1,371 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B004W5KPSQ"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[28].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].brand",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Melitta Filter Coffee Maker, Single Cup Pour-Over Brewer"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].observed_at",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers listing retrieved 2026-07-17"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].price_usd",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "$7.45"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].product_name",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Melitta Filter Coffee Maker, Single Cup Pour-Over Brewer, Black, 1 Count (640007)"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].product_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "https://www.amazon.com/Melitta-Filter-Coffee-Maker/dp/B0014CVEH6"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].rating",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 4,949 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].review_count",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "4.7 out of 5 stars, 4,949 ratings"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].retailer",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "amazon.com ... /dp/B0014CVEH6"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].source_url",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     },
+     {
+      "path": "$[29].subcategory",
+      "citations": [
+       {
+        "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+        "title": "Best Pour Over Coffee Makers",
+        "excerpts": [
+         "Best Sellers in Pour Over Coffee Makers"
+        ],
+        "source_type": "primary",
+        "source_intent": "other",
+        "source_category": "official",
+        "extract_template_name": null
+       }
+      ],
+      "reasoning": "Backed by a primary source (official)",
+      "confidence": "high"
+     }
+    ],
+    "sources": [
+     {
+      "url": "https://amazon.com/Best-Sellers-Coffee-Presses/zgbs/home-garden/289749",
+      "type": "primary",
+      "title": "Amazon Best Sellers: Best Coffee Presses",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+      "type": "primary",
+      "title": "https://www.amazon.com/Best-Sellers-Home-Kitchen-Coffee-Presses/zgbs/home-garden/289749/ref=zg_bs_pg_2_home-garden?_encoding=UTF8&pg=2",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     },
+     {
+      "url": "https://amazon.com/Best-Sellers-Pour-Over-Coffee-Makers/zgbs/home-garden/17725657011",
+      "type": "primary",
+      "title": "Best Pour Over Coffee Makers",
+      "source_intent": null,
+      "source_category": "official",
+      "extract_template_name": null
+     }
+    ],
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "confidence": "high"
+   }
+  }
+ }
+}

--- a/apps/assortment-gap-finder/data/sample_run/verify_4e541f1e.json
+++ b/apps/assortment-gap-finder/data/sample_run/verify_4e541f1e.json
@@ -1,0 +1,833 @@
+{
+ "run": {
+  "id": "task_run_395462044a1842e394b5a1074e541f1e",
+  "interaction_id": "task_run_395462044a1842e394b5a1074e541f1e",
+  "status": "completed",
+  "is_active": false,
+  "effort": "max",
+  "prompt": "Verify: No drip coffee maker priced $150-400 with a fully removable/dishwasher-safe brew basket and thermal (not glass) carafe rated 4.3+ exists on amazon.com",
+  "created_at": "2026-07-17T12:55:55.075853Z",
+  "workspace_id": "42b80cc0-b6df-41e5-a21d-f53effb725cb",
+  "web_search_agent_id": "wsa_9a41bd9dc4454dc5b0ee1e443a719723",
+  "started_at": "2026-07-17T12:55:55.389133Z",
+  "completed_at": "2026-07-17T13:01:33.395110Z",
+  "error": null
+ },
+ "output": {
+  "type": "json",
+  "content": {
+   "verdict": "refuted",
+   "observed_at": "2026-07-17",
+   "gap_statement": "No drip coffee maker priced $150-400 with a fully removable/dishwasher-safe brew basket and thermal (not glass) carafe rated 4.3+ exists on amazon.com",
+   "closest_matches": [
+    {
+     "brand": "Zojirushi",
+     "rating": "4.3 out of 5 stars (2,228)",
+     "price_usd": "$224.95",
+     "product_url": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+     "product_name": "Zojirushi EC-YTC100XB 10-Cup Coffee Maker (Stainless Steel/Black)",
+     "why_close_but_not_matching": "This is a MATCHING counterexample, not a near-miss: it satisfies every criterion in the gap spec. Drip coffee maker; price $224.95 (within $150-400); vacuum-insulated stainless steel thermal carafe (not glass); 4.3 out of 5 stars (>=4.3); and a 'Reusable and washable, permanent stainless mesh coffee filter' (removable/washable brew basket). Currently In Stock, sold and shipped by Amazon.com. This product refutes the gap hypothesis."
+    },
+    {
+     "brand": "Bunn",
+     "rating": "4.4 out of 5 stars (7,719)",
+     "price_usd": "$179.49",
+     "product_url": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+     "product_name": "BUNN 55200 CSB3T Speed Brew Platinum Thermal Coffee Maker Stainless Steel, 10-Cup, Black",
+     "why_close_but_not_matching": "This is a MATCHING counterexample, not a near-miss: it satisfies every criterion. Drip coffee maker; price $179.49 (within $150-400); 'VACUUM-INSULATED, double walled thermal carafe' (thermal, not glass); 4.4 out of 5 stars (>=4.3); and a removable brew funnel/basket plus removable water tank (Special Feature: Removable Tank, Thermal). Currently In Stock, sold and shipped by Amazon.com. This product refutes the gap hypothesis."
+    },
+    {
+     "brand": "Ninja (SharkNinja)",
+     "rating": "4.5 out of 5 stars (8,524)",
+     "price_usd": "$229.99",
+     "product_url": "https://www.amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+     "product_name": "Shark Ninja CP307 Hot and Cold Brewed System W/Thermal Carafe Coffee Maker, Black",
+     "why_close_but_not_matching": "Matches all hard criteria and In Stock (Amazon's Choice): drip-capable coffee maker, $229.99 (within $150-400), 4.5 out of 5 stars (>=4.3), and includes a thermal carafe. Minor caveat vs. a 'pure' drip maker: it is a multi-beverage Hot & Cold Brewed System (tea + coffee) with a removable brew basket, so it is a borderline rather than textbook drip-only unit; nonetheless it brews drip coffee into a thermal carafe and counts as a counterexample."
+    },
+    {
+     "brand": "Wolf Gourmet",
+     "rating": "4.4 out of 5 stars (644)",
+     "price_usd": "$599.95 (list); shown $179.54-$223.00 in variants",
+     "product_url": "https://www.amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+     "product_name": "WOLF GOURMET Programmable Coffee Maker System with 10 Cup Thermal Carafe, Built-In Grounds Scale, Removable Reservoir, Red Knob, Stainless Steel (WGCM100S)",
+     "why_close_but_not_matching": "Spec-wise the closest apparent match \u2014 stainless steel thermal carafe, removable front-load brew basket, removable reservoir, 4.4 stars. But it is DISQUALIFIED as a counterexample on two grounds: (1) the listing is 'Currently unavailable. We don't know when or if this item will be back in stock.' (not in stock), and (2) the featured list price is $599.95, above the $400 ceiling (the $179.54-$223 variant figures are out-of-stock/other offers). So it does NOT refute the gap; the gap is refuted by Zojirushi/BUNN instead."
+    },
+    {
+     "brand": "Bonavita",
+     "rating": "3.9 out of 5 stars (10,387)",
+     "price_usd": "$189.95",
+     "product_url": "https://www.amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+     "product_name": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch Pour Over, Auto Pause Brewing with Stainless Steel Double Wall Thermal Carafe, SCA Certified, Dishwasher Safe, BV1901TS",
+     "why_close_but_not_matching": "Fails the rating threshold only: price $189.95 (in band), stainless steel double-wall thermal carafe, 'Dishwasher Safe' (removable/dishwasher-safe brew basket per title), and a pure drip maker. But its rating is 3.9 out of 5 stars, below the 4.3 minimum, so it is not a counterexample."
+    }
+   ],
+   "evidence_summary": "REFUTED \u2014 the gap is disproven by in-stock products on Amazon's live shelf. I searched Amazon's catalog via 'drip coffee maker thermal carafe' queries plus targeted candidate product pages (Bonavita, OXO, Technivorm, Ninja, Wolf Gourmet, BUNN, Zojirushi, Fellow Aiden) and verified each candidate's live price, rating, carafe type, brew-basket construction, and stock status from the product pages themselves (not general knowledge).\n\nTwo products satisfy EVERY criterion simultaneously and are currently In Stock, sold and shipped by Amazon.com: (1) Zojirushi EC-YTC100XB \u2014 $224.95, 4.3 out of 5 stars (2,228 reviews), vacuum-insulated stainless steel thermal carafe, 'Reusable and washable, permanent stainless mesh coffee filter' (removable/washable brew basket), In Stock; and (2) BUNN 55200 CSB3T Speed Brew Platinum Thermal \u2014 $179.49, 4.4 out of 5 stars (7,719 reviews), vacuum-insulated double-wall thermal carafe, removable brew funnel/basket plus removable tank, In Stock. A third, the Ninja CP307 Hot and Cold Brewed System ($229.99, 4.5 out of 5 stars (8,524), thermal carafe, In Stock, Amazon's Choice) also qualifies, though it is a multi-beverage (tea+coffee) system rather than a pure drip-only maker.\n\nThis is a definitive counterexample finding, NOT 'not found after thorough search' nor 'confirmed absent' \u2014 the products were found on Amazon's live product pages with explicit 'In Stock' status and ship-by dates in July 2026. The closest apparent match that initially looked like a counterexample, the Wolf Gourmet Programmable Coffee System (WGCM100S, 4.4 stars, stainless steel thermal carafe, removable front-load brew basket), is disqualified because its listing reads 'Currently unavailable. We don't know when or if this item will be back in stock' and its featured price is $599.95 (above the $400 ceiling). Other near-misses fail on the rating threshold: Bonavita Connoisseur BV1901TS ($189.95, thermal, dishwasher-safe, but 3.9 stars), Bonavita Enthusiast 8-Cup ($149.99, 4.1 stars, just below the $150 band), and OXO Brew 8-Cup ($219.95, thermal, but 4.0 stars). Because at least one (here, two) in-stock product meets the full spec, the gap hypothesis is refuted.",
+   "_run_id": "task_run_395462044a1842e394b5a1074e541f1e",
+   "_interaction_id": "task_run_395462044a1842e394b5a1074e541f1e",
+   "_citations": [
+    "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+    "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+    "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+    "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+    "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+    "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV"
+   ]
+  },
+  "trust": {
+   "claims": [
+    {
+     "path": "$.gap_statement",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "Zojirushi EC-YTC100XB 10-Cup Coffee Maker... 4.3 out of 5 stars (2,228)... $224.95... In Stock... vacuum insulated... stainless steel carafe... Reusable and washable, permanent stainless mesh coffee filter"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "BUNN 55200 CSB3T Speed Brew Platinum Thermal Coffee Maker... 4.4 out of 5 stars (7,719)... $179.49... In Stock... VACUUM-INSULATED, double walled thermal carafe... funnel... Removable Tank"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.verdict",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "Zojirushi EC-YTC100XB 10-Cup Coffee Maker... 4.3 out of 5 stars (2,228)... $224.95... In Stock... vacuum insulated... stainless steel carafe... Reusable and washable, permanent stainless mesh coffee filter"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "BUNN 55200 CSB3T Speed Brew Platinum Thermal... 4.4 out of 5 stars (7,719)... $179.49... In Stock... VACUUM-INSULATED, double walled thermal carafe... Removable Tank"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.observed_at",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "retrieved: 2026-07-17"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "In Stock... Get it as soon as Wednesday, Jul 22"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[0].product_name",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "# Zojirushi EC-YTC100XB 10-Cup Coffee Maker (Stainless Steel/Black)"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[0].brand",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "| Brand | Zojirushi |"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[0].price_usd",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "In Stock... $$224.95 () Includes selected options... Ships from: Amazon.com... Sold by: Amazon.com"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[0].rating",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "_4.3 out of 5 stars_ [(2,228)]"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[0].product_url",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[0].why_close_but_not_matching",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "FEATURES: Brewing fresh, flavorful Coffee is easy with the fresh brew plus thermal carafe... VACUUM INSULATED: The stainless steel carafe is vacuum insulated keeps coffee hot for hours... INCLUDES: Reusable and washable, permanent stainless mesh coffee filter... The removable water tank makes filling easy and is fully washable"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[1].product_name",
+     "citations": [
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "# BUNN 55200 CSB3T Speed Brew Platinum Thermal Coffee Maker Stainless Steel, 10-Cup, Black"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[1].brand",
+     "citations": [
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "| Brand | Bunn |"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[1].price_usd",
+     "citations": [
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "New Condition Price: $179.49... In Stock... Ships from and sold by Amazon.com."
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[1].rating",
+     "citations": [
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "_4.4 out of 5 stars_ [(7,719)]"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[1].product_url",
+     "citations": [
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[1].why_close_but_not_matching",
+     "citations": [
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "VACUUM-INSULATED, double walled thermal carafe maintains ideal serving temperature for 2+ hours... TALLER FUNNEL - Our funnel is engineered to accommodate BUNN filters... | Special Feature | Removable Tank, Thermal |"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[2].brand",
+     "citations": [
+      {
+       "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+       "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+       "excerpts": [
+        "[Visit the Ninja Store]... # Shark Ninja CP307 Hot and Cold Brewed System W/Thermal Carafe Coffee Maker, Black"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[2].price_usd",
+     "citations": [
+      {
+       "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+       "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+       "excerpts": [
+        "$229.99... In Stock... New & Used (5) from $162.07"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[2].product_name",
+     "citations": [
+      {
+       "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+       "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+       "excerpts": [
+        "# Shark Ninja CP307 Hot and Cold Brewed System W/Thermal Carafe Coffee Maker, Black"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[2].product_url",
+     "citations": [
+      {
+       "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+       "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+       "excerpts": [
+        "https://www.amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[2].rating",
+     "citations": [
+      {
+       "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+       "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+       "excerpts": [
+        "_4.5 out of 5 stars_ [(8,524)]... Amazon's Choice"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[2].why_close_but_not_matching",
+     "citations": [
+      {
+       "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+       "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+       "excerpts": [
+        "Shark Ninja CP307 Hot and Cold Brewed System W/Thermal Carafe Coffee Maker... 4.5 out of 5 stars (8,524)... $229.99... In Stock"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[3].brand",
+     "citations": [
+      {
+       "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+       "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+       "excerpts": [
+        "[Visit the WOLF GOURMET Store]... # WOLF GOURMET Programmable Coffee Maker System with 10 Cup Thermal Carafe... (WGCM100S)"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[3].price_usd",
+     "citations": [
+      {
+       "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+       "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+       "excerpts": [
+        "$599.95... $179.54... $223.00... Currently unavailable. We don't know when or if this item will be back in stock."
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[3].product_name",
+     "citations": [
+      {
+       "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+       "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+       "excerpts": [
+        "# WOLF GOURMET Programmable Coffee Maker System with 10 Cup Thermal Carafe, Built-In Grounds Scale, Removable Reservoir, Red Knob, Stainless Steel (WGCM100S)"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[3].product_url",
+     "citations": [
+      {
+       "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+       "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+       "excerpts": [
+        "https://www.amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[3].rating",
+     "citations": [
+      {
+       "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+       "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+       "excerpts": [
+        "_4.4 out of 5 stars_ [(644)]"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[3].why_close_but_not_matching",
+     "citations": [
+      {
+       "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+       "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+       "excerpts": [
+        "Currently unavailable. We don't know when or if this item will be back in stock... STAINLESS STEEL THERMAL CARAFE: 10-cup carafe with double-wall construction... smooth-glide, front-load brew basket. The removable side-access reservoir... $599.95"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[4].brand",
+     "citations": [
+      {
+       "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+       "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+       "excerpts": [
+        "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch Pour Over, Auto Pause Brewing with Stainless Steel Double Wall Thermal Carafe, SCA Certified, Dishwasher Safe, BV1901TS"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[4].price_usd",
+     "citations": [
+      {
+       "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+       "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+       "excerpts": [
+        "$189.95"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[4].product_name",
+     "citations": [
+      {
+       "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+       "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+       "excerpts": [
+        "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch Pour Over, Auto Pause Brewing with Stainless Steel Double Wall Thermal Carafe, SCA Certified, Dishwasher Safe, BV1901TS"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[4].product_url",
+     "citations": [
+      {
+       "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+       "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+       "excerpts": [
+        "https://www.amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[4].rating",
+     "citations": [
+      {
+       "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+       "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+       "excerpts": [
+        "[3.910,387]"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.closest_matches[4].why_close_but_not_matching",
+     "citations": [
+      {
+       "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+       "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+       "excerpts": [
+        "Bonavita 8 Cup Drip Coffee Maker Machine... Stainless Steel Double Wall Thermal Carafe, SCA Certified, Dishwasher Safe, BV1901TS... [3.910,387]... $189.95"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    },
+    {
+     "path": "$.evidence_summary",
+     "citations": [
+      {
+       "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+       "excerpts": [
+        "Zojirushi EC-YTC100XB... 4.3 out of 5 stars (2,228)... In Stock... $$224.95... Ships from: Amazon.com... vacuum insulated... stainless steel carafe... Reusable and washable, permanent stainless mesh coffee filter"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+       "excerpts": [
+        "BUNN 55200 CSB3T Speed Brew Platinum Thermal... 4.4 out of 5 stars (7,719)... $179.49... In Stock... Ships from and sold by Amazon.com... VACUUM-INSULATED, double walled thermal carafe... Removable Tank, Thermal"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+       "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+       "excerpts": [
+        "Shark Ninja CP307 Hot and Cold Brewed System W/Thermal Carafe... 4.5 out of 5 stars (8,524)... $229.99... In Stock... Amazon's Choice"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+       "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+       "excerpts": [
+        "WOLF GOURMET Programmable Coffee Maker System with 10 Cup Thermal Carafe... 4.4 out of 5 stars (644)... Currently unavailable. We don't know when or if this item will be back in stock... $599.95... STAINLESS STEEL THERMAL CARAFE... front-load brew basket"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+       "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+       "excerpts": [
+        "Bonavita 8 Cup Drip Coffee Maker... Stainless Steel Double Wall Thermal Carafe, SCA Certified, Dishwasher Safe, BV1901TS... [3.910,387]... $189.95"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      },
+      {
+       "url": "https://amazon.com/OXO-Cup-Coffee-Maker-8718800/dp/B07H9G93WK",
+       "title": "OXO Brew 8-Cup Coffee Maker - Single-Serve & Carafe ...",
+       "excerpts": [
+        "OXO Brew 8-Cup Coffee Maker... Thermal Stainless Steel, SCA Certified... [4.04,807]... $219.95"
+       ],
+       "source_type": "secondary",
+       "source_intent": "other",
+       "source_category": "other",
+       "extract_template_name": null
+      }
+     ],
+     "reasoning": "Backed by a secondary source (other)",
+     "confidence": "medium"
+    }
+   ],
+   "sources": [
+    {
+     "url": "https://amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+     "type": "secondary",
+     "title": "https://www.amazon.com/Zojirushi-EC-YTC100XB-Coffee-Maker-Stainless/dp/B07B83DGMV",
+     "source_intent": null,
+     "source_category": "other",
+     "extract_template_name": null
+    },
+    {
+     "url": "https://amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+     "type": "secondary",
+     "title": "https://www.amazon.com/BUNN-CSB3T-Platinum-Thermal-Coffee/dp/B07GY6PHYZ",
+     "source_intent": null,
+     "source_category": "other",
+     "extract_template_name": null
+    },
+    {
+     "url": "https://amazon.com/Ninja-CP307-Brewed-System-Thermal/dp/B07FX73Y7H",
+     "type": "secondary",
+     "title": "Shark Ninja CP307 Hot and Cold Brewed System W/ ...",
+     "source_intent": null,
+     "source_category": "other",
+     "extract_template_name": null
+    },
+    {
+     "url": "https://amazon.com/Wolf-Gourmet-Programmable-Coffee-System/dp/B07HCMRJZD",
+     "type": "secondary",
+     "title": "WOLF GOURMET Programmable Coffee Maker System ...",
+     "source_intent": null,
+     "source_category": "other",
+     "extract_template_name": null
+    },
+    {
+     "url": "https://amazon.com/Bonavita-Connoisseur-One-Touch-Featuring-BV1901TS/dp/B076PFMRGX",
+     "type": "secondary",
+     "title": "Bonavita 8 Cup Drip Coffee Maker Machine, One-Touch ...",
+     "source_intent": null,
+     "source_category": "other",
+     "extract_template_name": null
+    },
+    {
+     "url": "https://amazon.com/OXO-Cup-Coffee-Maker-8718800/dp/B07H9G93WK",
+     "type": "secondary",
+     "title": "OXO Brew 8-Cup Coffee Maker - Single-Serve & Carafe ...",
+     "source_intent": null,
+     "source_category": "other",
+     "extract_template_name": null
+    }
+   ],
+   "reasoning": "Medium confidence - trust per claim ratio is 100%",
+   "confidence": "medium"
+  }
+ }
+}

--- a/apps/assortment-gap-finder/delta.py
+++ b/apps/assortment-gap-finder/delta.py
@@ -56,6 +56,24 @@ def insert_rows(table, rows):
             [[r[c] for c in cols] for r in rows])
 
 
+def replace_rows(table, rows):
+    """Atomic refresh: stage into a temp table, then one INSERT OVERWRITE.
+    A crash mid-load leaves the live table untouched."""
+    with connect() as conn, conn.cursor() as cur:
+        cur.execute(f"CREATE TABLE IF NOT EXISTS {C.DBX_SCHEMA}.{table}_staging LIKE {C.DBX_SCHEMA}.{table}")
+        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.{table}_staging")
+        if rows:
+            cols = list(rows[0].keys())
+            ph = ", ".join(["?"] * len(cols))
+            cur.executemany(
+                f"INSERT INTO {C.DBX_SCHEMA}.{table}_staging ({', '.join(cols)}) VALUES ({ph})",
+                [[r[c] for c in cols] for r in rows])
+            cur.execute(f"INSERT OVERWRITE {C.DBX_SCHEMA}.{table} "
+                        f"SELECT {', '.join(cols)} FROM {C.DBX_SCHEMA}.{table}_staging")
+        else:
+            cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.{table}")
+
+
 def query(sql_text, params=None):
     with connect() as conn, conn.cursor() as cur:
         cur.execute(sql_text, params or [])

--- a/apps/assortment-gap-finder/delta.py
+++ b/apps/assortment-gap-finder/delta.py
@@ -1,0 +1,67 @@
+"""Databricks Delta layer: schema + tables + helpers (idempotent)."""
+import json
+
+from databricks import sql as dbsql
+
+import config as C
+
+DDL = [
+    "CREATE SCHEMA IF NOT EXISTS {s}",
+    """CREATE TABLE IF NOT EXISTS {s}.discovery_runs (
+        chunk_id STRING, retailer STRING, subcategory STRING, run_id STRING,
+        status STRING, item_count INT, wall_clock_s INT, error STRING,
+        completed_at TIMESTAMP)""",
+    """CREATE TABLE IF NOT EXISTS {s}.catalog (
+        sku_key STRING, product_name STRING, brand STRING, retailer STRING,
+        subcategory STRING, price_usd DOUBLE, price_raw STRING, rating DOUBLE,
+        rating_raw STRING, review_count INT, review_count_raw STRING,
+        product_url STRING, source_url STRING, observed_at STRING,
+        chunk_id STRING, run_id STRING)""",
+    """CREATE TABLE IF NOT EXISTS {s}.review_themes (
+        sku_key STRING, product_name STRING, retailer STRING, found BOOLEAN,
+        kind STRING, theme STRING, quote STRING, quote_source_url STRING,
+        run_id STRING, observed_at STRING)""",
+    """CREATE TABLE IF NOT EXISTS {s}.gaps (
+        gap_id STRING, gap_statement STRING, price_band STRING, subcategory STRING,
+        demand_evidence STRING, verdict STRING, evidence_summary STRING,
+        closest_matches STRING, verify_run_id STRING, interaction_id STRING,
+        linear_issue_id STRING, linear_issue_url STRING, created_at TIMESTAMP)""",
+    """CREATE TABLE IF NOT EXISTS {s}.merch_rules (
+        rule STRING, taught_at TIMESTAMP)""",
+]
+
+
+def connect():
+    return dbsql.connect(server_hostname=C.DBX_HOST, http_path=C.DBX_HTTP_PATH,
+                         access_token=C.DBX_TOKEN)
+
+
+def setup():
+    with connect() as conn, conn.cursor() as cur:
+        for stmt in DDL:
+            cur.execute(stmt.format(s=C.DBX_SCHEMA))
+        cur.execute(f"SHOW TABLES IN {C.DBX_SCHEMA}")
+        print(f"{len(cur.fetchall())} tables ready in {C.DBX_SCHEMA}")
+
+
+def insert_rows(table, rows):
+    """Parameterized batch insert."""
+    if not rows:
+        return
+    cols = list(rows[0].keys())
+    ph = ", ".join(["?"] * len(cols))
+    with connect() as conn, conn.cursor() as cur:
+        cur.executemany(
+            f"INSERT INTO {C.DBX_SCHEMA}.{table} ({', '.join(cols)}) VALUES ({ph})",
+            [[r[c] for c in cols] for r in rows])
+
+
+def query(sql_text, params=None):
+    with connect() as conn, conn.cursor() as cur:
+        cur.execute(sql_text, params or [])
+        cols = [d[0] for d in cur.description]
+        return cols, cur.fetchall()
+
+
+if __name__ == "__main__":
+    setup()

--- a/apps/assortment-gap-finder/delta.py
+++ b/apps/assortment-gap-finder/delta.py
@@ -57,21 +57,26 @@ def insert_rows(table, rows):
 
 
 def replace_rows(table, rows):
-    """Atomic refresh: stage into a temp table, then one INSERT OVERWRITE.
-    A crash mid-load leaves the live table untouched."""
+    """Atomic refresh: stage into a per-call staging table, then one INSERT OVERWRITE.
+    A crash mid-load leaves the live table untouched. Empty input is a no-op:
+    a refresh with nothing to load must never wipe live data."""
+    if not rows:
+        print(f"replace_rows({table}): no rows to load - live table left untouched")
+        return
+    import uuid
+    staging = f"{table}_staging_{uuid.uuid4().hex[:8]}"  # per-call: concurrent refreshes cannot race
+    cols = list(rows[0].keys())
+    ph = ", ".join(["?"] * len(cols))
     with connect() as conn, conn.cursor() as cur:
-        cur.execute(f"CREATE TABLE IF NOT EXISTS {C.DBX_SCHEMA}.{table}_staging LIKE {C.DBX_SCHEMA}.{table}")
-        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.{table}_staging")
-        if rows:
-            cols = list(rows[0].keys())
-            ph = ", ".join(["?"] * len(cols))
+        try:
+            cur.execute(f"CREATE TABLE {C.DBX_SCHEMA}.{staging} LIKE {C.DBX_SCHEMA}.{table}")
             cur.executemany(
-                f"INSERT INTO {C.DBX_SCHEMA}.{table}_staging ({', '.join(cols)}) VALUES ({ph})",
+                f"INSERT INTO {C.DBX_SCHEMA}.{staging} ({', '.join(cols)}) VALUES ({ph})",
                 [[r[c] for c in cols] for r in rows])
             cur.execute(f"INSERT OVERWRITE {C.DBX_SCHEMA}.{table} "
-                        f"SELECT {', '.join(cols)} FROM {C.DBX_SCHEMA}.{table}_staging")
-        else:
-            cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.{table}")
+                        f"SELECT {', '.join(cols)} FROM {C.DBX_SCHEMA}.{staging}")
+        finally:
+            cur.execute(f"DROP TABLE IF EXISTS {C.DBX_SCHEMA}.{staging}")
 
 
 def query(sql_text, params=None):

--- a/apps/assortment-gap-finder/discover.py
+++ b/apps/assortment-gap-finder/discover.py
@@ -97,11 +97,8 @@ def load_to_delta():
         "product_url": r.get("product_url"), "source_url": r.get("source_url"),
         "observed_at": r.get("observed_at"), "chunk_id": r["_chunk"], "run_id": r["_run"],
     } for r in best.values()]
-    with delta.connect() as conn, conn.cursor() as cur:
-        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.catalog")
-        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.discovery_runs")
-    delta.insert_rows("catalog", catalog)
-    delta.insert_rows("discovery_runs", run_meta)
+    delta.replace_rows("catalog", catalog)
+    delta.replace_rows("discovery_runs", run_meta)
     print(f"catalog: {len(catalog)} distinct SKUs from "
           f"{sum(m['item_count'] for m in run_meta)} raw rows across {len(run_meta)} chunks")
 

--- a/apps/assortment-gap-finder/discover.py
+++ b/apps/assortment-gap-finder/discover.py
@@ -1,0 +1,123 @@
+"""Discovery batch: 6 Amazon chunks -> 300+ SKUs into Delta. Resumable.
+
+Usage: python discover.py [chunk_id ...]   (no args = all chunks not yet on disk)
+"""
+import json
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+import config as C
+import delta
+import wsa
+
+STOP_TOKENS = re.compile(
+    r"\b(black|white|red|silver|stainless(?:\s+steel)?|gray|grey|matte|chrome|"
+    r"\d+\s*(?:oz|ounce|cup|cups|pack)|20\d\d)\b")
+
+
+def sku_key(row):
+    """(retailer, canonical id or normalized model name)."""
+    url = row.get("product_url") or ""
+    m = re.search(r"/dp/([A-Z0-9]{10})", url) or re.search(r"/ip/(\d+)", url) or \
+        re.search(r"/A-(\d+)", url)
+    if m:
+        return f"{row.get('retailer', 'amazon')}:{m.group(1)}"
+    name = STOP_TOKENS.sub("", str(row.get("product_name", "")).lower())
+    name = re.sub(r"[^a-z0-9]+", "-", name).strip("-")
+    return f"{row.get('retailer', 'amazon')}:{row.get('brand', '')}:{name}".lower()
+
+
+def parse_num(s, cast=float):
+    if s is None:
+        return None
+    m = re.search(r"[\d,]+(?:\.\d+)?", str(s))
+    if not m:
+        return None
+    try:
+        return cast(float(m.group(0).replace(",", "")))
+    except ValueError:
+        return None
+
+
+def one_chunk(agent_id, chunk_id, scope, goal):
+    out = C.RAW_DIR / f"discover_{chunk_id}.json"
+    if out.exists():
+        return chunk_id, "skipped (exists)", 0, 0
+    prompt = (f"{scope} on amazon.com - at least {goal} distinct products. Cover the whole "
+              f"price range and paginate beyond the first results page. Category context: {C.CATEGORY}.")
+    for attempt in (1, 2):
+        t0 = time.time()
+        try:
+            run = wsa.start_run(agent_id, prompt, sources=C.AMAZON_SOURCES)
+            result, run_final = wsa.wait_for_result(agent_id, run["id"])
+            rows = result["output"]["content"]
+            out.write_text(json.dumps({"run_id": run["id"], "chunk_id": chunk_id,
+                                       "wall_clock_s": int(time.time() - t0),
+                                       "result": result}, indent=1))
+            return chunk_id, "ok", len(rows), int(time.time() - t0)
+        except Exception as e:
+            print(f"  ! {chunk_id} attempt {attempt}: {e}", flush=True)
+            time.sleep(10)
+    return chunk_id, "FAILED after 2 attempts", 0, 0
+
+
+def load_to_delta():
+    """Dedup across all raw chunk files and rewrite the catalog table."""
+    best = {}
+    run_meta = []
+    for f in sorted(C.RAW_DIR.glob("discover_*.json")):
+        d = json.loads(f.read_text())
+        rows = d["result"]["output"]["content"]
+        run_meta.append({"chunk_id": d["chunk_id"], "retailer": "amazon",
+                         "subcategory": d["chunk_id"], "run_id": d["run_id"],
+                         "status": "completed", "item_count": len(rows),
+                         "wall_clock_s": d.get("wall_clock_s"), "error": None,
+                         "completed_at": datetime.now(timezone.utc)})
+        for r in rows:
+            if not isinstance(r, dict) or not r.get("product_name"):
+                continue
+            k = sku_key(r)
+            rc = parse_num(r.get("review_count"), int) or 0
+            prev = best.get(k)
+            if prev and (parse_num(prev.get("review_count"), int) or 0) >= rc:
+                continue
+            r["_key"], r["_chunk"], r["_run"] = k, d["chunk_id"], d["run_id"]
+            best[k] = r
+    catalog = [{
+        "sku_key": r["_key"], "product_name": r.get("product_name"),
+        "brand": r.get("brand"), "retailer": r.get("retailer", "amazon"),
+        "subcategory": r.get("subcategory"),
+        "price_usd": parse_num(r.get("price_usd")), "price_raw": r.get("price_usd"),
+        "rating": parse_num(r.get("rating")), "rating_raw": r.get("rating"),
+        "review_count": parse_num(r.get("review_count"), int),
+        "review_count_raw": r.get("review_count"),
+        "product_url": r.get("product_url"), "source_url": r.get("source_url"),
+        "observed_at": r.get("observed_at"), "chunk_id": r["_chunk"], "run_id": r["_run"],
+    } for r in best.values()]
+    with delta.connect() as conn, conn.cursor() as cur:
+        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.catalog")
+        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.discovery_runs")
+    delta.insert_rows("catalog", catalog)
+    delta.insert_rows("discovery_runs", run_meta)
+    print(f"catalog: {len(catalog)} distinct SKUs from "
+          f"{sum(m['item_count'] for m in run_meta)} raw rows across {len(run_meta)} chunks")
+
+
+def main():
+    agent = C.agent_id("catalog_discovery")
+    wanted = sys.argv[1:] or [c[0] for c in C.CHUNKS]
+    jobs = [(cid, scope, goal) for cid, scope, goal in C.CHUNKS if cid in wanted]
+    print(f"{len(jobs)} chunks (3 concurrent)")
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        futures = [pool.submit(one_chunk, agent, *j) for j in jobs]
+        for i, fut in enumerate(as_completed(futures), 1):
+            cid, status, n, secs = fut.result()
+            print(f"[{i}/{len(jobs)}] {cid}: {status} ({n} items, {secs}s)", flush=True)
+    load_to_delta()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/assortment-gap-finder/gaps.py
+++ b/apps/assortment-gap-finder/gaps.py
@@ -1,0 +1,79 @@
+"""Catalog whitespace math: find empty/weak cells in subcategory x price band x rating.
+
+Zero API runs - pure SQL over the Delta catalog. Produces candidate gap cells that
+the synthesis loop turns into verified gap statements.
+
+Usage: python gaps.py   # prints the whitespace report
+"""
+import config as C
+import delta
+
+BAND_SQL = """
+CASE
+  WHEN price_usd < 50 THEN '<$50'
+  WHEN price_usd < 150 THEN '$50-150'
+  WHEN price_usd < 400 THEN '$150-400'
+  ELSE '$400+'
+END"""
+
+
+def normalize_subcat_sql():
+    """Map free-text subcategory values onto the six chunk families."""
+    return """
+    CASE
+      WHEN LOWER(CONCAT(COALESCE(subcategory, ''), ' ', chunk_id)) RLIKE 'espresso' THEN 'espresso'
+      WHEN LOWER(CONCAT(COALESCE(subcategory, ''), ' ', chunk_id)) RLIKE 'single|pod|k-cup' THEN 'single-serve'
+      WHEN LOWER(CONCAT(COALESCE(subcategory, ''), ' ', chunk_id)) RLIKE 'drip' THEN 'drip'
+      WHEN LOWER(CONCAT(COALESCE(subcategory, ''), ' ', chunk_id)) RLIKE 'french|pour|moka|specialty' THEN 'specialty'
+      WHEN LOWER(CONCAT(COALESCE(subcategory, ''), ' ', chunk_id)) RLIKE 'cold|iced' THEN 'cold-brew'
+      WHEN LOWER(CONCAT(COALESCE(subcategory, ''), ' ', chunk_id)) RLIKE 'combo|grind|dual' THEN 'combo'
+      ELSE 'other'
+    END"""
+
+
+def whitespace_cells():
+    """Every (subcategory, band) cell with counts + quality stats."""
+    cols, rows = delta.query(f"""
+        SELECT {normalize_subcat_sql()} AS subcat, {BAND_SQL} AS band,
+               COUNT(*) AS n_products,
+               SUM(CASE WHEN rating >= 4.2 THEN 1 ELSE 0 END) AS n_wellrated,
+               ROUND(AVG(rating), 2) AS avg_rating,
+               MAX(review_count) AS max_reviews
+        FROM {C.DBX_SCHEMA}.catalog
+        WHERE price_usd IS NOT NULL
+        GROUP BY 1, 2
+        ORDER BY 1, 2""")
+    return cols, rows
+
+
+def candidate_cells(min_products=3, min_wellrated=1):
+    """Cells that look like whitespace: few products, or none well-rated.
+
+    A cell with products but zero rated >=4.2 is a QUALITY gap (demand exists,
+    nothing satisfies it) - usually the more interesting story than a bare empty cell.
+    """
+    cols, rows = whitespace_cells()
+    idx = {c: i for i, c in enumerate(cols)}
+    out = []
+    for r in rows:
+        subcat, band = r[idx["subcat"]], r[idx["band"]]
+        n, wr = r[idx["n_products"]], r[idx["n_wellrated"]]
+        if subcat == "other":
+            continue
+        if n < min_products:
+            out.append({"subcat": subcat, "band": band, "kind": "assortment gap",
+                        "detail": f"only {n} products in cell"})
+        elif wr < min_wellrated:
+            out.append({"subcat": subcat, "band": band, "kind": "quality gap",
+                        "detail": f"{n} products, none rated >=4.2"})
+    return out
+
+
+if __name__ == "__main__":
+    cols, rows = whitespace_cells()
+    print(f"{'subcat':13}{'band':10}{'n':>4}{'4.2+':>6}{'avg':>6}{'maxRev':>8}")
+    for r in rows:
+        print(f"{str(r[0]):13}{str(r[1]):10}{r[2]:>4}{r[3]:>6}{str(r[4]):>6}{str(r[5]):>8}")
+    print("\ncandidates:")
+    for c in candidate_cells():
+        print(" ", c)

--- a/apps/assortment-gap-finder/linear_client.py
+++ b/apps/assortment-gap-finder/linear_client.py
@@ -1,0 +1,66 @@
+"""Linear GraphQL client: file verified gaps as issues."""
+import os
+
+import requests
+
+API = "https://api.linear.app/graphql"
+
+
+def _gql(query, variables=None):
+    r = requests.post(API, json={"query": query, "variables": variables or {}},
+                      headers={"Authorization": os.environ["LINEAR_API_KEY"],
+                               "Content-Type": "application/json"}, timeout=30)
+    r.raise_for_status()
+    d = r.json()
+    if "errors" in d:
+        raise RuntimeError(d["errors"][0].get("message"))
+    return d["data"]
+
+
+def team_id():
+    key = os.environ["LINEAR_TEAM_KEY"]
+    teams = _gql("{ teams { nodes { id key } } }")["teams"]["nodes"]
+    for t in teams:
+        if t["key"] == key:
+            return t["id"]
+    raise RuntimeError(f"Linear team key {key} not found (have: {[t['key'] for t in teams]})")
+
+
+def file_gap_ticket(gap_statement, verdict, evidence_summary, demand_evidence,
+                    closest_matches, citation_urls):
+    """Create one Linear issue for a verified gap. Returns (identifier, url)."""
+    closest = "\n".join(
+        f"- {m.get('product_name')} ({m.get('price_usd') or '?'}, rating {m.get('rating') or '?'}) - "
+        f"{m.get('why_close_but_not_matching') or ''} {m.get('product_url')}"
+        for m in (closest_matches or [])[:5])
+    cites = "\n".join(f"- {u}" for u in (citation_urls or [])[:6])
+    body = f"""## Assortment gap ({verdict})
+
+**{gap_statement}**
+
+### Customer demand evidence
+{demand_evidence or '(from catalog whitespace analysis)'}
+
+### Live-shelf verification
+{evidence_summary}
+
+### Closest existing products
+{closest or '(none found)'}
+
+### Sources
+{cites or '(see app)'}
+
+_Filed automatically by Assortment Gap Finder (Nimble Web Search Agents)._"""
+    data = _gql("""
+        mutation($input: IssueCreateInput!) {
+          issueCreate(input: $input) { success issue { identifier url } }
+        }""", {"input": {"teamId": team_id(),
+                         "title": f"[Gap] {gap_statement[:120]}",
+                         "description": body}})
+    issue = data["issueCreate"]["issue"]
+    return issue["identifier"], issue["url"]
+
+
+if __name__ == "__main__":
+    import config  # noqa: F401
+    print("team id:", team_id())

--- a/apps/assortment-gap-finder/mine.py
+++ b/apps/assortment-gap-finder/mine.py
@@ -1,0 +1,87 @@
+"""Targeted review mining: SKUs adjacent to candidate gap cells, 4 per run.
+
+Usage: python mine.py           # picks ~10 SKUs from candidate cells, runs, loads Delta
+"""
+import json
+import time
+from datetime import datetime, timezone
+
+import config as C
+import delta
+import gaps
+import wsa
+
+PER_RUN = 4
+MAX_SKUS = 12
+
+
+def pick_targets():
+    """Top-reviewed SKUs in (or adjacent to) each candidate cell."""
+    cands = gaps.candidate_cells()
+    if not cands:
+        cands = [{"subcat": "espresso", "band": "$50-150"}]  # sane default
+    targets, seen = [], set()
+    for c in cands:
+        _, rows = delta.query(f"""
+            SELECT product_name, product_url, sku_key
+            FROM {C.DBX_SCHEMA}.catalog
+            WHERE {gaps.normalize_subcat_sql()} = ?
+            ORDER BY review_count DESC NULLS LAST LIMIT 4""", [c["subcat"]])
+        for name, url, key in rows:
+            if key not in seen:
+                seen.add(key)
+                targets.append({"name": name, "url": url, "key": key, "cell": c})
+        if len(targets) >= MAX_SKUS:
+            break
+    return targets[:MAX_SKUS]
+
+
+def run_batch(agent_id, batch):
+    lines = "\n".join(f"- {t['name']} ({t['url']})" for t in batch)
+    prompt = (f"Review themes for the following products on amazon.com. For each: the 2-4 most "
+              f"recurring complaint themes and 2-3 praise themes with VERBATIM quotes and review-page "
+              f"source URLs.\n{lines}")
+    run = wsa.start_run(agent_id, prompt)
+    result, _ = wsa.wait_for_result(agent_id, run["id"])
+    return run["id"], result
+
+
+def main():
+    agent = C.agent_id("review_miner")
+    targets = pick_targets()
+    print(f"mining {len(targets)} SKUs in batches of {PER_RUN}")
+    url_to_key = {t["url"]: t["key"] for t in targets}
+    name_to_key = {t["name"].lower(): t["key"] for t in targets}
+    theme_rows = []
+    for i in range(0, len(targets), PER_RUN):
+        batch = targets[i:i + PER_RUN]
+        t0 = time.time()
+        run_id, result = run_batch(agent, batch)
+        (C.RAW_DIR / f"mine_{i // PER_RUN}.json").write_text(json.dumps(
+            {"run_id": run_id, "result": result}, indent=1))
+        rows = result["output"]["content"]
+        for r in rows:
+            if not isinstance(r, dict):
+                continue
+            key = url_to_key.get(r.get("product_url")) or name_to_key.get(
+                str(r.get("product_name", "")).lower()) or r.get("product_name")
+            for kind, arr in (("complaint", r.get("top_complaints") or []),
+                              ("praise", r.get("top_praise") or [])):
+                for t in arr:
+                    if isinstance(t, dict):
+                        theme_rows.append({
+                            "sku_key": key, "product_name": r.get("product_name"),
+                            "retailer": r.get("retailer", "amazon"),
+                            "found": bool(r.get("found", True)), "kind": kind,
+                            "theme": t.get("theme"), "quote": t.get("representative_quote"),
+                            "quote_source_url": t.get("source_url"), "run_id": run_id,
+                            "observed_at": r.get("observed_at")})
+        print(f"batch {i // PER_RUN}: {len(rows)} SKUs in {int(time.time() - t0)}s")
+    with delta.connect() as conn, conn.cursor() as cur:
+        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.review_themes")
+    delta.insert_rows("review_themes", theme_rows)
+    print(f"loaded {len(theme_rows)} theme rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/assortment-gap-finder/mine.py
+++ b/apps/assortment-gap-finder/mine.py
@@ -77,9 +77,7 @@ def main():
                             "quote_source_url": t.get("source_url"), "run_id": run_id,
                             "observed_at": r.get("observed_at")})
         print(f"batch {i // PER_RUN}: {len(rows)} SKUs in {int(time.time() - t0)}s")
-    with delta.connect() as conn, conn.cursor() as cur:
-        cur.execute(f"DELETE FROM {C.DBX_SCHEMA}.review_themes")
-    delta.insert_rows("review_themes", theme_rows)
+    delta.replace_rows("review_themes", theme_rows)
     print(f"loaded {len(theme_rows)} theme rows")
 
 

--- a/apps/assortment-gap-finder/requirements.txt
+++ b/apps/assortment-gap-finder/requirements.txt
@@ -1,0 +1,7 @@
+requests
+python-dotenv
+databricks-sql-connector
+openai-agents[litellm]
+litellm[proxy]  # litellm's tool-calling path imports proxy modules (fastapi, orjson, ...) it does not declare
+streamlit
+pandas

--- a/apps/assortment-gap-finder/setup_agents.py
+++ b/apps/assortment-gap-finder/setup_agents.py
@@ -1,0 +1,222 @@
+"""Create the three production agents (idempotent via agents.json)."""
+import json
+
+import requests
+
+import config as C
+
+H = {"Authorization": f"Bearer {C.NIMBLE_API_KEY}"}
+
+CATALOG_DISCOVERY = {
+    "display_name": "AGF Catalog Discovery",
+    "description": "Discovers the full catalog of a retail category on one retailer at high recall.",
+    "icon": "🛒",
+    "use_case": "dataset_building",
+    "effort": "high",
+    "domain_expertise": """# Retail Catalog Discovery — Domain Expertise
+
+You are a digital-shelf analyst building a complete catalog of products in a retail category on a specific retailer's site.
+
+## Coverage
+- The category, subcategory, and retailer come from the prompt. Enumerate category browse pages, search results, and best-seller lists; paginate — do not stop at the first results page.
+- Recall targets in the prompt (e.g. 'at least 40 distinct products') are hard minimums; keep expanding subcategories and price points until met.
+
+## Row rules
+- One row per distinct product model. Deduplicate color/size variants into one row (keep the most-reviewed variant's URL).
+- price_usd, rating, review_count copied verbatim from the product listing as strings. Use null when not shown, never omit the field.
+- product_url must be a direct product-detail-page URL on the retailer's site.
+- Include source_url (the listing/search page where found) and observed_at (ISO 8601).
+- Never invent data - omit a product rather than guess. All numeric-looking fields (price, rating, review counts) are strings copied from the page.""",
+    "goals": [
+        "Meets the minimum distinct-product count stated in the prompt (e.g. at least 40 distinct products)",
+        "Covers the category beyond the first results page - spans subcategories and price points",
+        "One row per distinct product model with variants deduplicated",
+        "Every row has a direct product_url on the retailer's own site",
+        "price_usd, rating, review_count are strings copied from the page; null when not shown, never invented",
+        "Every row includes source_url and observed_at (ISO 8601)",
+    ],
+    "sources": C.AMAZON_SOURCES,
+    "output_schema": {
+        "type": "array",
+        "description": "One row per distinct product in the category on the retailer.",
+        "items": {
+            "type": "object",
+            "required": ["product_name", "brand", "retailer", "product_url", "source_url", "observed_at"],
+            "properties": {
+                "product_name": {"type": "string"},
+                "brand": {"type": "string"},
+                "retailer": {"type": "string", "description": "amazon | walmart | target"},
+                "subcategory": {"type": ["string", "null"], "description": "e.g. drip, espresso, single-serve, french-press"},
+                "price_usd": {"type": ["string", "null"], "description": "Current price as shown, string, e.g. '129.99'"},
+                "rating": {"type": ["string", "null"], "description": "Avg star rating as shown, string, e.g. '4.6'"},
+                "review_count": {"type": ["string", "null"], "description": "Review count as shown, string, e.g. '12,483'"},
+                "product_url": {"type": "string"},
+                "source_url": {"type": "string"},
+                "observed_at": {"type": "string", "description": "ISO 8601"},
+            },
+            "additionalProperties": True,
+        },
+    },
+    "suggested_questions": [
+        "Coffee makers on amazon.com - at least 40 distinct products across drip, espresso, and single-serve",
+        "Espresso machines under $200 on walmart.com - at least 30 distinct products",
+        "Single-serve coffee makers on target.com - full catalog",
+    ],
+}
+
+REVIEW_MINER = {
+    "display_name": "AGF Review Miner",
+    "description": "Mines recurring review complaint/praise themes with verbatim quotes for known SKUs.",
+    "icon": "🔍",
+    "use_case": "enrichment",
+    "effort": "high",
+    "domain_expertise": """# Review Theme Mining — Domain Expertise
+
+You are a consumer-insights analyst mining customer reviews for a known list of products.
+
+## Per product
+- Locate the product's page and its customer reviews on the retailer named in the prompt.
+- Read enough reviews (prioritize recent + critical) to identify recurring themes, not one-off gripes.
+- top_complaints: the 2-4 most recurring negative themes. top_praise: the 2-3 most recurring positive themes.
+- representative_quote must be a VERBATIM customer sentence copied from a real review - never paraphrase, never fabricate. source_url is the URL of the review page where the quote appears.
+- avg_rating and review_count as strings exactly as shown on the page; null if not shown.
+- If a product cannot be found, return its row with found=false and empty theme arrays - never omit a product.""",
+    "goals": [
+        "Returns one row per product in the input list - never omits a product (found=false when not located)",
+        "top_complaints has 2-4 recurring negative themes per found product, each with a verbatim representative_quote and the source_url of the review page",
+        "top_praise has 2-3 recurring positive themes per found product with verbatim quotes and source URLs",
+        "Quotes are copied verbatim from real customer reviews - never paraphrased or invented",
+        "avg_rating and review_count are strings as shown on the page; null when not shown",
+    ],
+    "sources": {
+        "allow": [{"title": "Amazon", "domains": ["amazon.com", "www.amazon.com"], "order": 0}],
+        "block": [],
+        "avoid": "editorial review blogs and affiliate roundups",
+        "prioritize": "the retailer's own customer review pages for the exact product",
+    },
+    "output_schema": {
+        "type": "array",
+        "description": "One row per input product.",
+        "items": {
+            "type": "object",
+            "required": ["product_name", "retailer", "found", "top_complaints", "top_praise", "observed_at"],
+            "properties": {
+                "product_name": {"type": "string"},
+                "retailer": {"type": "string"},
+                "found": {"type": "boolean"},
+                "product_url": {"type": ["string", "null"]},
+                "avg_rating": {"type": ["string", "null"]},
+                "review_count": {"type": ["string", "null"]},
+                "top_complaints": {"type": "array", "items": {"type": "object",
+                    "required": ["theme", "representative_quote", "source_url"],
+                    "properties": {
+                        "theme": {"type": "string"},
+                        "theme_frequency_note": {"type": ["string", "null"]},
+                        "representative_quote": {"type": "string"},
+                        "source_url": {"type": "string"}},
+                    "additionalProperties": True}},
+                "top_praise": {"type": "array", "items": {"type": "object",
+                    "required": ["theme", "representative_quote", "source_url"],
+                    "properties": {
+                        "theme": {"type": "string"},
+                        "representative_quote": {"type": "string"},
+                        "source_url": {"type": "string"}},
+                    "additionalProperties": True}},
+                "observed_at": {"type": "string"},
+            },
+            "additionalProperties": True,
+        },
+    },
+    "suggested_questions": [
+        "Review themes for Ninja DualBrew Pro CFP301 and Keurig K-Elite on amazon.com",
+        "Top complaints for Breville Bambino Plus on amazon.com with verbatim quotes",
+        "Review themes for Keurig K-Compact and Mr. Coffee 12-Cup on walmart.com",
+    ],
+}
+
+WHITESPACE_VERIFIER = {
+    "display_name": "AGF Whitespace Verifier",
+    "description": "Verifies whether a hypothesized assortment gap truly exists on a retailer's live shelf.",
+    "icon": "🧭",
+    "use_case": "research",
+    "effort": "max",
+    "domain_expertise": """# Assortment Whitespace Verification — Domain Expertise
+
+You are a merchandising analyst verifying assortment-gap hypotheses against a retailer's live shelf.
+
+## Method
+- The prompt states a gap hypothesis, e.g. 'no espresso machine under $150 with an integrated milk frother rated 4.2+ exists on target.com'.
+- Search the named retailer's live catalog exhaustively for counterexamples before ruling. A single in-stock counterexample refutes the gap.
+- verdict: 'confirmed' (no counterexample found after thorough search), 'refuted' (counterexample found), or 'partial' (near-misses exist; explain the nearest miss).
+- closest_matches: the 2-5 products closest to the gap spec, with price, rating, and URL as shown on the page (strings).
+- Distinguish 'not found after thorough search' from 'confirmed absent' in the evidence_summary. Never invent products or prices; cite every claim.
+
+## Taught merchandising rules
+- Always segment analysis by price band; a gap statement must name its price band.""",
+    "goals": [
+        "States a verdict of exactly 'confirmed', 'refuted', or 'partial' for the gap hypothesis",
+        "Searches the named retailer's live shelf for counterexamples before ruling - never rules from general knowledge",
+        "Lists 2-5 closest_matches with price, rating, and a direct product URL, all copied from the page",
+        "evidence_summary explains the ruling and distinguishes 'not found after thorough search' from 'confirmed absent'",
+        "Every claim carries a source URL; never invents products, prices, or ratings",
+    ],
+    "sources": {
+        "allow": [
+            {"title": "Target", "domains": ["target.com", "www.target.com"], "order": 0},
+            {"title": "Walmart", "domains": ["walmart.com", "www.walmart.com"], "order": 1},
+            {"title": "Amazon", "domains": ["amazon.com", "www.amazon.com"], "order": 2},
+        ],
+        "block": [],
+        "avoid": "affiliate roundups and price aggregators",
+        "prioritize": "the retailer named in the hypothesis - its live search and category pages",
+    },
+    "output_schema": {
+        "type": "object",
+        "required": ["gap_statement", "verdict", "closest_matches", "evidence_summary", "observed_at"],
+        "properties": {
+            "gap_statement": {"type": "string"},
+            "verdict": {"type": "string", "enum": ["confirmed", "refuted", "partial"]},
+            "closest_matches": {"type": "array", "items": {"type": "object",
+                "required": ["product_name", "product_url"],
+                "properties": {
+                    "product_name": {"type": "string"},
+                    "brand": {"type": ["string", "null"]},
+                    "price_usd": {"type": ["string", "null"]},
+                    "rating": {"type": ["string", "null"]},
+                    "why_close_but_not_matching": {"type": ["string", "null"]},
+                    "product_url": {"type": "string"}},
+                "additionalProperties": True}},
+            "evidence_summary": {"type": "string"},
+            "observed_at": {"type": "string"},
+        },
+        "additionalProperties": True,
+    },
+    "suggested_questions": [
+        "Verify: no espresso machine under $150 with an integrated milk frother rated 4.2+ exists on target.com",
+        "Verify: no 12-cup drip coffee maker with a thermal carafe under $80 exists on walmart.com",
+        "Verify: every single-serve machine under $60 on amazon.com has recurring leak complaints",
+    ],
+}
+
+
+def create(cfg):
+    r = requests.post(f"{C.BASE_URL}/task-agents", headers=H, json=cfg, timeout=120)
+    r.raise_for_status()
+    return r.json()["id"]
+
+
+def main():
+    if C.AGENTS_FILE.exists():
+        print(f"agents.json exists - reusing {json.loads(C.AGENTS_FILE.read_text())}")
+        return
+    ids = {
+        "catalog_discovery": create(CATALOG_DISCOVERY),
+        "review_miner": create(REVIEW_MINER),
+        "whitespace_verifier": create(WHITESPACE_VERIFIER),
+    }
+    C.AGENTS_FILE.write_text(json.dumps(ids, indent=2))
+    print("created:", ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/assortment-gap-finder/synth.py
+++ b/apps/assortment-gap-finder/synth.py
@@ -1,0 +1,131 @@
+"""The agentic synthesis loop: whitespace + review themes -> gap hypotheses ->
+live-shelf verification -> Linear tickets.
+
+Claude (via the OpenAI Agent SDK + LiteLLM) owns judgment: which cells matter, how to
+phrase each gap, whether the verification verdict justifies a ticket. The tools do the
+deterministic work.
+
+Usage: python synth.py [--max-gaps 5]
+"""
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+
+from agents import Agent, Runner, function_tool, set_tracing_disabled
+set_tracing_disabled(True)  # no OpenAI key; tracing would warn every run
+from agents.extensions.models.litellm_model import LitellmModel
+
+import config as C
+import delta
+import gaps as gaps_mod
+import linear_client
+import wsa
+
+MAX_GAPS = int(sys.argv[sys.argv.index("--max-gaps") + 1]) if "--max-gaps" in sys.argv else 5
+filed = []
+
+
+@function_tool
+def get_whitespace_report() -> str:
+    """The catalog whitespace grid (subcategory x price band: product counts, well-rated
+    counts) plus the flagged candidate cells."""
+    cols, rows = gaps_mod.whitespace_cells()
+    lines = ["subcat | band | products | rated4.2+ | avg_rating"]
+    lines += [f"{r[0]} | {r[1]} | {r[2]} | {r[3]} | {r[4]}" for r in rows]
+    lines.append("\nFlagged candidates: " + json.dumps(gaps_mod.candidate_cells()))
+    return "\n".join(lines)
+
+
+@function_tool
+def get_review_themes() -> str:
+    """Mined complaint/praise themes with verbatim customer quotes, by product."""
+    _, rows = delta.query(f"""
+        SELECT product_name, kind, theme, quote, quote_source_url
+        FROM {C.DBX_SCHEMA}.review_themes WHERE found = true ORDER BY product_name""")
+    return "\n".join(f"[{k}] {p}: {t} - \"{q}\" ({u})" for p, k, t, q, u in rows) or "(none mined)"
+
+
+@function_tool
+def verify_gap(gap_statement: str) -> str:
+    """Verify a gap hypothesis against the retailer's LIVE shelf using the
+    whitespace-verifier research agent (5-10 minutes). The statement must name a
+    price band and a retailer site, e.g. 'no espresso machine under $150 with an
+    integrated milk frother rated 4.2+ exists on target.com'."""
+    agent_id = C.agent_id("whitespace_verifier")
+    run = wsa.start_run(agent_id, f"Verify: {gap_statement}", effort="max")
+    result, run_final = wsa.wait_for_result(agent_id, run["id"], timeout_seconds=1800)
+    out = result["output"]["content"]
+    out["_run_id"] = run["id"]
+    out["_interaction_id"] = run_final.get("interaction_id")
+    out["_citations"] = [c.get("citations", [{}])[0].get("url")
+                         for c in (result["output"].get("trust") or {}).get("claims", [])[:6]]
+    (C.RAW_DIR / f"verify_{run['id'][-8:]}.json").write_text(json.dumps(result, indent=1))
+    return json.dumps(out)
+
+
+@function_tool
+def file_linear_ticket(gap_statement: str, verdict: str, evidence_summary: str,
+                       demand_evidence: str, verification_json: str) -> str:
+    """File a verified gap as a Linear ticket. verification_json is the exact string
+    returned by verify_gap. Only call for verdicts 'confirmed' or 'partial'."""
+    v = json.loads(verification_json)
+    ident, url = linear_client.file_gap_ticket(
+        gap_statement, verdict, evidence_summary, demand_evidence,
+        v.get("closest_matches"), v.get("_citations"))
+    gap_id = hashlib.md5(gap_statement.encode()).hexdigest()[:12]
+    delta.insert_rows("gaps", [{
+        "gap_id": gap_id, "gap_statement": gap_statement, "price_band": "",
+        "subcategory": "", "demand_evidence": demand_evidence, "verdict": verdict,
+        "evidence_summary": evidence_summary,
+        "closest_matches": json.dumps(v.get("closest_matches"))[:4000],
+        "verify_run_id": v.get("_run_id"), "interaction_id": v.get("_interaction_id"),
+        "linear_issue_id": ident, "linear_issue_url": url,
+        "created_at": datetime.now(timezone.utc)}])
+    filed.append(ident)
+    return f"filed {ident}: {url}"
+
+
+def taught_rules():
+    try:
+        _, rows = delta.query(f"SELECT rule FROM {C.DBX_SCHEMA}.merch_rules")
+        return "\n".join(f"- {r[0]}" for r in rows)
+    except Exception:
+        return ""
+
+
+INSTRUCTIONS = f"""You are a merchandising analyst finding real assortment gaps in the
+{C.CATEGORY} category for a retail buyer.
+
+Process, in order:
+1. get_whitespace_report - see where the catalog is thin or badly rated.
+2. get_review_themes - see what customers actually complain about (demand evidence).
+3. Synthesize up to {MAX_GAPS} specific, checkable gap hypotheses. Each MUST name a price
+   band, concrete product attributes, and a retailer site (rotate across amazon.com,
+   walmart.com, target.com). Prefer gaps where whitespace math AND customer complaints
+   point the same way - cite the quotes in your demand evidence.
+4. verify_gap for each hypothesis, one at a time.
+5. For every 'confirmed' or 'partial' verdict, file_linear_ticket with a demand_evidence
+   paragraph quoting the customer complaints verbatim.
+Refuted gaps: do not file; note what counterexample killed them.
+Finish with a short summary listing verdicts and filed tickets.
+
+Taught merchandising rules (always apply):
+{taught_rules() or '- Always segment analysis by price band.'}"""
+
+
+def main():
+    import os
+    model = LitellmModel(model="anthropic/claude-sonnet-5",
+                         api_key=os.environ["ANTHROPIC_API_KEY"])
+    agent = Agent(name="Gap Synthesizer", instructions=INSTRUCTIONS, model=model,
+                  tools=[get_whitespace_report, get_review_themes, verify_gap,
+                         file_linear_ticket])
+    result = Runner.run_sync(agent, "Find and file the top assortment gaps.",
+                             max_turns=30)
+    print("\n=== agent summary ===\n", result.final_output)
+    print("\nfiled tickets:", filed)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/assortment-gap-finder/synth.py
+++ b/apps/assortment-gap-finder/synth.py
@@ -69,11 +69,18 @@ def file_linear_ticket(gap_statement: str, verdict: str, evidence_summary: str,
                        demand_evidence: str, verification_json: str) -> str:
     """File a verified gap as a Linear ticket. verification_json is the exact string
     returned by verify_gap. Only call for verdicts 'confirmed' or 'partial'."""
+    if str(verdict).lower() not in ("confirmed", "partial"):
+        return f"refused: verdict '{verdict}' does not justify a ticket - only confirmed or partial gaps are filed"
+    gap_id = hashlib.md5(gap_statement.encode()).hexdigest()[:12]
+    _, existing = delta.query(
+        f"SELECT linear_issue_id, linear_issue_url FROM {C.DBX_SCHEMA}.gaps "
+        f"WHERE gap_id = ? AND linear_issue_id IS NOT NULL", [gap_id])
+    if existing:
+        return f"already filed as {existing[0][0]}: {existing[0][1]} (not filing a duplicate)"
     v = json.loads(verification_json)
     ident, url = linear_client.file_gap_ticket(
         gap_statement, verdict, evidence_summary, demand_evidence,
         v.get("closest_matches"), v.get("_citations"))
-    gap_id = hashlib.md5(gap_statement.encode()).hexdigest()[:12]
     delta.insert_rows("gaps", [{
         "gap_id": gap_id, "gap_statement": gap_statement, "price_band": "",
         "subcategory": "", "demand_evidence": demand_evidence, "verdict": verdict,

--- a/apps/assortment-gap-finder/wsa.py
+++ b/apps/assortment-gap-finder/wsa.py
@@ -1,0 +1,67 @@
+"""Thin client for Nimble Web Search Agents runs."""
+import time
+
+import requests
+
+import config as C
+
+H = {"Authorization": f"Bearer {C.NIMBLE_API_KEY}"}
+
+
+class RunFailed(Exception):
+    def __init__(self, msg, payload=None):
+        super().__init__(msg)
+        self.payload = payload
+
+
+def start_run(agent_id, input_text, previous_interaction_id=None, sources=None, effort="high"):
+    body = {"input": input_text, "effort": effort}  # never below high (planner bug)
+    if previous_interaction_id:
+        body["previous_interaction_id"] = previous_interaction_id
+    if sources:
+        body["sources"] = sources
+    r = requests.post(f"{C.BASE_URL}/task-agents/{agent_id}/runs", json=body, headers=H, timeout=120)
+    r.raise_for_status()
+    return r.json()
+
+
+def poll_run(agent_id, run_id):
+    r = requests.get(f"{C.BASE_URL}/task-agents/{agent_id}/runs/{run_id}", headers=H, timeout=60)
+    r.raise_for_status()
+    return r.json()
+
+
+def fetch_result(agent_id, run_id):
+    r = requests.get(f"{C.BASE_URL}/task-agents/{agent_id}/runs/{run_id}/result", headers=H, timeout=120)
+    if r.status_code == 408:
+        return None
+    r.raise_for_status()
+    return r.json()
+
+
+def wait_for_result(agent_id, run_id, on_tick=None, poll_seconds=20, timeout_seconds=1500):
+    t0 = time.time()
+    while True:
+        run = poll_run(agent_id, run_id)
+        elapsed = int(time.time() - t0)
+        if on_tick:
+            on_tick(elapsed, run["status"])
+        if not run["is_active"]:
+            break
+        if elapsed > timeout_seconds:
+            raise RunFailed(f"run {run_id} timed out after {elapsed}s")
+        time.sleep(poll_seconds)
+
+    # the result endpoint can still 408 briefly after the run turns terminal
+    result = fetch_result(agent_id, run_id)
+    for _ in range(5):
+        if result is not None:
+            break
+        time.sleep(15)
+        result = fetch_result(agent_id, run_id)
+    if run["status"] != "completed":
+        msg = (run.get("error") or {}).get("message") or run["status"]
+        raise RunFailed(f"run {run['status']}: {msg}", payload=result)
+    if result is None:
+        raise RunFailed(f"run {run_id} completed but the result never became available")
+    return result, run


### PR DESCRIPTION
Retail category in → verified assortment gaps out, filed as Linear tickets with evidence. Built on Nimble Web Search Agents (3 agents: dataset_building discovery, enrichment review-mining, max-effort research verification) + Databricks Delta + OpenAI Agent SDK/LiteLLM running Claude + Linear + Streamlit.

- 310-SKU catalog from 6 chunked, resumable discovery runs (hard source whitelist held)
- Whitespace math (pure SQL) proposes; customer quotes evidence; live-shelf verification refutes or confirms — refuted hypotheses are dropped, not filed
- Teach mechanism PATCHes merchandising rules into the verifier agent permanently
- ai-setup.md tested literally in a clean directory; Databricks catalog parameterized; litellm[proxy] dependency quirk documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)