### PR TITLE
Add LlamaIndex Tariff Desk app

### DIFF
--- a/apps/llamaindex-tariff-desk/.env.example
+++ b/apps/llamaindex-tariff-desk/.env.example
@@ -1,0 +1,34 @@
+# Copy to .env and fill in. Never commit .env.
+
+# --- required -------------------------------------------------------------
+
+# Nimble API key — https://online.nimbleway.com/settings/api-keys
+# Every fact in the corpus comes from a Nimble Web Search Agent run.
+NIMBLE_API_KEY=
+
+# Anthropic — turns a question into a canonical route key, and writes the answer
+# from the facts retrieved out of the index.
+ANTHROPIC_API_KEY=
+
+# OpenAI — embeddings only (text-embedding-3-small). Anthropic has no embeddings
+# API. Costs a fraction of a cent for a corpus this size. Every agent run works
+# without this key; only the index does not.
+OPENAI_API_KEY=
+
+# --- agent ids: written by setup_agents.py, do not fill in by hand ---------
+
+# Three agents. The two corpus agents are split because the facts age at very
+# different rates; the third is the plain-language tariff-code lookup.
+NIMBLE_RATE_AGENT_ID=
+NIMBLE_OVERLAY_AGENT_ID=
+NIMBLE_HTS_AGENT_ID=
+
+# --- optional -------------------------------------------------------------
+
+# false replays the cached runs under data/samples/ and makes no network calls.
+# true researches anything the corpus is missing.
+USE_LIVE=false
+
+# Model overrides.
+# DESK_LLM_MODEL=claude-sonnet-5
+# DESK_EMBED_MODEL=text-embedding-3-small

--- a/apps/llamaindex-tariff-desk/.gitignore
+++ b/apps/llamaindex-tariff-desk/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+.env
+__pycache__/
+*.pyc
+storage/
+data/runs/
+data/jobs/
+data/history/
+data/hts_lookups/
+data/changes.jsonl

--- a/apps/llamaindex-tariff-desk/.streamlit/config.toml
+++ b/apps/llamaindex-tariff-desk/.streamlit/config.toml
@@ -1,0 +1,9 @@
+[theme]
+base = "dark"
+primaryColor = "#edc602"
+backgroundColor = "#0e1117"
+secondaryBackgroundColor = "#1a1d24"
+textColor = "#fafafa"
+
+[browser]
+gatherUsageStats = false

--- a/apps/llamaindex-tariff-desk/README.md
+++ b/apps/llamaindex-tariff-desk/README.md
@@ -1,0 +1,201 @@
+# llamaindex-tariff-desk — Nimble × LlamaIndex
+
+![Built with Nimble + LlamaIndex](https://img.shields.io/badge/Built%20with-Nimble%20%2B%20LlamaIndex-edc602)
+
+A knowledge base that researches what it doesn't know, dates everything it holds, and refuses
+to answer from a fact that has aged out. Built on the official
+[`llama-index-tools-nimble`](https://pypi.org/project/llama-index-tools-nimble/) integration.
+
+## The integration
+
+```python
+from llama_index.tools.nimble import NimbleAgentToolSpec
+
+# Raise timeout: the default is 300s, shorter than a typical run.
+tool = NimbleAgentToolSpec(agent_id="wsa_...", effort="high", timeout=1800)
+
+doc = tool.run(
+    "Which duty overlays are in force for this tariff line?",
+    output_schema=SCHEMA,          # structured answer instead of prose
+    sources={"prioritize": "official register notices"},
+)
+
+doc.text                      # the answer, plus a Sources: list
+doc.metadata["confidence"]    # high | medium | low | pre_existing
+doc.metadata["claims"]        # per-claim citations, keyed by JSON path
+doc.metadata["run_id"]        # durable handle on the run
+```
+
+The package ships two tool specs. `NimbleToolSpec` wraps Search — one query, ranked results in
+seconds. `NimbleAgentToolSpec` runs a **Nimble Web Search Agent** — it plans, reads and
+cross-checks many sources, then returns one synthesized answer with per-claim citations.
+
+Both return LlamaIndex `Document` objects, which is why this integration fits RAG unusually well:
+research output *is* the framework's native currency, so it drops straight into an index.
+
+### Four things worth knowing before you build on it
+
+**Raise `timeout`.** It defaults to 300 seconds while the default effort takes 5–15 minutes, so an
+out-of-the-box configuration fails on runs that are working perfectly. This app uses 1800.
+
+**`run()` blocks for the whole run.** There is no start-now/collect-later split and no event stream
+through the tool, so research belongs on a background thread with its state on disk. A run that
+outlives its deadline is *not* lost: `NimbleAgentTimeoutError` carries the `run_id`, the run keeps
+going server-side, and `recover_runs.py` collects it later.
+
+**`output_schema` is what buys per-cell provenance.** With a schema, `claims` are keyed by JSON path
+(`$.additional_duties[0].rate`) so every value has its own citation. Without one they are keyed by
+prose callout and cannot be attached to a field.
+
+**`sources.allow` is a hard whitelist.** A domain left out is a domain the agent cannot read, and it
+fails silently — the gap shows up in `unverified`, not as an error. This app uses that deliberately:
+the base-rate agent may only read the official schedule.
+
+## What this cookbook builds with it
+
+A tariff desk. Ask what the duty is on a product from a country; get an answer assembled from
+cited, dated facts. If the corpus doesn't cover it, agents research it and the result joins the
+index, so the next question about it is free.
+
+Retrieval-augmented generation exists because a model's knowledge is frozen at training time. But a
+vector store built once has the same disease: it relocates the staleness from the model's weights
+into your index, where nobody notices. Ask a static index for a duty rate that changed in April and
+it answers with March's figure, confidently, forever.
+
+So the corpus here is **researched rather than uploaded, dated rather than timeless, and refreshed
+rather than fixed** — and the retrieval path withholds anything past its shelf life instead of
+serving it as current.
+
+> **A demonstration, not a compliance reference.** The shipped corpus is a snapshot of what the
+> agents found on the dates shown. Every figure carries its source and its research date; none have
+> been reviewed by a customs professional. Point it at your own products before drawing conclusions.
+
+## What it does
+
+1. **Look up the tariff code** — describe a product in plain words; an agent returns candidate
+   subheadings quoted from the official schedule, each cited. It never picks one, because
+   classification is a human decision and a wrong code yields a confidently wrong duty.
+2. **Research the facts** — two agents run per product-and-origin: one reads the base schedule rate,
+   one establishes which duty overlays are in force.
+3. **Index with provenance** — each run becomes a `Document` whose node metadata carries confidence,
+   per-claim citations, source URLs and the research date.
+4. **Answer, or decline** — a freshness guard withholds expired facts rather than answering from
+   them, and the reply states the research date and source beside every figure.
+5. **Refresh what moved** — re-research only what is past its shelf life, and log what changed.
+
+## Three agents, because the jobs differ
+
+| Agent | Reads | Effort | Shelf life |
+|---|---|---|---|
+| `tariff-schedule-rate` | official schedule (USITC), CBP | `medium` | 90 days |
+| `tariff-policy-overlay` | Federal Register, USTR, White House, CBP | `high` | 7 days |
+| `hts-code-candidates` | official schedule + CBP rulings | `medium` | cached per query |
+
+The split is not tidiness. A single run asked for both the rate *and* the overlays let the schedule
+lookup fail quietly into `unverified`; narrowing each task fixed it. And since base rates hold for
+years while overlays move constantly, separate shelf lives mean a refresh only re-researches the
+volatile half.
+
+Base rates are keyed **origin-free** — the rate belongs to the tariff code, not the route — so
+adding a new sourcing country for a code already covered costs one run, not two.
+
+The overlay agent runs at `high` because `medium` was measurably unreliable here: it listed expired
+instruments as active and, on one lane, never found the order that had terminated a duty. `high`
+found it. That is the kind of thing only measurement tells you.
+
+## Stack
+
+- [Nimble Web Search Agents](https://nimbleway.com) — every fact in the corpus
+- [`llama-index-tools-nimble`](https://pypi.org/project/llama-index-tools-nimble/) — the integration
+- [LlamaIndex](https://www.llamaindex.ai/) — ingestion, index, retrieval, response synthesis
+- [Anthropic Claude](https://www.anthropic.com) — question parsing and answer writing
+- OpenAI `text-embedding-3-small` — embeddings only
+- [Streamlit](https://streamlit.io) — UI
+
+## Setup
+
+```bash
+git clone https://github.com/Nimbleway/cookbook
+cd cookbook/apps/llamaindex-tariff-desk
+
+python -m venv .venv && ./.venv/bin/pip install -r requirements.txt
+cp .env.example .env                     # add the three API keys
+./.venv/bin/python setup_agents.py       # provisions the three agents, writes their ids
+./.venv/bin/python build_index.py        # indexes the shipped corpus (~10 seconds)
+./.venv/bin/streamlit run app.py
+```
+
+Get a Nimble API key at [nimbleway.com](https://nimbleway.com). That sequence runs against the
+cached corpus and makes no billable calls. Set `USE_LIVE=true` to research live.
+
+## Usage
+
+Ask `What's the duty on HTS 8507.60.00 from China?` and the answer separates the base schedule rate
+from each duty overlay, with the instrument, effective date, source link and research date on each.
+
+Don't know the code? Open the lookup and type `canvas sneakers with rubber soles`. Candidates come
+back quoted from the schedule; pick one and it fills the question.
+
+Ask `What's out of date?` and it answers from index metadata — no agent run, no cost.
+
+The shipped corpus contains one deliberately expired fact, so the freshness guard has something to
+catch: ask about `6109.10.00 from India` and watch it decline to answer from a stale overlay.
+
+## Project structure
+
+```
+app.py                  Streamlit UI: question box, code lookup, coverage sidebar
+setup_agents.py         provision the three agents once, verify with a GET
+prewarm.py              research a starting corpus (concurrency-capped)
+build_index.py          build or update the index; re-embeds only what changed
+refresh.py              re-research what is past its shelf life, log what moved
+recover_runs.py         collect runs that outlived their deadline
+prefetch_lookups.py     cache code lookups so the lookup box works offline
+desk/
+  agents_config.py      the three agent configs — schemas, prompts, goals, sources
+  research.py           run an agent, save raw, stay resumable
+  classify.py           plain-language product -> candidate tariff codes
+  ingest.py             run records -> Documents -> persisted index
+  freshness.py          shelf-life guard and the node postprocessor
+  router.py             lane retrieval, plus corpus questions answered from metadata
+  normalize.py          question -> canonical route key
+  delta.py              what changed between two runs of the same fact
+  models.py             LLM and embedding configuration
+tests/test_offline.py   31 tests, no API keys and no billable calls required
+data/samples/           the shipped corpus, replayed when USE_LIVE=false
+data/hts_samples/       cached code lookups for offline use
+```
+
+## Output
+
+Every answer carries, per figure:
+
+| Field | Description |
+|---|---|
+| the value | rate or duty, as the source states it |
+| `researched_at` | when an agent established it |
+| `confidence` | the run's own grade: `high`, `medium`, `low`, `pre_existing` |
+| source URL | the document it was read from |
+| `unverified` | what the agent could not confirm — shown as prominently as the answer |
+| `confirmed_absent` | overlays checked and ruled out, kept distinct from "couldn't check" |
+
+That last pair matters more than it looks. **`confidence` grades what was claimed, not what was
+covered** — a run returns `high` while leaving facts unverified. Showing gaps beside answers is the
+difference between a demo and a trap.
+
+## Going further
+
+- **Swap the domain.** Nothing here is tariff-specific except the three agent configs in
+  `desk/agents_config.py`. The pattern — research into `Document`s, index with provenance, guard on
+  shelf life, refresh the volatile half — fits any corpus whose facts expire at different rates.
+- **Tune the shelf lives.** `TTL_DAYS` in `desk/agents_config.py`. Shorter means fresher and more
+  expensive; the point is that the number is explicit rather than implied.
+- **Schedule the refresh.** `refresh.py` is idempotent and concurrency-capped, so cron works.
+- **Add a fact class.** A third `kind` with its own agent, schema and shelf life is about thirty
+  lines, and the sidebar picks it up automatically.
+
+## Requirements
+
+Python 3.10+ (required by `llama-index-tools-nimble`). Three keys: Nimble, Anthropic, OpenAI. A full
+corpus build is two agent runs per product-and-origin, a few minutes each — the shipped corpus means
+you don't need to pay for one to see the app work.

--- a/apps/llamaindex-tariff-desk/ai-setup.md
+++ b/apps/llamaindex-tariff-desk/ai-setup.md
@@ -1,0 +1,186 @@
+# Setup: Tariff Desk (Nimble × LlamaIndex)
+
+You are helping the user set up and run the Tariff Desk cookbook. Follow these steps in order.
+Check each prerequisite before proceeding. Tell the user what you're doing at each step.
+
+---
+
+## Step 1 — Check prerequisites
+
+**Python 3.10 or later.** `llama-index-tools-nimble` requires it.
+
+```bash
+python3 --version
+```
+
+If it reports 3.9 or lower, ask the user to install a newer Python (`brew install python@3.12` on
+macOS) and use that interpreter explicitly for every command below.
+
+**git**
+
+```bash
+git --version
+```
+
+Tell the user they will need three API keys, and that step 4 covers where to get each one:
+
+- **Nimble** — every fact in the corpus comes from a Nimble Web Search Agent run
+- **Anthropic** — parses the question and writes the answer from retrieved facts
+- **OpenAI** — embeddings only, a fraction of a cent for this corpus
+
+---
+
+## Step 2 — Clone the repo
+
+If a `cookbook` directory already exists, pull instead of cloning.
+
+```bash
+if [ -d cookbook ]; then cd cookbook && git pull && cd ..; else git clone https://github.com/Nimbleway/cookbook; fi
+cd cookbook/apps/llamaindex-tariff-desk
+```
+
+---
+
+## Step 3 — Install dependencies
+
+```bash
+python3 -m venv .venv
+./.venv/bin/pip install --upgrade pip
+./.venv/bin/pip install -r requirements.txt
+```
+
+Takes 1–3 minutes. Use `./.venv/bin/python` for every command from here — do not rely on an
+activated shell.
+
+Confirm the integration is present:
+
+```bash
+./.venv/bin/python -c "import llama_index.tools.nimble as m; print('ok', [n for n in dir(m) if n.endswith('ToolSpec')])"
+```
+
+Expect `ok ['NimbleAgentToolSpec', 'NimbleToolSpec']`.
+
+> `requirements.txt` pins `starlette<1` deliberately. Streamlit permits a newer Starlette that
+> breaks its own middleware, and the failure is nasty: every page returns a 500 while the health
+> endpoint stays green, so it looks like a browser or network problem. Do not relax that pin.
+
+---
+
+## Step 4 — Get API keys
+
+Tell the user where to get each key and what it is for in this app:
+
+1. **`NIMBLE_API_KEY`** — https://online.nimbleway.com/settings/api-keys (free trial available).
+   Runs the Web Search Agents that establish every tariff fact in the corpus.
+2. **`ANTHROPIC_API_KEY`** — https://console.anthropic.com/settings/keys. Turns a plain question
+   into a tariff code plus origin, and writes the final answer from the retrieved facts.
+3. **`OPENAI_API_KEY`** — https://platform.openai.com/api-keys. Embeddings only
+   (`text-embedding-3-small`). The account needs a positive balance — an unfunded key returns
+   `429 insufficient_quota` and the index cannot build.
+
+---
+
+## Step 5 — Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` and fill in the three keys:
+
+```
+NIMBLE_API_KEY=...
+ANTHROPIC_API_KEY=...
+OPENAI_API_KEY=...
+```
+
+Leave `USE_LIVE=false` for now — that replays the shipped corpus and makes no billable calls.
+Leave the three agent-id lines empty; the next step writes them.
+
+---
+
+## Step 6 — Provision the three agents
+
+```bash
+./.venv/bin/python setup_agents.py
+```
+
+Takes about 10 seconds. It creates three Web Search Agents, verifies each with a `GET`, and writes
+their ids into `.env`. Expect three `created wsa_...` lines followed by `verify:` lines showing
+non-zero `goals`, `sources.allow` and `schema=Y`.
+
+It is safe to re-run: ids already in `.env` are skipped rather than duplicated.
+
+Ask the user to confirm all three verified before continuing. If any line reports `sources.allow=0`,
+stop — source restriction is load-bearing here and an empty allow list means the agent reads the
+open web.
+
+---
+
+## Step 7 — Build the index
+
+```bash
+./.venv/bin/python build_index.py
+```
+
+Takes about 10 seconds and embeds the 17 shipped records. Expect a `document(s) added` list and a
+coverage line naming 7 tariff codes.
+
+This is the only step that needs the OpenAI key. If it fails with `insufficient_quota`, the account
+needs a balance; everything else in the app works without it.
+
+---
+
+## Step 8 — Run the app
+
+```bash
+./.venv/bin/streamlit run app.py
+```
+
+Opens on http://localhost:8501. If the page fails to load while the terminal looks healthy, check
+the Starlette pin from step 3.
+
+---
+
+## Step 9 — Orient the user
+
+Walk them through it:
+
+**The question box.** Ask about a product and where it's coming from. Try:
+
+- `What's the duty on HTS 8507.60.00 from China?` — answers instantly from the corpus, with the base
+  rate and each duty overlay separated, cited and dated
+- `What's the duty on 6109.10.00 from India?` — the shipped corpus has this one deliberately
+  expired, so the freshness guard withholds the stale overlay instead of answering from it
+- `What's out of date?` — answered from index metadata, no agent run
+- `What's the tariff on batteries from Vietnam?` — no tariff code, so it declines to guess one
+
+**The code lookup.** Expand *"Don't know the tariff code?"* and try `lithium-ion battery packs` or
+`stainless steel insulated drinks bottle` — both cached. Point out that candidates are quoted from
+the official schedule, each cited, and that the app never picks one for you.
+
+**The sidebar.** Coverage grouped by product, with each fact's age and whether it is inside its
+shelf life. The change log shows what moved the last time something was re-researched.
+
+**To see research actually happen**, set `USE_LIVE=true` in `.env`, restart, and ask about a
+product-and-origin not in the corpus. Two agent runs fire, a few minutes each, and the result joins
+the index automatically. Warn the user this costs Nimble credits.
+
+---
+
+## Notes
+
+- **Runs take minutes, not seconds.** A base-rate run is 30–90s; an overlay run at `high` effort is
+  2–5. The app runs them on background threads and shows progress; closing the tab does not cancel
+  them.
+- **A timed-out run is not a lost run.** `recover_runs.py` reconciles anything still in flight
+  against the agent's run history and files the result when it lands.
+- **Never re-submit an ambiguous create.** If a run fails with `NimbleAgentCreateAmbiguousError`, a
+  billable run may already exist with no id. Reconcile in the dashboard instead.
+- **`confidence` is not completeness.** A run returns `high` while leaving facts in `unverified`.
+  The UI shows both; so should anything built on this.
+- **Cached lookups cover six products.** Anything else needs `USE_LIVE=true`.
+- **The tests need no keys:** `./.venv/bin/python -m pytest tests/ -q` runs 31 checks against the
+  shipped corpus with no network calls.
+- **This is a demonstration, not a compliance reference.** Figures are a dated snapshot of what the
+  agents found, unreviewed by a customs professional.

--- a/apps/llamaindex-tariff-desk/app.py
+++ b/apps/llamaindex-tariff-desk/app.py
@@ -62,20 +62,31 @@ FIELD_LABELS = {
 
 
 @st.cache_resource(show_spinner=False)
+def _load_index():
+    """Configure the models and load the index. Allowed to raise.
+
+    Deliberately not catching here: Streamlit does not cache an exception, so a
+    corrected `.env` takes effect on the next rerun. Catching inside the cached
+    function stored `None` as the cached resource, which meant a reader who fixed
+    their keys kept seeing the same error until they restarted the process.
+    """
+    configure_models()
+    return ingest.load_index()
+
+
 def _index():
-    """The index, or None with the reason shown.
+    """The index, or None with the reason shown to the reader.
 
     `configure_models()` raises when a key is missing. The sidebar warns about it,
-    but a warning is not control flow — without this guard the first question after
-    a bad `.env` becomes an uncaught Streamlit traceback instead of a message the
-    reader can act on. Callers already handle None.
+    but a warning is not control flow: without this, the first question after a bad
+    `.env` is an uncaught Streamlit traceback rather than something actionable.
+    Callers already handle None.
     """
     try:
-        configure_models()
+        return _load_index()
     except RuntimeError as err:
         st.error(str(err), icon="🚫")
         return None
-    return ingest.load_index()
 
 
 @st.cache_resource(show_spinner=False)
@@ -479,7 +490,7 @@ def _run_research(lane: Lane, kinds: list[str], force: bool) -> bool:
 
         line.write(f"✅ researched in {elapsed}s — adding to the corpus")
         ingest.build_index(ingest.to_documents(ingest.load_records()))
-        _index.clear()          # the cached index handle is now stale
+        _load_index.clear()          # the cached index handle is now stale
         status.update(label=f"Researched and indexed in {elapsed}s",
                       state="complete", expanded=False)
     return True

--- a/apps/llamaindex-tariff-desk/app.py
+++ b/apps/llamaindex-tariff-desk/app.py
@@ -1,0 +1,715 @@
+"""Tariff Desk — a demo of the Nimble + LlamaIndex integration.
+
+Ask a customs question; get an answer assembled from cited, dated facts. If the
+corpus doesn't cover the lane, a Nimble Web Search Agent researches it and the
+result joins the index, so the next question about it is free.
+
+Three outcomes, and the UI always says which one you got:
+
+    from corpus          covered and inside its TTL — free, instant
+    stale -> researched  covered but past its TTL, so the guard withheld it
+    not covered -> researched   new lane; the run's Document joins the corpus
+
+The point being demonstrated: RAG fixes *private* data but not *stale* data. A
+vector store built once relocates the model's staleness into your index, where
+nobody notices. Here every fact is dated and the retrieval path refuses to answer
+from an expired one.
+
+    streamlit run app.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import streamlit as st
+from dotenv import load_dotenv
+
+HERE = Path(__file__).parent
+load_dotenv(HERE / ".env")
+sys.path.insert(0, str(HERE))
+
+from desk import classify, ingest, router  # noqa: E402
+from desk.freshness import assess, stale_report  # noqa: E402
+from desk.models import configure_models  # noqa: E402
+from desk.normalize import get_llm, normalize  # noqa: E402
+from desk.research import (  # noqa: E402
+    Lane, ResearchTask, TTL_DAYS, needs_research, open_jobs, read_job, use_live,
+)
+
+st.set_page_config(page_title="Tariff Desk", page_icon="🧾", layout="wide")
+
+# Every state names the agent, because agent research is what produces every answer
+# here — the only difference is whether it already happened. Framing a covered answer
+# as "from corpus, nothing to run" sells the cache and buries the thing doing the work.
+BADGE = {
+    "corpus": ("✅", "researched by a Nimble Web Search Agent"),
+    "stale": ("🕒", "research expired — a Nimble agent is re-checking"),
+    "new": ("🔎", "not researched yet — a Nimble Web Search Agent is on it"),
+}
+
+FIELD_LABELS = {
+    "additional_duties": "an extra duty",
+    "exclusions_in_force": "an exclusion",
+    "general_rate": "the base rate",
+    "htsus_revision": "the schedule revision",
+    "unverified": "unverified items",
+    "confirmed_absent": "ruled-out items",
+}
+
+
+@st.cache_resource(show_spinner=False)
+def _index():
+    configure_models()
+    return ingest.load_index()
+
+
+@st.cache_resource(show_spinner=False)
+def _llm():
+    return get_llm()
+
+
+# --- formatting helpers ----------------------------------------------------
+
+
+def friendly_lane(lane_key: str | None) -> str:
+    """`8507.60.00|Vietnam|United States` -> `Vietnam → United States (HTS 8507.60.00)`."""
+    if not lane_key:
+        return "unknown route"
+    parts = lane_key.split("|")
+    if len(parts) == 3:
+        code, origin, destination = parts
+        return f"{origin} → {destination} (HTS {code})"
+    if len(parts) == 2:
+        code, destination = parts
+        return f"base rate into {destination} (HTS {code})"
+    return lane_key
+
+
+def humanize_age(days: float | None) -> str:
+    """'0.04d' means nothing to a reader. '1h ago' does."""
+    if days is None:
+        return "no date recorded"
+    if days < 0.04:
+        return "just now"
+    if days < 1:
+        return f"{max(1, int(round(days * 24)))}h ago"
+    if days < 2:
+        return "yesterday"
+    return f"{int(round(days))}d ago"
+
+
+# --- sidebar ---------------------------------------------------------------
+
+
+def render_coverage(records: list[dict]) -> None:
+    """Coverage grouped by product, in the shape a person reads it.
+
+    Product name leads; the HTS code stays as supporting detail because the duty
+    attaches to the code, not the product name — an answer you can't tie back to a
+    code isn't checkable. An earlier version printed the raw storage key
+    (`8507.60.00|China|United States [overlay] · 0.04d · high`), which is data, not
+    information.
+    """
+    by_code: dict[str, dict] = {}
+    for record in records:
+        code = (record.get("lane") or {}).get("hts_code")
+        if not code:
+            continue
+        entry = by_code.setdefault(code, {"rate": None, "overlays": [], "product": ""})
+        entry["product"] = entry["product"] or (record.get("lane") or {}).get("product") or ""
+        if record.get("kind") == "rate":
+            entry["rate"] = record
+        else:
+            entry["overlays"].append(record)
+
+    for code in sorted(by_code, key=lambda c: (by_code[c]["product"] or c).lower()):
+        entry = by_code[code]
+        st.caption(f"**{(entry['product'] or 'Unnamed product').capitalize()}**")
+
+        rate = entry["rate"]
+        if rate is None:
+            st.caption(f"　🕒 HTS {code} · no base rate researched yet")
+        else:
+            verdict = assess({"kind": "rate", "researched_at": rate.get("researched_at")})
+            content = ingest.parsed_content(rate) or {}
+            st.caption(
+                f"　{'🕒' if verdict.stale else '✅'} HTS {code} · base rate "
+                f"**{content.get('general_rate') or '—'}** for any origin · "
+                f"{humanize_age(verdict.age_days)}"
+            )
+
+        for overlay in sorted(entry["overlays"],
+                              key=lambda r: (r.get("lane") or {}).get("origin") or ""):
+            meta = ingest.node_metadata(overlay)
+            verdict = assess({"kind": "overlay",
+                              "researched_at": overlay.get("researched_at")})
+            origin = (overlay.get("lane") or {}).get("origin") or "?"
+            in_force = meta.get("duties_in_force", 0)
+            gaps = len(meta.get("unverified") or [])
+
+            if verdict.stale:
+                detail = "expired — will be re-checked"
+            elif in_force:
+                detail = f"{in_force} extra dut{'y' if in_force == 1 else 'ies'}"
+            else:
+                detail = "no extra duties"
+            if gaps:
+                detail += f" · {gaps} unverified"
+
+            st.caption(
+                f"　{'🕒' if verdict.stale else '✅'} from **{origin}** · {detail} · "
+                f"{humanize_age(verdict.age_days)}"
+            )
+
+
+def render_change_log() -> None:
+    # Only substantive movement. Every refresh rewords the prose fields, so listing
+    # those says "something changed" over and over and buries the line that matters.
+    material = set(FIELD_LABELS)
+    changes = [c for c in router.load_changes(limit=6) if c.get("changes")]
+    st.subheader("What the corpus learned")
+    st.caption(
+        "Differences found the last time a fact was re-researched. Some are real "
+        "changes in the world; some are simply a deeper answer than before."
+    )
+    if not changes:
+        st.caption("No refreshes recorded yet.")
+    for entry in changes:
+        shown = [c for c in entry["changes"] if c.get("field") in material]
+        st.caption(f"**{entry['at'][:10]}** · {friendly_lane(entry.get('lane_key'))}")
+        if not shown:
+            st.caption("　wording only — no duty or exclusion changed")
+            continue
+        for change in shown[:3]:
+            label = FIELD_LABELS.get(change.get("field"),
+                                     str(change.get("field", "")).replace("_", " "))
+            if change["type"] == "added":
+                st.caption(f"　now lists {label}: {str(change.get('after'))[:80]}")
+            elif change["type"] == "removed":
+                st.caption(f"　no longer lists: {str(change.get('before'))[:80]}")
+            elif change["type"] == "coverage":
+                st.caption(f"　{label}: {change.get('before')} → {change.get('after')}")
+            else:
+                st.caption(f"　{label}: {str(change.get('before'))[:40]} → "
+                           f"{str(change.get('after'))[:40]}")
+
+
+def sidebar() -> None:
+    with st.sidebar:
+        st.header("Corpus")
+        records = ingest.load_records()
+        cov = ingest.coverage(records)
+        rows = stale_report(records)
+        stale = [r for r in rows if r["stale"]]
+
+        a, b = st.columns(2)
+        a.metric("Facts", cov["records"])
+        b.metric("Expired", len(stale))
+        st.caption(
+            f"{cov['rate_docs']} base rate(s) over {len(cov['hts_codes'])} tariff "
+            f"code(s) · {cov['overlay_docs']} route(s)"
+        )
+
+        # Default is to show it: a reader must know when they are seeing replayed runs
+        # rather than live research. `DESK_HIDE_DEMO_NOTICE` exists only so a recording
+        # isn't dominated by a banner, and it is deliberately absent from .env.example
+        # so it cannot ship switched on.
+        hide_notice = os.environ.get("DESK_HIDE_DEMO_NOTICE", "").strip().lower() in {
+            "1", "true", "yes"}
+        if not use_live() and not hide_notice:
+            st.warning("`USE_LIVE=false` — replaying cached runs. No new research.", icon="⚠️")
+        if not os.environ.get("OPENAI_API_KEY"):
+            st.error("`OPENAI_API_KEY` missing — the index cannot be built.", icon="🚫")
+
+        st.divider()
+        st.subheader("Coverage")
+        st.caption(
+            "✅ inside its TTL · 🕒 expired, re-researched before it is used. "
+            f"Base rates hold for {TTL_DAYS['rate']} days, duty overlays for "
+            f"{TTL_DAYS['overlay']}."
+        )
+        render_coverage(records)
+
+        jobs = [j for j in open_jobs() if j.get("status") in {"running", "timeout"}]
+        if jobs:
+            st.divider()
+            st.subheader("Research in flight")
+            for job in jobs:
+                st.caption(f"⏳ {friendly_lane(job.get('lane_key'))} — {job.get('status')}")
+            st.caption("Runs continue even if you close this tab.")
+
+        st.divider()
+        render_change_log()
+
+
+
+# --- code lookup -----------------------------------------------------------
+# Rough phase labels for the wait. The connector blocks for the whole run and exposes
+# no progress events, so these are time-based narration, not real status — worded so
+# they never claim to know more than they do.
+LOOKUP_PHASES = (
+    (0, "starting the research run"),
+    (12, "searching the tariff schedule"),
+    (40, "reading chapter documents and CBP rulings"),
+    (95, "assembling candidates with citations"),
+    (150, "still working — long runs happen"),
+)
+
+
+def _phase(elapsed: float) -> str:
+    label = LOOKUP_PHASES[0][1]
+    for after, text in LOOKUP_PHASES:
+        if elapsed >= after:
+            label = text
+    return label
+
+
+def _run_lookup(product: str) -> dict:
+    """Look up codes, narrating the wait.
+
+    A cached lookup returns instantly and gets no theatre. A live one takes ~2 minutes,
+    which a bare spinner makes look hung — so the run goes on a thread and the status
+    line ticks with elapsed seconds while it works.
+    """
+    hit = classify.cached(product)
+    if hit and demo_replay():
+        _replay_status(f"Looking up “{product}”…", hit.get("elapsed_s") or 90,
+                       _phase, "Reading the official schedule and CBP's rulings.")
+        return {**hit, "from_cache": True}
+    if hit:
+        return classify.find_candidates(product)
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    with st.status(f"Looking up “{product}”…", expanded=True) as status:
+        line = st.empty()
+        st.caption(
+            "Reading the official schedule and CBP's rulings. Typically 1–3 minutes."
+        )
+        started = time.monotonic()
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(classify.find_candidates, product)
+            while not future.done():
+                elapsed = time.monotonic() - started
+                line.write(f"⏳ {_phase(elapsed)} — {int(elapsed)}s elapsed")
+                time.sleep(1)
+            result = future.result()
+
+        elapsed = int(time.monotonic() - started)
+        if result.get("error"):
+            line.write(f"❌ failed after {elapsed}s")
+            status.update(label=f"Lookup failed after {elapsed}s", state="error")
+        else:
+            found = len(result.get("candidates") or [])
+            line.write(f"✅ {found} candidate(s) in {elapsed}s")
+            status.update(label=f"Found {found} candidate(s) in {elapsed}s",
+                          state="complete", expanded=False)
+        return result
+
+
+
+
+
+def render_lookup() -> None:
+    """Plain-language product -> candidate codes, so a reader can get started.
+
+    An HTS subheading means nothing to most people, which makes the rest of the app
+    unusable to them. This is the way in. It shows candidates with citations and never
+    picks one — classification is a human decision, and a wrong code produces a
+    confidently wrong duty for the wrong product.
+    """
+    with st.expander("🔍 Don't know the tariff code? Describe the product", expanded=False):
+        st.caption(
+            "A Web Search Agent reads the official schedule and CBP's rulings and comes "
+            "back with candidates to choose between. About two minutes."
+        )
+        col_input, col_button = st.columns([4, 1])
+        product = col_input.text_input(
+            "Product", key="lookup_product", label_visibility="collapsed",
+            placeholder="stainless steel insulated drinks bottle",
+        )
+        go = col_button.button("Find codes", use_container_width=True)
+
+        if go and product:
+            st.session_state["lookup_result"] = _run_lookup(product)
+
+        result = st.session_state.get("lookup_result")
+        if not result:
+            return
+        if result.get("error"):
+            st.warning(result["error"], icon="⚠️")
+            return
+
+        candidates = result.get("candidates") or []
+        source = "cached" if result.get("from_cache") else f"{result.get('elapsed_s')}s"
+        usable = sum(1 for c in candidates
+                     if (c.get("is_full_rate_line")
+                         if c.get("is_full_rate_line") is not None
+                         else sum(ch.isdigit() for ch in c.get("hts_code") or "") >= 8))
+        st.caption(f"{len(candidates)} candidate(s) · {source} · {usable} usable as a "
+                   "rate line · these are options to choose between, not an answer")
+        if not usable:
+            st.warning(
+                "None of these is a full tariff line, so none can give you a duty rate. "
+                "That usually means the description was too broad — say what the upper "
+                "and sole are made of, or what the item actually is, and search again.",
+                icon="🔢",
+            )
+
+        for idx, candidate in enumerate(candidates):
+            code = candidate.get("hts_code") or "?"
+            digits = sum(c.isdigit() for c in code)
+            # Trust the agent's own flag when it set one, else fall back to the digit
+            # count. A rate only exists on an 8- or 10-digit line, so handing a heading
+            # to the question box gives the reader a code the app cannot answer.
+            full_line = candidate.get("is_full_rate_line")
+            if full_line is None:
+                full_line = digits >= 8
+            row, button = st.columns([5, 1])
+            with row:
+                st.markdown(f"**`{code}`** — {candidate.get('description') or ''}")
+                if candidate.get("why_it_might_fit"):
+                    st.caption(candidate["why_it_might_fit"])
+                if not full_line:
+                    need = candidate.get("narrowing_needed")
+                    st.caption(
+                        f"⚠️ {digits}-digit "
+                        f"{'heading' if digits <= 4 else 'subheading'} — no duty rate at "
+                        "this level."
+                        + (f" Needed to narrow it: {need}" if need else
+                           " Add material or type to your description and search again.")
+                    )
+                if candidate.get("citation_url"):
+                    st.caption(f"[official source]({candidate['citation_url']})"
+                               + (f" · confidence `{candidate['confidence']}`"
+                                  if candidate.get("confidence") else ""))
+            if full_line:
+                button.button("Use this", key=f"use_{idx}_{code}",
+                              on_click=_use_code, args=(code,),
+                              use_container_width=True)
+            else:
+                button.caption("not a rate line")
+
+        if result.get("what_would_settle_it"):
+            st.info(f"**What still has to be decided:** {result['what_would_settle_it']}",
+                    icon="🧑‍⚖️")
+
+
+def _use_code(code: str) -> None:
+    """Prefill the question. Runs as a callback, before the rerun, so setting the
+    widget's session_state key is safe."""
+    # Left deliberately open-ended for the reader to name the country. The app now
+    # asks for it rather than failing, which it used to do: a question with a code
+    # and no origin produced no Lane and no flag, and the button walked into it.
+    st.session_state["question_box"] = (
+        f"What's the duty on HTS {code} from <country>?"
+    )
+
+
+RESEARCH_PHASES = (
+    (0, "starting the research run"),
+    (15, "the agent is planning and searching"),
+    (60, "reading official sources"),
+    (150, "cross-checking and assembling the answer"),
+    (260, "still working — a thorough run can take a while"),
+)
+
+
+def _research_phase(elapsed: float) -> str:
+    label = RESEARCH_PHASES[0][1]
+    for after, text in RESEARCH_PHASES:
+        if elapsed >= after:
+            label = text
+    return label
+
+
+def _run_research(lane: Lane, kinds: list[str], force: bool) -> bool:
+    """Research missing facts, narrating the wait, then fold them into the index.
+
+    The earlier version fired the threads and told the reader to come back later and
+    run `build_index.py` by hand — true, but a poor demo of a corpus that extends
+    itself. This waits with a ticking status and re-indexes on completion, so asking
+    about something uncovered just works.
+
+    Returns True if the index was updated.
+    """
+    threads = ResearchTask(lane=lane, kinds=list(kinds), force=force).start()
+    with st.status(f"Researching {friendly_lane(lane.key)}\u2026", expanded=True) as status:
+        line = st.empty()
+        st.caption(
+            "Each fact is a separate agent run against official sources. Runs continue "
+            "server-side even if you close this tab — the ids are on disk, and "
+            "`recover_runs.py` collects anything that outlives its deadline."
+        )
+        started = time.monotonic()
+        while any(t.is_alive() for t in threads):
+            elapsed = time.monotonic() - started
+            states = " · ".join(
+                f"{k}: {(read_job(lane, k) or {}).get('status', 'done')}" for k in kinds
+            )
+            line.write(f"⏳ {_research_phase(elapsed)} — {int(elapsed)}s · {states}")
+            time.sleep(2)
+
+        elapsed = int(time.monotonic() - started)
+        failed = [k for k in kinds
+                  if (read_job(lane, k) or {}).get("status") in
+                  {"failed", "timeout", "ambiguous_create"}]
+        if failed:
+            details = "; ".join(
+                f"{k}: {(read_job(lane, k) or {}).get('status')}" for k in failed
+            )
+            line.write(f"⚠️ finished in {elapsed}s with problems — {details}")
+            status.update(label=f"Research incomplete after {elapsed}s", state="error")
+            return False
+
+        line.write(f"✅ researched in {elapsed}s — adding to the corpus")
+        ingest.build_index(ingest.to_documents(ingest.load_records()))
+        _index.clear()          # the cached index handle is now stale
+        status.update(label=f"Researched and indexed in {elapsed}s",
+                      state="complete", expanded=False)
+    return True
+
+
+def demo_replay() -> bool:
+    """Replay cached runs through the live progress UI, for recording.
+
+    `USE_LIVE=false` answers instantly from cached runs, which looks nothing like the
+    real thing and makes a video misleading in the other direction. With this on, a
+    covered question shows the same status panel and phase labels as a live run, ticking
+    through the **actual elapsed time that run took**, on a faster clock — a sped-up
+    recording rather than an invented one. The answers, citations and confidence shown
+    are the genuine agent output.
+
+    Off by default and absent from .env.example: it must never ship enabled.
+    """
+    return os.environ.get("DESK_DEMO_REPLAY", "").strip().lower() in {"1", "true", "yes"}
+
+
+def demo_pause() -> float:
+    """Seconds to hold the status panel before showing the result."""
+    try:
+        return max(0.5, float(os.environ.get("DESK_DEMO_PAUSE", "3")))
+    except ValueError:
+        return 3.0
+
+
+def _replay_status(label: str, total_s: float, phase_fn, caption: str,
+                   work=None):
+    """Hold a status panel, do the remaining work inside it, then report the real time.
+
+    No counting clock: a ticking number is hard to cut around in an edit, and the only
+    figure worth showing is what the run actually took.
+
+    `work` runs *before* the panel says completed. Writing the answer takes another
+    10-15 seconds of LLM synthesis after retrieval, and declaring completion first left
+    a silent gap with nothing on screen — the panel was lying about being finished.
+    """
+    total_s = max(1.0, float(total_s or 0))
+    result = None
+    with st.status(label, expanded=True) as status:
+        line = st.empty()
+        st.caption(caption)
+        line.write(f"⏳ {phase_fn(total_s / 2)}…")
+        time.sleep(demo_pause())
+        if work is not None:
+            line.write("⏳ writing the answer from the cited facts…")
+            result = work()
+        line.write(f"✅ completed in {int(total_s)}s")
+        status.update(label=f"Completed in {int(total_s)}s", state="complete",
+                      expanded=False)
+    return result
+
+
+# --- main pane -------------------------------------------------------------
+
+
+def render_facts(nodes) -> None:
+    """The facts behind an answer, with the agent's own trust payload shown as-is."""
+    for nws in nodes:
+        meta = nws.node.metadata or {}
+        verdict = assess(meta)
+        kind = "base rate" if meta.get("kind") == "rate" else "duty overlays"
+        title = f"{'🕒' if verdict.stale else '✅'} {kind} · {verdict.describe()}"
+        with st.expander(title, expanded=False):
+            c1, c2, c3 = st.columns(3)
+            c1.metric("Confidence", str(meta.get("confidence")))
+            c2.metric("Primary sources", meta.get("primary_sources", 0))
+            c3.metric("Unverified", len(meta.get("unverified") or []))
+
+            if meta.get("duties_excluded"):
+                st.caption(
+                    f"{meta['duties_excluded']} duty(ies) filtered out — the agent "
+                    "marked them not in force, or their window has closed."
+                )
+            # Given equal billing with the answer on purpose: a run can return `high`
+            # confidence while leaving facts unverified. `confidence` grades what was
+            # claimed, not what was covered.
+            if meta.get("unverified"):
+                st.warning("The agent could not verify:\n\n" + "\n".join(
+                    f"- {u}" for u in meta["unverified"]), icon="❓")
+            if meta.get("confirmed_absent"):
+                st.info("Checked and confirmed NOT to apply:\n\n" + "\n".join(
+                    f"- {a}" for a in meta["confirmed_absent"][:6]), icon="✔️")
+            if meta.get("echoed_claims"):
+                st.caption(
+                    f"{meta['echoed_claims']} field(s) echo the question's own input "
+                    "and are not researched facts."
+                )
+            urls = meta.get("source_urls") or []
+            if urls:
+                st.caption("Sources: " + " · ".join(
+                    f"[{i + 1}]({u})" for i, u in enumerate(urls)))
+            st.caption(f"run `{meta.get('run_id')}` · agent `{meta.get('agent_id')}` "
+                       f"· effort `{meta.get('effort')}`")
+
+
+def main() -> None:
+    st.title("🧾 Tariff Desk")
+    st.caption(
+        "A demo of the Nimble + LlamaIndex integration: a knowledge base that "
+        "researches what it doesn't know and tells you how old everything is. "
+        "**Illustrative, not a compliance reference** — the figures are a snapshot of "
+        "what the agents found on the dates shown, kept to demonstrate the mechanics."
+    )
+
+    sidebar()
+
+    render_lookup()
+
+    question = st.text_input(
+        "Ask about a product and where it's coming from",
+        key="question_box",
+        placeholder="What's the duty on HTS 8507.60.00 from Vietnam?",
+    )
+    if not question:
+        st.info(
+            "Try: **What's the duty on HTS 8507.60.00 from China?** · "
+            "**Is any exclusion in force for 7604.29.10 from Mexico?** · "
+            "**What's out of date?**"
+        )
+        return
+
+    parsed = normalize(question, llm=_llm())
+
+    # Corpus questions never cost a run.
+    if parsed.intent == "corpus":
+        result = router.answer_corpus(question)
+        st.success("answered from corpus metadata — no research run", icon="📇")
+        st.markdown(result["answer"])
+        return
+
+    if parsed.needs_hts_code:
+        st.warning(
+            "That needs a tariff code. Duty attaches to the code rather than the "
+            "product name, and classification is a human decision — so the app will "
+            "not guess one.", icon="✋",
+        )
+        for note in parsed.notes:
+            st.caption(note)
+        if parsed.suggested_hts_code:
+            st.caption(
+                f"Possible match: `{parsed.suggested_hts_code}` "
+                f"({parsed.suggestion_basis}). Confirm it, then ask again including "
+                "the code."
+            )
+        return
+
+    if parsed.partial_code and parsed.lane is not None:
+        digits = sum(c.isdigit() for c in parsed.hts_code or "")
+        kind = "heading" if digits <= 4 else "subheading"
+        st.warning(
+            f"`{parsed.hts_code}` is a {digits}-digit {kind}, not a full tariff line. "
+            "A duty rate lives on an 8- or 10-digit statistical line, and a "
+            f"{kind} covers many lines with very different rates — so there is no "
+            "single rate to report for it.",
+            icon="🔢",
+        )
+        st.caption(
+            "Use the lookup above to find the full line for your product, then ask "
+            "again. (Duty overlays are often described at this level, so a "
+            "heading-level answer can still be partially useful — but it cannot give "
+            "you a rate.)"
+        )
+        return
+
+    if parsed.needs_origin or parsed.lane is None:
+        st.warning(
+            f"Which country is it coming from? Add it to the question — for example "
+            f"“…HTS {parsed.hts_code or '8507.60.00'} from Vietnam”.", icon="🌍",
+        )
+        for note in parsed.notes:
+            st.caption(note)
+        return
+
+    lane: Lane = parsed.lane
+    index = _index()
+    if index is None:
+        st.error("No index yet. Run `python build_index.py --samples`.", icon="🚫")
+        return
+
+    rate_needed, rate_why = needs_research(lane, "rate")
+    overlay_needed, overlay_why = needs_research(lane, "overlay")
+    result = None
+
+    if not rate_needed and not overlay_needed and demo_replay():
+        records = {r.get("kind"): r for r in ingest.load_records()
+                   if r.get("doc_key") in {lane.rate_key, lane.key}}
+        longest = max((float(r.get("elapsed_s") or 0) for r in records.values()),
+                      default=120.0)
+        icon, label = BADGE["new"]
+        st.info(f"{icon} {label}")
+        result = _replay_status(
+            f"Researching {friendly_lane(lane.key)}…", longest, _research_phase,
+            "Each fact is a separate agent run against official sources.",
+            work=lambda: router.answer_lane(index, lane, question, strict=True),
+        )
+    elif not rate_needed and not overlay_needed:
+        icon, label = BADGE["corpus"]
+        st.success(f"{icon} {label} — every figure below came from an agent run against "
+                   "official sources, cited and dated")
+    else:
+        which = [k for k, needed in (("rate", rate_needed), ("overlay", overlay_needed))
+                 if needed]
+        stale_case = "stale" in rate_why or "stale" in overlay_why
+        icon, label = BADGE["stale" if stale_case else "new"]
+        if not use_live():
+            st.warning(
+                f"{icon} {label}, but `USE_LIVE=false` — cannot research. Answering "
+                "from whatever is cached.", icon="⚠️",
+            )
+        else:
+            st.info(f"{icon} {label} — reading official sources now "
+                    f"({', '.join(which)}).")
+            if _run_research(lane, which, force=stale_case):
+                index = _index()
+
+    if result is None:
+        with st.spinner("Writing the answer from the cited facts…"):
+            result = router.answer_lane(index, lane, question, strict=True)
+
+    if not result["answered"]:
+        if result["reason"] == "stale":
+            st.warning(
+                "The corpus holds this lane but every fact is past its TTL, so it was "
+                "withheld rather than served as current.", icon="🕒",
+            )
+            render_facts(result["withheld"])
+        else:
+            st.info("Not in the corpus yet.", icon="🔎")
+        return
+
+    st.markdown("### Answer")
+    st.markdown(result["answer"])
+    if result["withheld"]:
+        st.caption(f"{len(result['withheld'])} expired fact(s) were withheld from this "
+                   "answer.")
+    st.markdown("### The facts behind it")
+    render_facts(result["nodes"])
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/llamaindex-tariff-desk/app.py
+++ b/apps/llamaindex-tariff-desk/app.py
@@ -63,7 +63,18 @@ FIELD_LABELS = {
 
 @st.cache_resource(show_spinner=False)
 def _index():
-    configure_models()
+    """The index, or None with the reason shown.
+
+    `configure_models()` raises when a key is missing. The sidebar warns about it,
+    but a warning is not control flow — without this guard the first question after
+    a bad `.env` becomes an uncaught Streamlit traceback instead of a message the
+    reader can act on. Callers already handle None.
+    """
+    try:
+        configure_models()
+    except RuntimeError as err:
+        st.error(str(err), icon="🚫")
+        return None
     return ingest.load_index()
 
 

--- a/apps/llamaindex-tariff-desk/build_index.py
+++ b/apps/llamaindex-tariff-desk/build_index.py
@@ -34,7 +34,7 @@ def _indexed_ids(storage: Path) -> set[str]:
     if not path.exists():
         return set()
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         return set()
     return set((data.get("docstore/ref_doc_info") or {}).keys())

--- a/apps/llamaindex-tariff-desk/build_index.py
+++ b/apps/llamaindex-tariff-desk/build_index.py
@@ -1,0 +1,105 @@
+"""Build or update the index from the corpus on disk.
+
+Separate from research on purpose: researching is slow and billable, indexing is
+fast and cheap, and conflating them means a re-index costs agent runs. Run this
+after prewarm.py, after refresh.py, or after recover_runs.py.
+
+    ./.venv/bin/python build_index.py
+    ./.venv/bin/python build_index.py --samples   # build from the shipped samples
+
+Only this script and the query path need an embedding model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+HERE = Path(__file__).parent
+load_dotenv(HERE / ".env")
+sys.path.insert(0, str(HERE))
+
+from desk import ingest  # noqa: E402
+from desk.models import configure_models  # noqa: E402
+
+
+def _indexed_ids(storage: Path) -> set[str]:
+    """Document ids currently in the docstore."""
+    path = storage / "docstore.json"
+    if not path.exists():
+        return set()
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return set()
+    return set((data.get("docstore/ref_doc_info") or {}).keys())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", action="store_true",
+                        help="force building from data/samples/")
+    parser.add_argument("--runs", action="store_true",
+                        help="force building from data/runs/")
+    parser.add_argument("--storage", default=None, help="override the storage dir")
+    args = parser.parse_args()
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("OPENAI_API_KEY is not set — embeddings need it.", file=sys.stderr)
+        print("The corpus and every agent run work without it; only the index does not.",
+              file=sys.stderr)
+        return 2
+
+    configure_models()
+
+    # Default to whatever the app will read (USE_LIVE decides), because an index built
+    # from one directory while the app reads another contradicts itself in front of the
+    # user — the sidebar calls a fact fresh while the retrieval guard withholds it.
+    if args.samples:
+        source = ingest.SAMPLES_DIR
+    elif args.runs:
+        source = ingest.RUNS_DIR
+    else:
+        source = ingest.active_dir()
+    records = ingest.load_records(source)
+    if not records:
+        print(f"no records in {source} — run prewarm.py first", file=sys.stderr)
+        return 2
+
+    documents = ingest.to_documents(records)
+    storage = Path(args.storage) if args.storage else ingest.STORAGE_DIR
+    existed = (storage / "docstore.json").exists()
+
+    print(f"{len(documents)} document(s) from {source.name}/")
+    print(f"{'updating' if existed else 'creating'} index at {storage.name}/")
+
+    before = _indexed_ids(storage)
+    index, _ = ingest.build_index(documents, storage_dir=storage)
+    after = _indexed_ids(storage)
+
+    # Reported from the docstore rather than from refresh_ref_docs' return value:
+    # that came back all-False on a run which had just inserted two new documents,
+    # so trusting it printed "0 embedded" while the corpus had visibly grown.
+    added = sorted(after - before)
+    if added:
+        print(f"done — {len(added)} document(s) added:")
+        for doc_id in added:
+            print(f"    + {doc_id}")
+        print(f"  {len(after) - len(added)} already present (unchanged content is not "
+              "re-embedded)")
+    else:
+        print(f"done — {len(after)} document(s) in the index, none added")
+
+    cov = ingest.coverage(records)
+    print(f"coverage: {cov['rate_docs']} base rate(s) over "
+          f"{len(cov['hts_codes'])} code(s), {cov['overlay_docs']} lane overlay(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/llamaindex-tariff-desk/data/hts_samples/aluminium-extrusions.json
+++ b/apps/llamaindex-tariff-desk/data/hts_samples/aluminium-extrusions.json
@@ -1,0 +1,65 @@
+{
+  "product": "aluminium extrusions",
+  "candidates": [
+    {
+      "chapter": "76",
+      "hts_code": "7604.29.10",
+      "source_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "description": "Aluminum bars, rods and profiles: ... Of aluminum alloys: ... Other: Other profiles",
+      "why_it_might_fit": "Default home for a generic solid extruded aluminium profile sold as stock shape (not prepared for a structure, not a finished article).",
+      "citation_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "citation_title": "HTS CHAPTER 76 ALUMINUM AND ARTICLES THEREOF",
+      "citation_excerpt": "7604 Aluminum bars, rods and profiles: ... Of aluminum alloys: Hollow profiles (7604.21.00); Other: Other profiles (7604.29.10).",
+      "confidence": "high"
+    },
+    {
+      "chapter": "76",
+      "hts_code": "7604.10.10",
+      "source_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "description": "Aluminum bars, rods and profiles: ... Of aluminum, not alloyed: Profiles",
+      "why_it_might_fit": "If the extrusion is unalloyed aluminium (>= 99% Al per chapter 76 subheading note 2(a)), it goes to the \"Of aluminum, not alloyed:\" branch of heading 7604 instead of the alloy branch.",
+      "citation_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "citation_title": "HTS CHAPTER 76 ALUMINUM AND ARTICLES THEREOF",
+      "citation_excerpt": "7604 Aluminum bars, rods and profiles: Of aluminum, not alloyed: Profiles (7604.10.10).",
+      "confidence": "high"
+    },
+    {
+      "chapter": "76",
+      "hts_code": "7604.21.00",
+      "source_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "description": "Aluminum bars, rods and profiles: ... Of aluminum alloys: Hollow profiles",
+      "why_it_might_fit": "If the extrusion is a hollow profile with a single enclosed void, it sits in the \"Hollow profiles\" line inside the alloyed branch of heading 7604 rather than \"Other profiles.\"",
+      "citation_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "citation_title": "HTS CHAPTER 76 ALUMINUM AND ARTICLES THEREOF",
+      "citation_excerpt": "7604.21.00 00 of aluminum alloys Hollow profiles.",
+      "confidence": "high"
+    },
+    {
+      "chapter": "76",
+      "hts_code": "7610.90.00",
+      "source_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "description": "Aluminum structures (excluding prefabricated buildings of heading 9406) and parts of structures (for example, bridges and bridge-sections, towers, lattice masts, roofs, roofing frameworks, doors and windows and their frames and thresholds for doors, balustrades, pillars and columns); aluminum plates, rods, profiles, tubes and the like, prepared for use in structures: Other",
+      "why_it_might_fit": "If the extrusion has been \"prepared for use in structures\" (cut to length, machined, drilled, mitred) for assembly into a structure rather than sold as stock profile, heading 7610 applies; within 7610, 7610.90 covers \"Other\" (everything that isn't doors/windows/frames under 7610.10).",
+      "citation_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "citation_title": "HTS CHAPTER 76 ALUMINUM AND ARTICLES THEREOF",
+      "citation_excerpt": "7610 Aluminum structures ... and parts of structures ... aluminum plates, rods, profiles, tubes and the like, prepared for use in structures: ... 7610.90.00 Other.",
+      "confidence": "high"
+    },
+    {
+      "chapter": "76",
+      "hts_code": "7616.99.50",
+      "source_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "description": "Other articles of aluminum: ... Other: Other",
+      "why_it_might_fit": "Residual basket for finished or further-worked aluminium articles that are not stock profiles (7604) and not prepared-for-structure (7610) and not elsewhere specified; picks up extrusions that have become identifiable finished articles like brackets, fittings, frames for non-structural use.",
+      "citation_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1000c76.pdf",
+      "citation_title": "HTS CHAPTER 76 ALUMINUM AND ARTICLES THEREOF",
+      "citation_excerpt": "7616 Other articles of aluminum: ... 7616.99 Other: 7616.99.50 Other.",
+      "confidence": "high"
+    }
+  ],
+  "what_would_settle_it": "The schedule distributes \"aluminium extrusions\" across several lines based on facts not stated in the product description: (1) alloyed vs. not alloyed (chapter 76 subheading note 2 splits heading 7604 into 7604.10 vs. 7604.21/7604.29), (2) hollow vs. solid (7604.21 \"Hollow profiles\" vs. 7604.29.10 \"Other profiles\"), (3) end use / degree of further preparation (stock profiles stay in heading 7604; profiles \"prepared for use in structures\" go to heading 7610.10 or 7610.90), and (4) whether the part has become a finished identifiable article that falls into a more specific heading such as 7615 (household/sanitary) or the residual 7616.99.50 \"Other\" articles of aluminum. A binding CBP CROSS/NY/NQ ruling on the specific part is the usual way importers resolve this.",
+  "overall_confidence": "high",
+  "run_id": "task_run_904f4cc5182f45d4b922b29d223c1f19",
+  "elapsed_s": 95.9,
+  "from_cache": false
+}

--- a/apps/llamaindex-tariff-desk/data/hts_samples/cotton-knit-t-shirts.json
+++ b/apps/llamaindex-tariff-desk/data/hts_samples/cotton-knit-t-shirts.json
@@ -1,0 +1,76 @@
+{
+  "product": "cotton knit t-shirts",
+  "candidates": [
+    {
+      "chapter": "61",
+      "hts_code": "6109.10.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "description": "Of cotton",
+      "why_it_might_fit": "The 6-digit subheading directly under heading 6109 (\"T-shirts, singlets, tank tops and similar garments, knitted or crocheted\") that names cotton \u2014 the closest single fit for a knit T-shirt whose body is cotton.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "\"6109.10.00 | Of cotton\"",
+      "confidence": "high"
+    },
+    {
+      "chapter": "61",
+      "hts_code": "6109.10.0012",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "description": "Men's",
+      "why_it_might_fit": "Statistical breakout under 6109.10.00 covering an \"Other\" men's T-shirt (cat. 338); the gender-specific statistical suffix the schedule requires for a men's T-shirt that does not match the narrow \"all white, short hemmed sleeves\u2026\" description at suffix 04.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "\"12 | Men's (338) | doz. | kg\"",
+      "confidence": "high"
+    },
+    {
+      "chapter": "61",
+      "hts_code": "6109.10.0040",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "description": "Women's",
+      "why_it_might_fit": "Statistical breakout under 6109.10.00 for an \"Other\" women's T-shirt (cat. 339); the gender-specific statistical suffix a women's cotton knit T-shirt normally reports against.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "\"Other: | 40 | Women's (339) | doz.\"",
+      "confidence": "high"
+    },
+    {
+      "chapter": "61",
+      "hts_code": "6109.10.0004",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "description": "T-shirts, all white, short hemmed sleeves, hemmed bottom, crew or round neckline, or V-neck with a mitered seam at the center of the V, without pockets, trim or embroidery",
+      "why_it_might_fit": "Special statistical breakout under 6109.10.00 that fits ONLY a men's/boys' cotton knit T-shirt meeting the schedule's narrow written description (plain white, crew-or-V neckline, no pockets/trim/embroidery). The garment must clear every phrase; any printed cotton tee falls to suffix 12, not 04.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "\"04 | T-shirts, all white, short hemmed sleeves, hemmed bottom, crew or round neckline, or V-neck with a mitered seam at the center of the V, without pockets, trim or embroidery (352) | doz. | kg\"",
+      "confidence": "high"
+    },
+    {
+      "chapter": "61",
+      "hts_code": "6109",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "description": "T-shirts, singlets, tank tops and similar garments, knitted or crocheted",
+      "why_it_might_fit": "The 4-digit heading-level candidate covering knit T-shirts of any fiber; useful if the person doesn't yet know the fabric composition (the next split \u2014 \"Of cotton\" 6109.10 vs. \"Of other textile materials\" 6109.90 \u2014 depends on it).",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "\"6109 | T-shirts, singlets, tank tops and similar garments, knitted or crocheted:\"",
+      "confidence": "high"
+    },
+    {
+      "chapter": "61",
+      "hts_code": "6109.90.10",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "description": "Of man-made fibers",
+      "why_it_might_fit": "The non-cotton fiber branch under the same heading \u2014 listed so a person who later discovers the T-shirt is polyester or a cotton-rich blend at the GRI-3 / GRI-6 textile threshold (Chapter rule for \"cotton\" subheadings requires the cotton to be the predominant fiber by weight) can see that \"Of cotton\" is not the only option under 6109.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "\"6109.90.10 | Of man-made fibers\"",
+      "confidence": "high"
+    }
+  ],
+  "what_would_settle_it": "A person still has to decide three things before picking a code: (1) the fabric \u2014 is cotton the predominant fiber by weight (so it stays under 6109.10 \"Of cotton\") or does a man-made, wool, silk, or other fiber take it to 6109.90; (2) the construction \u2014 Chapter 61 Note 5 says heading 6109 does NOT cover garments with a drawstring, ribbed waistband, or other means of tightening at the bottom, so a knit tee with a ribbed waistband re-routes to 6110 (sweaters, pullovers, sweatshirts) where stitch gauge (\u22649 vs >9 stitches per 2 cm) then decides the next branch; and (3) the gender/category suffix \u2014 within 6109.10 the schedule further splits men's/boys' garmets (cat. 338, with a carve-out at suffix 04 for plain white, no-print, no-trim, no-embroidery tees) from women's/girls' (cat. 339, with a separate \"Underwear\" 37 and \"Other\" 40/45), and the right 10-digit suffix depends on those physical attributes and market designation. A CBP binding ruling letter (rulings.cbp.gov) on substantially identical merchandise would settle these in one step.",
+  "overall_confidence": "high",
+  "run_id": "task_run_2b2b50b9a1ff4317bb35fe1c9826991c",
+  "elapsed_s": 79.0,
+  "from_cache": false
+}

--- a/apps/llamaindex-tariff-desk/data/hts_samples/lithium-ion-battery-packs.json
+++ b/apps/llamaindex-tariff-desk/data/hts_samples/lithium-ion-battery-packs.json
@@ -1,0 +1,76 @@
+{
+  "product": "lithium-ion battery packs",
+  "candidates": [
+    {
+      "chapter": "85",
+      "hts_code": "8507.60.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "description": "Lithium-ion batteries",
+      "why_it_might_fit": "Heading 8507 covers electric storage batteries (rechargeable/secondary) and Note 3 to Chapter 85 expressly includes batteries \"presented with ancillary components which contribute to the accumulator's function of storing and supplying energy or protect it from damage\" \u2014 language that captures a multi-cell lithium-ion pack with BMS and connectors.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "citation_title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "citation_excerpt": "8507.60.00 | Lithium-ion batteries",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8507.60.0030",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "description": "Battery energy storage systems fully encased within a housing, as described in statistical note 2 to this chapter",
+      "why_it_might_fit": "If the pack meets the four-part statutory test in Statistical Note 2 to Chapter 85 \u2014 designed to (i) store and (ii) discharge energy, consists of one or more lithium-ion modules plus battery-management circuitry and other components, has minimum 1 kWh capacity, and is fully encased in a housing \u2014 the statistical breakout below 8507.60.00 is 8507.60.0030 rather than .0010 or .0090.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "citation_title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "citation_excerpt": "30 | Battery energy storage systems fully encased within a housing, as described in statistical note 2 to this chapter",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8507.60.0010",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "description": "Of a kind used as the primary source of electrical power for electrically powered vehicles of subheadings 8703.40, 8703.50, 8703.60, 8703.70 or 8703.80",
+      "why_it_might_fit": "If the lithium-ion pack is dedicated to powering a passenger electric vehicle under 8703.40/8703.50/8703.60/8703.70/8703.80, the statistical breakout under the same 8507.60.00 subheading is 8507.60.0010 rather than 0020 / 0030 / 0090.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "citation_title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "citation_excerpt": "10 | Of a kind used as the primary source of electrical power for electrically powered vehicles of subheadings 8703.40, 8703.50, 8703.60, 8703.70 or 8703.80",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8507.60.0090",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "description": "Lithium-ion batteries: Other",
+      "why_it_might_fit": "If the pack is rechargeable lithium-ion but does not fit the EV-primary-power use of .0010 and does not meet the four-part BESS definition of .0030, it falls to the residual \"Other\" stat-suffix 8507.60.0090 for lithium-ion batteries.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "citation_title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "citation_excerpt": "90 | Other (lithium-ion batteries)",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8507.90.80",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "description": "Parts: Other (parts of electric storage batteries other than lead-acid)",
+      "why_it_might_fit": "If the article is a component (a battery module, BMS, or housing shell) sold on its own rather than a finished pack, Note 3 still covers \"electric accumulators presented with ancillary components\" but a standalone part may instead sit under 8507.90.80, otherwise classified as charger/inverter components in 8504.40 or as electrical parts in 8536/8537.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "citation_title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter%2085",
+      "citation_excerpt": "8507.90.80 | 00 | Parts: Other",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8506.50.00",
+      "source_url": "https://www.usitc.gov/publications/docs/tata/hts/bychapter/1501c85.pdf",
+      "description": "Primary cells and primary batteries; parts thereof: Lithium",
+      "why_it_might_fit": "If the product is a non-rechargeable (primary) lithium battery pack instead of a rechargeable lithium-ion (secondary) pack, it would sit under heading 8506 (Primary cells and primary batteries) rather than 8507 (Electric storage batteries / secondary); this is the material-vs-function branch the schedule forces a person to choose on.",
+      "citation_url": "https://usitc.gov/publications/docs/tata/hts/bychapter/1501c85.pdf",
+      "citation_title": "https://www.usitc.gov/publications/docs/tata/hts/bychapter/1501c85.pdf",
+      "citation_excerpt": "8506.50.00 00 | Lithium",
+      "confidence": "high"
+    }
+  ],
+  "what_would_settle_it": "A person still has to decide between (a) whether the pack is rechargeable (lithium-ion, secondary) or non-rechargeable (lithium primary) \u2014 that picks between heading 8507 and heading 8506; (b) whether it is a complete pack or a component/part \u2014 that picks between 8507.60.00 (and its statistical breakouts) and 8507.90.80; and (c) what the pack is destined to power \u2014 a passenger electric vehicle of subheading 8703.40, 8703.50, 8703.60, 8703.70 or 8703.80 (stat suffix 10), a battery energy storage system meeting the four-part test in Statistical Note 2 to Chapter 85 with minimum 1 kWh capacity, battery-management circuitry, and a housing (stat suffix 30), or something else (stat suffix 90). Chapter 85 Note 3 expressly includes within heading 8507 articles \"presented with ancillary components which contribute to the accumulator's function of storing and supplying energy or protect it from damage\" (e.g., electrical connectors, thermistors, circuit-protection devices). CBP CROSS rulings (e.g. NY N206384 on a (3S2P/LIC18650) pack classified under 8507.60.0000; NY N329305 on a Stihl AP 300 S power-tool pack classified under 8507.60.0020 \"Other\"; NY N336711 on a Lithium Nickel Cobalt Manganese Battery Module classified under 8507.60.0020; and NY N350116 on a prismatic cell classified under 8507.60.0020) illustrate how Customs reads the schedule's wording for these articles.",
+  "overall_confidence": "high",
+  "run_id": "task_run_7773d1ad4f8840ad9a201dcdbe685ea0",
+  "elapsed_s": 163.8,
+  "from_cache": false
+}

--- a/apps/llamaindex-tariff-desk/data/hts_samples/photovoltaic-solar-modules.json
+++ b/apps/llamaindex-tariff-desk/data/hts_samples/photovoltaic-solar-modules.json
@@ -1,0 +1,54 @@
+{
+  "product": "photovoltaic solar modules",
+  "candidates": [
+    {
+      "chapter": "85",
+      "hts_code": "8541.43.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "description": "Solar cells assembled into modules or made up into panels: This subheading covers solar cells that have been assembled into modules or made up into panels. (Per the CBP 2025 Solar Cells and Modules Quota Bulletin, subheading 8541.43.00 is the line on which additional safeguard duties under 9903.45.25 are levied for modules comprised of CSPV cells.)",
+      "why_it_might_fit": "A complete photovoltaic solar module (cells laminated between encapsulant and glass, framed, with junction box) is the textbook \"solar cells assembled into modules or made up into panels\" good of heading 8541.",
+      "citation_url": "https://cbp.gov/trade/quota/bulletins/qb-25-507-2025",
+      "citation_title": "QB 25-507 2025 Solar Cells and Modules | U.S. Customs and Border ...",
+      "citation_excerpt": "In addition to duty rates applicable under subheading 8541.43.00:",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8541.42.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "description": "Solar cells not assembled into modules or made up into panels: This subheading covers individual solar cells (photovoltaic cells) that have NOT yet been assembled into modules or panels. (Per the CBP 2025 Solar Cells and Modules Quota Bulletin, subheading 8541.42.00 is the base rate line on which the section 201 in-quota and over-quota safeguard duties on CSPV cells are stacked.)",
+      "why_it_might_fit": "If the imported product is bare solar cells (individual photovoltaic cells/dies before they are laminated into a module), 8541.42.00 is the heading 8541 line rather than the assembled-module line.",
+      "citation_url": "https://cbp.gov/trade/quota/bulletins/qb-25-507-2025",
+      "citation_title": "QB 25-507 2025 Solar Cells and Modules | U.S. Customs and Border ...",
+      "citation_excerpt": "No change from those duties applicable under subheading 8541.42.00 as appropriate.",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8541.49",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "description": "Other photosensitive semiconductor devices: residual subheading of heading 8541 for devices that perform the same function as solar cells by converting light into electricity but are not crystalline-silicon solar cells and not assembled into modules/panels. (Cornerstone category in CBP/CSPV safeguard scope as the \"solar cell\" base rate for non-CSPV technology.)",
+      "why_it_might_fit": "If the module is made of thin-film, CdTe, CIGS, amorphous silicon or any non-crystalline-silicon PV technology, it still falls under heading 8541 as a \"photosensitive semiconductor device,\" but the section 201 CSPV safeguard (Module 9903.45.25) does not apply.",
+      "citation_url": "https://cbp.gov/trade/quota/bulletins/qb-25-507-2025",
+      "citation_title": "QB 25-507 2025 Solar Cells and Modules | U.S. Customs and Border ...",
+      "citation_excerpt": "Crystalline Silicon Photovoltaic (CSPV) Cells and Modules",
+      "confidence": "high"
+    },
+    {
+      "chapter": "85",
+      "hts_code": "8501.71.0000 or 8501.79.0000",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+      "description": "Photovoltaic generators (heading 8501) \u2014 Chapter 85, Note 9 (added by USITC) reads: \"For the purposes of heading 8501, photovoltaic generators consist of panels of photocells combined with other apparatus, e.g., storage batteries and electronic controls (voltage regulator, inverter, etc.) and panels or modules equipped with elements, however simple (for example, diodes to control the direction of the current), which supply the power directly to, for example, a motor, an electrolyser. In these devices, electricity is produced by means of solar cells which convert solar energy directly into electricity (photovoltaic conversion).\"",
+      "why_it_might_fit": "If the imported product is not a bare PV panel but a more complete unit \u2014 a panel plus inverter, charge controller, or storage battery integrated so it can supply power directly to a load or back to a motor/electrolyser \u2014 Chapter Note 9 routes it to heading 8501 (photovoltaic generators) instead of heading 8541.",
+      "citation_url": "https://usitc.gov/tariff_affairs.htm",
+      "citation_title": "Tariff Affairs | United States International Trade Commission",
+      "citation_excerpt": "For the purposes of heading 8501, photovoltaic generators consist of panels of photocells combined with other apparatus, e.g., storage batteries and electronic controls (voltage regulator, inverter, etc.) and panels or modules equipped with elements, however simple (for example, diodes to control the direction of the current), which supply the power directly to, for example, a motor, an electrolyser.",
+      "confidence": "high"
+    }
+  ],
+  "what_would_settle_it": "A person still has to decide (a) whether the imported good is solar cells already assembled into a module/panel (a finished PV laminate in a frame with junction box) or individual unassembled solar cells (wafers/dices with metallization, not yet laminated); (b) whether the cells are of crystalline silicon (CSPV) or another material (thin-film CdTe, CIGS, perovskite, amorphous silicon), because CSPV goods carry section 201 safeguard duties (10% plus 9903.45.25 add-on) that other PV goods do not; (c) for the Chapter 84/Chapter 85 boundary, whether the module is imported with an inverter, charge controller, or storage battery integrated into a self-contained \"photovoltaic generator\" (residual to heading 8501) versus as bare PV panel only (heading 8541); and (d) the right 10-digit statistical breakout under 8541.42 vs 8541.43 for cell-vs-module and the wattage/unit to report under chapter 85 statistical note 9. The binding authority for any of these factual questions is a CBP Customs Ruling (CROSS) such as N338270 on solar panels, or a binding pre-classification request to CBP; the HTSUS itself only sets the categories.",
+  "overall_confidence": "high",
+  "run_id": "task_run_50d2b5b6998e4bbc8a971e1e2f1bbc1a",
+  "elapsed_s": 207.9,
+  "from_cache": false
+}

--- a/apps/llamaindex-tariff-desk/data/hts_samples/printed-books.json
+++ b/apps/llamaindex-tariff-desk/data/hts_samples/printed-books.json
@@ -1,0 +1,65 @@
+{
+  "product": "printed books",
+  "candidates": [
+    {
+      "chapter": "49",
+      "hts_code": "4901.99.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "description": "Other",
+      "why_it_might_fit": "This is the residual subheading under heading 4901 ('Printed books, brochures, leaflets and similar printed matter, whether or not in single sheets') that catches printed books not specifically enumerated elsewhere in the chapter (textbooks, religious books, hardbound books, rack-size paperbound books, and books broken out by page count), making it the default landing zone for an ordinary printed book.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "4901.99.00 | Other | Free | Free *1/*",
+      "confidence": "high"
+    },
+    {
+      "chapter": "49",
+      "hts_code": "4901.91.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "description": "Dictionaries and encyclopedias, and serial installments thereof",
+      "why_it_might_fit": "If the 'printed book' is a dictionary, an encyclopedia, or a serial installment of one (e.g., a weekly part of an encyclopedia set), this subheading names it expressly, separate from the 4901.99 'Other' basket.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "4901.91.00 | Dictionaries and encyclopedias, and serial installments thereof | Free | Free *1/*",
+      "confidence": "high"
+    },
+    {
+      "chapter": "49",
+      "hts_code": "4903.00.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "description": "Children's picture, drawing or coloring books",
+      "why_it_might_fit": "If the product is a book aimed at children in which the pictures form the principal interest and the text is subsidiary (chapter 49 Note 6), this subheading names it expressly and is preferred over the residual 4901.99 'Other'.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "4903.00.00 00 | Children's picture, drawing or coloring books | No. | Free | Free *1/*",
+      "confidence": "high"
+    },
+    {
+      "chapter": "49",
+      "hts_code": "4904.00.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "description": "Music, printed or in manuscript, whether or not bound or illustrated",
+      "why_it_might_fit": "If the printed book is principally printed music (sheet music, a bound or unbound music book, manuscript music, or a music book with illustrations), this subheading names it expressly and is preferred over the residual 4901.99 'Other'.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "4904.00.00 | Music, printed or in manuscript, whether or not bound or illustrated | Free | Free *1/*",
+      "confidence": "high"
+    },
+    {
+      "chapter": "49",
+      "hts_code": "4901.10.00",
+      "source_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "description": "In single sheets, whether or not folded",
+      "why_it_might_fit": "If the 'printed book' is actually unbound printed matter supplied as a single folded/unfolded sheet (booklet, leaflet, brochure, or a printed signature intended for binding), this subheading catches it before the bound-book subheadings \u2014 heading 4901 explicitly covers printed parts of books in the form of separate sheets or signatures designed for binding.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "4901.10.00 | In single sheets, whether or not folded | kg | Free | Free *1/*",
+      "confidence": "high"
+    }
+  ],
+  "what_would_settle_it": "A person still has to decide: (a) whether the book is a dictionary/encyclopedia, a children's picture book, or printed music, because each routes to a different specific subheading (4901.91.00, 4903.00.00, or 4904.00.00) instead of the residual 'Other' basket; (b) if it sits under 4901.99.00, which statistical suffix applies \u2014 by physical format (hardbound, stat. suffix 70; rack-size paperbound, stat. suffix 75), by page count excluding covers (not more than 4 pages, stat. suffix 91; 5\u201348 pages, stat. suffix 92; 49 or more pages, stat. suffix 93), or by content category (textbooks stat. suffix 10, directories 30, Bibles/testaments/prayer books and other religious books 40, technical/scientific/professional books 50, art and pictorial books valued under $5 or $5 or more each, stat. suffixes 60/65); and (c) whether the item is actually a bound book or is sheets, leaflets, or material essentially devoted to advertising, which would shift it toward 4901.10.00 (in single sheets) or 4911 (other printed matter / tourist / advertising literature).",
+  "overall_confidence": "high",
+  "run_id": "task_run_1a1c0a753ae845bba12b530337c666ca",
+  "elapsed_s": 84.6,
+  "from_cache": false
+}

--- a/apps/llamaindex-tariff-desk/data/hts_samples/stainless-steel-insulated-drinks-bottle.json
+++ b/apps/llamaindex-tariff-desk/data/hts_samples/stainless-steel-insulated-drinks-bottle.json
@@ -1,0 +1,65 @@
+{
+  "product": "stainless steel insulated drinks bottle",
+  "candidates": [
+    {
+      "chapter": "73",
+      "hts_code": "7323.93.0080",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+73",
+      "description": "Table, kitchen or other household articles and parts thereof, of iron or steel; iron or steel wool; pot scourers and scouring or polishing pads, gloves and the like, of iron or steel: Other: Of stainless steel: Other",
+      "why_it_might_fit": "A stainless steel insulated drink bottle is, materially, an article of stainless steel of heading 7323, and CBP has classified similar stainless bottles under 7323.93.0080 (ruling N299732: 19-oz Stainless Steel Water Bottle KY001T; ruling N297165: insulated beverage containers).",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+96&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "7323.93.00 Of stainless steel ... Other (statistical suffix 80)",
+      "confidence": "high"
+    },
+    {
+      "chapter": "73",
+      "hts_code": "7323.93.0060",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+73",
+      "description": "Table, kitchen or other household articles and parts thereof, of iron or steel; iron or steel wool; pot scourers and scouring or polishing pads, gloves and the like, of iron or steel: Other: Of stainless steel: Kitchen ware",
+      "why_it_might_fit": "If an importer argues the bottle is a \"Kitchen ware\" article of stainless steel rather than the catch-all \"Other\", the statistical-suffix line under 7323.93 is a separate reporting line on the same heading.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+96&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "7323.93.00 Of stainless steel ... Kitchen ware (statistical suffix 60)",
+      "confidence": "high"
+    },
+    {
+      "chapter": "96",
+      "hts_code": "9617.00.1000",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+96",
+      "description": "Vacuum flasks and other vacuum vessels, complete; parts thereof other than glass inners: Having a capacity not exceeding 1 liter",
+      "why_it_might_fit": "An insulated stainless drink bottle whose principal character is a vacuum vessel belongs under heading 9617, and CBP classified stainless vacuum insulated bottles in ruling N321985 (styles Y27-500 and KL13-500) under 9617.00.1000 when capacity does not exceed 1 liter.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+96&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "9617.00.10 00 Having a capacity not exceeding 1 liter",
+      "confidence": "high"
+    },
+    {
+      "chapter": "96",
+      "hts_code": "9617.00.3000",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+96",
+      "description": "Vacuum flasks and other vacuum vessels, complete; parts thereof other than glass inners: Having a capacity exceeding 1 liter but not exceeding 2 liters",
+      "why_it_might_fit": "If the vacuum-insulated bottle exceeds 1 liter (a common large sports-bottle or \"growler\" size), the schedule's capacity breakdown under 9617.00.30 applies if heading 9617 is chosen.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+96&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "9617.00.30 00 Having a capacity exceeding 1 liter but not exceeding 2 liters",
+      "confidence": "high"
+    },
+    {
+      "chapter": "96",
+      "hts_code": "9617.00.6000",
+      "source_url": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+96",
+      "description": "Vacuum flasks and other vacuum vessels, complete; parts thereof other than glass inners: Parts",
+      "why_it_might_fit": "The schedule separately provides \"Parts\" of vacuum vessels under 9617.00.60; this applies only when the importer brings in bottle sub-components (e.g., lids, inner stoppers) rather than the complete article.",
+      "citation_url": "https://hts.usitc.gov/reststop/file?filename=Chapter+96&release=currentRelease",
+      "citation_title": "Harmonized Tariff Schedule of the United States Revision ...",
+      "citation_excerpt": "9617.00.60 00 Parts",
+      "confidence": "high"
+    }
+  ],
+  "what_would_settle_it": "Whether the article's essential character is the stainless-steel kitchen/tableware material (heading 7323, e.g. N299732 and N297165 classified stainless insulated water bottles under 7323.93.0080) or the vacuum-insulation function (heading 9617, under which CBP classified vacuum insulated stainless bottles in N321985). Within heading 7323, the importer must also pick a statistical suffix \u2014 \"Kitchen ware\" (7323.93.0060) versus catch-all \"Other\" (7323.93.0080). Within heading 9617, capacity is the further break (1 L, 1\u20132 L, >2 L, or \"Parts\" if importing components only). The dividing case-law question is whether the vacuum space between two walls of stainless steel is the essential character \u2014 a CROSS ruling search for the same product description and any preclassification ruling on the importer's exact article is the controlling input the importer still owes.",
+  "overall_confidence": "high",
+  "run_id": "task_run_4ac44cf38b7f47bcb1801c203f19a510",
+  "elapsed_s": 112.8,
+  "from_cache": false
+}

--- a/apps/llamaindex-tariff-desk/data/samples/3923.50.00_United-States.rate.json
+++ b/apps/llamaindex-tariff-desk/data/samples/3923.50.00_United-States.rate.json
@@ -1,0 +1,170 @@
+{
+  "lane": {
+    "hts_code": "3923.50.00",
+    "origin": "Vietnam",
+    "destination": "United States",
+    "product": ""
+  },
+  "lane_key": "3923.50.00|Vietnam|United States",
+  "doc_key": "3923.50.00|United States",
+  "kind": "rate",
+  "doc_id": "3923.50.00|United States#rate",
+  "researched_at": "2026-08-05T13:58:59.448541+00:00",
+  "elapsed_s": 78.7,
+  "text": "{\n  \"origin\": \"Vietnam\",\n  \"hts_code\": \"3923.50.00\",\n  \"source_url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease\",\n  \"destination\": \"United States\",\n  \"general_rate\": \"5.3%\",\n  \"htsus_revision\": \"Revision 15 (2026)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"retrieval_notes\": \"Read directly from the official USITC HTSUS Chapter 39 PDF (currentRelease) at hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease. The document self-identifies as \\\"Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes.\\\" Revision 15 is the current revision per the USITC Harmonized Tariff Information page (usitc.gov/harmonized_tariff_information), which records \\\"2026 HTS Revision 15 was published on August 3, 2026.\\\" Column headers in the Chapter 39 schedule explicitly label the two duty columns as \\\"General\\\" and \\\"Special\\\"; for 3923.50.00 the General column reads 5.3% and the Special column reads Free (A, AU, B, BH, CL, CO, D, E, IL, JO, KR, MA, OM, P, PA, PE, S, SG). Sanity-checked against neighbouring 3923 subheadings (3923.10\u20133923.40 at 3%\u20135.3%, 3923.90 at 3%). Section 301/232/IEEPA/reciprocal overlays are not folded into this rate.\",\n  \"verified_against_official_schedule\": true\n}\n\nSources:\n- Harmonized Tariff Schedule of the United States Revision ... \u2014 https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease (primary)\n- Harmonized Tariff Information | United States International Trade ... \u2014 https://usitc.gov/harmonized_tariff_information (primary)",
+  "metadata": {
+    "run_id": "task_run_5bac9df0d46042e48f32ac84a129d65d",
+    "agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "web_search_agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "effort": "medium",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease",
+        "source_category": "official",
+        "title": "Harmonized Tariff Schedule of the United States Revision ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://usitc.gov/harmonized_tariff_information",
+        "source_category": "official",
+        "title": "Harmonized Tariff Information | United States International Trade ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease",
+            "excerpts": [
+              "Column headers at 3923 (con.) page are explicitly: General | Special. Row 3923.50.00 00 reads 5.3% under General and Free (A, AU, B, BH, CL, CO, D, E, IL, JO, KR, MA, OM, P, PA, PE, S, SG) under Special."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.general_rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          },
+          {
+            "url": "https://usitc.gov/harmonized_tariff_information",
+            "excerpts": [
+              "2026 HTS Revision 15 was published on August 3, 2026"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Information | United States International Trade ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.htsus_revision",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease",
+            "excerpts": [
+              "retrieved: 2026-08-05"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease",
+            "excerpts": [
+              "General | Special column headers confirmed on Chapter 39 page 39-32 (3923 (con.) row); neighbouring rows: 3923.10.90 Other 3%, 3923.40.00 Spools 5.3%, 3923.50.00 Stoppers 5.3%, 3923.90.00 Other 3%."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.retrieval_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease",
+            "excerpts": [
+              "Source URL https://hts.usitc.gov/reststop/file?filename=Chapter+39&release=currentRelease is hosted on hts.usitc.gov (USITC's official Harmonized Tariff Schedule publication); provenance header tags source_category as \"official\". "
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.verified_against_official_schedule",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/3923.50.00_Vietnam_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/3923.50.00_Vietnam_United-States.overlay.json
@@ -1,0 +1,775 @@
+{
+  "lane": {
+    "hts_code": "3923.50.00",
+    "origin": "Vietnam",
+    "destination": "United States",
+    "product": ""
+  },
+  "lane_key": "3923.50.00|Vietnam|United States",
+  "doc_key": "3923.50.00|Vietnam|United States",
+  "kind": "overlay",
+  "doc_id": "3923.50.00|Vietnam|United States#overlay",
+  "researched_at": "2026-08-05T14:01:19.786054+00:00",
+  "elapsed_s": 219.1,
+  "text": "{\n  \"origin\": \"Vietnam\",\n  \"hts_code\": \"3923.50.00\",\n  \"unverified\": [\n    \"Any post-July 24, 2026 amendment of the USTR Section 301 forced-labor Notice (e.g., Vietnam-specific exemption or modification in Annex II). Looked but no Vietnam-specific carve-out found in the available July 2026 Federal Register PDF (it exempts only Argentina, Bangladesh, Cambodia, Ecuador, El Salvador, EU, Guatemala, Indonesia, Jordan, Malaysia, Switzerland, Taiwan, UK by name; Vietnam is not listed). Cannot rule out a later individual Vietnam modification without a more recent instrument.\",\n    \"Whether a Vietnam bilateral trade agreement has entered into force (and any tariff treatment committed therein) as of August 5, 2026. Framework Joint Statement was issued October 2025; USTR enumeration shows ART signed with Vietnam, but a signed/text ratification by Vietnam's National Assembly or whether the ART has entered into force was not confirmed in available sources; no official Federal Register implementing notice for Vietnam ART was retrieved by August 5, 2026.\",\n    \"Whether any Section 232 Proclamation or Expansion Petition in 2025-2026 added plastic articles (Chapter 39) \u2014 including HTS 3923.50 \u2014 to Section 232 coverage. No Federal Register notice retrieved that adds plastic stoppers/lids/caps to Section 232; CBP Tariff Fact Sheet 8/20/2025 confirms only steel/aluminum/copper/autos/MHDVs/semiconductors under 232. Could not rule out a pending unpublished investigation outcome as of 2026-08-05.\",\n    \"Section 232 medium- and heavy-duty vehicle (MHDV) and parts tariffs on Vietnam-origin HTS 3923.50.00: not confirmed that plastic closures for MHDVs are within scope; CBP MHDV scope consultation required.\",\n    \"Section 232 timber/lumber and wood products tariffs on Vietnam-origin HTS 3923.50.00: HTS 3923.50.00 (plastic closures) not in scope of wood/timber; CBP confirmation required.\",\n    \"Section 232 semiconductors and downstream articles: HTS 3923.50.00 (plastic closures) not within semiconductor scope; Confirmation needed that downstream exclusion does not capture.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"USTR Notice of Action imposing Section 301 forced-labor duties on Vietnam, effective 2026-07-24 (12.5% on products of Vietnam under Annex II, Part A only).\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"EO 14257 (April 2, 2025) as amended by EO 14346 (September 5, 2025) \u2014 IEEPA reciprocal duty of 20% on Vietnam-origin goods (HTS 9903.02.69). Originally effective April 9, 2025 (10% universal floor) and August 7, 2025 (country-specific rates including Vietnam 20%); modified by EO 14346 effective September 12, 2025. Terminated for cause: U.S. Supreme Court held in Learning Resources, Inc. v. Trump (Feb 2026) that IEEPA does not authorize these tariffs; EO 14389 of February 20, 2026 ('Ending Certain Tariff Actions', 91 FR 9437) terminated all IEEPA ad valorem duties imposed under EO 14257 effective on signing and no longer collected 'as soon as practicable.' Window closed before the research date.\",\n    \"Presidential Proclamation 11012 (February 20, 2026), 'Imposing a Temporary Import Surcharge to Address Fundamental International Payments Problems' \u2014 Section 122 of the Trade Act of 1974, 10% ad valorem surcharge, Federal Register 91 FR 9339, 2026-03824. Effective February 24, 2026 at 12:01 a.m. EST and explicitly ended July 24, 2026 at 12:01 a.m. EDT (150-day statutory limit under 19 U.S.C. 2132). Window closed (expired) before the research date.\",\n    \"Section 232 of the Trade Expansion Act of 1962 \u2014 does not reach HTS 3923.50.00. Section 232 instruments currently in force cover only steel, aluminum, copper, and derivative articles of those metals (HTS Chapter 99 amendments under 9903.81/85 series); autos and auto parts; medium and heavy-duty vehicles; semiconductors; and timber/lumber. 'Stoppers, lids, caps and other closures of plastics' are plastic articles with no steel, aluminum, or copper content subject to Section 232 and are not classified under any Section 232 derivative HTSUS number. Out of scope by product classification.\",\n    \"Section 301 China-origin Lists 1, 2, 3, and 4A \u2014 out of scope by origin. These duties cover only imports of Chinese origin (covered by USTR Federal Register notices 83 FR 47974, et seq., rates 7.5% to 100% on specified Chinese subheadings) and do not extend to Vietnam-origin goods.\",\n    \"USTR-initiated Section 301 investigation of Vietnam's IP protection and enforcement (May 29, 2026 announcement). Investigation only; no tariff action or duty imposed. Status: investigation ongoing.\",\n    \"Section 232 tariff-product exclusions & IEEPA reciprocal Annex III zero-rate product list (EO 14257, as amended by EO 14346, 'Potential Tariff Adjustments for Aligned Partners') \u2014 Annex III zero-percent reciprocal carve-outs are tied to the Vietnam bilateral framework but the underlying reciprocal duty itself was terminated by EO 14389 (Feb 20, 2026). No live exclusion product list now applies to Vietnam.\",\n    \"Section 301 Vietnam Currency and Vietnam Timber investigations (USTR pages) \u2014 no responsive duties imposed under these prior Vietnam-targeted investigations. The Vietnam Currency investigation (FRN 84 FR 39814) and Vietnam Timber investigation closed without tariff action; only the present 2026 forced-labor investigation produced Section 301 duties on Vietnam. No actionable tariff under those prior investigations.\",\n    \"80 FR 28741 \u2014 HTSUS heading 9903.02.69 Vietnam reciprocal tariff: not applied; instrument terminated by Court.\",\n    \"80 FR 48761 \u2014 USTR modification of reciprocal tariffs: not applied; instrument terminated by Court.\",\n    \"81 FR 11235 \u2014 Section 122 temporary 10% import surcharge (Proc. 11012) on Vietnam: not applied as of research date; 150-day window ended July 24, 2026.\",\n    \"Section 232 steel and aluminum (and derivatives) tariffs under Proc. 9704/9705 as amended: not applied; HTS 3923.50.00 (plastic closures) is not in the steel/aluminum Chapter 99 derivative list (9903.81/85) or primary scope.\",\n    \"Section 232 copper and copper derivative tariffs: not applied; HTS 3923.50.00 (plastic closures) is not on the copper Chapter 99 derivative list.\",\n    \"Section 232 passenger auto and light-truck tariffs: not applied; HTS 3923.50.00 (plastic closures) is not an automotive vehicle or part under the scope.\",\n    \"80% of Section 301 (USTR 2018) List 1/2/3/4A China tariffs: not applied; Vietnam is not China.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"12.5%\",\n      \"in_force\": true,\n      \"authority\": \"Section 301 (forced-labor) - USTR Notice of Action, Docket USTR-2026-0265 / USTR-2026-0266, July 23, 2026; Vietnam classified as '12.5 percent tariff rate: For goods of all other investigated economies'\",\n      \"source_url\": \"https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf\",\n      \"effective_date\": \"2026-07-24\"\n    },\n    {\n      \"ends\": null,\n      \"rate\": \"12.5%\",\n      \"in_force\": true,\n      \"authority\": \"Section 301 of the Trade Act of 1974 \u2014 USTR Notice of Action, July 23, 2026 (Docket USTR-2026-0265, USTR-2026-0266); 91 FR 34272 proposed June 5, 2026; imposed July 23, 2026; effective 2026-07-24.\",\n      \"source_url\": \"https://ustr.gov/sites/default/files/files/Press%20Releases/2026/USTR%20Flip%20301%20I%20-%20Notice%20of%20Action.pdf\",\n      \"effective_date\": \"2026-07-24\"\n    }\n  ],\n  \"origin_rules_notes\": \"Vietnam is in the 54-economy list that failed to both impose and enforce a forced-labor import prohibition; rate falls under tier (iii) at 12.5%. HTS 3923.50.00 (Stoppers, lids, caps and other closures of plastics) is not on the Annex II Part A product-exclusion table nor in Annex II Part (f) cross-category carve-outs (Section 232 steel/aluminum/copper, autos/parts, semiconductors, MHDVs, wood, USMCA articles).\",\n  \"exclusions_in_force\": [\n    {\n      \"source_url\": \"https://ustr.gov/sites/default/files/files/Press%20Releases/2026/USTR%20Flip%20301%20I%20-%20Notice%20of%20Action.pdf\",\n      \"description\": \"No product-specific exclusion from the Section 301 forced-labor action is currently in force for HTS 3923.50.00 from Vietnam.\"\n    }\n  ]\n}\n\nSources:\n- 1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ... \u2014 https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf (primary)\n- Fact Sheet: The United States and Viet Nam Reach a Framework for ... \u2014 https://ustr.gov/about/policy-offices/press-office/fact-sheets/2025/october/fact-sheet-united-states-and-viet-nam-reach-framework-agreement-reciprocal-fair-and-balanced-trade (primary)\n- New Tariff Requirements for 2025 Send questions to: traderemed... \u2014 https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf (primary)\n- Ending Certain Tariff Actions \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions (primary)\n- Ambassador Greer Issues Statement on Supreme Court IEEPA Decision ... \u2014 https://ustr.gov/about/policy-offices/press-office/press-releases/2026/february/ambassador-greer-issues-statement-supreme-court-ieepa-decision (primary)\n- IMPOSING A TEMPORARY IMPORT SURCHARGE TO ADDRESS FUNDAMENTAL \u2014 https://public-inspection.federalregister.gov/2026-03824.pdf (primary)\n- USTR Announces Section 301 Investigation of Vietnam\u2019s Acts, ... \u2014 https://ustr.gov/about/policy-offices/press-office/press-releases/2026/may/ustr-announces-section-301-investigation-vietnams-acts-policies-and-practices-related-intellectual (primary)\n- Federal Register :: Regulating Imports With a Reciprocal Tariff ... \u2014 https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and (primary)\n- Federal Register :: Ending Certain Tariff Actions \u2014 https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions (primary)\n- Federal Register :: Modifying the Scope of Reciprocal Tariffs and ... \u2014 https://federalregister.gov/documents/2025/09/10/2025-17507/modifying-the-scope-of-reciprocal-tariffs-and-establishing-procedures-for-implementing-trade-and (primary)\n- Federal Register :: Imposing a Temporary Import Surcharge To Address ... \u2014 https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems (primary)\n- Section 301 Trade Remedies Frequently Asked Questions | U.S. Customs ... \u2014 https://cbp.gov/trade/programs-administration/entry-summary/section-301-trade-remedies/faqs (primary)",
+  "metadata": {
+    "run_id": "task_run_5ad52e2ed6784eb789f2c89e2560b3f0",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 93% and trust per claim ratio is 97%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+        "source_category": "official",
+        "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/about/policy-offices/press-office/fact-sheets/2025/october/fact-sheet-united-states-and-viet-nam-reach-framework-agreement-reciprocal-fair-and-balanced-trade",
+        "source_category": "official",
+        "title": "Fact Sheet: The United States and Viet Nam Reach a Framework for ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+        "source_category": "official",
+        "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Ending Certain Tariff Actions \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2026/february/ambassador-greer-issues-statement-supreme-court-ieepa-decision",
+        "source_category": "official",
+        "title": "Ambassador Greer Issues Statement on Supreme Court IEEPA Decision ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://public-inspection.federalregister.gov/2026-03824.pdf",
+        "source_category": "other",
+        "title": "IMPOSING A TEMPORARY IMPORT SURCHARGE TO ADDRESS FUNDAMENTAL"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2026/may/ustr-announces-section-301-investigation-vietnams-acts-policies-and-practices-related-intellectual",
+        "source_category": "official",
+        "title": "USTR Announces Section 301 Investigation of Vietnam\u2019s Acts, ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and",
+        "source_category": "official",
+        "title": "Federal Register :: Regulating Imports With a Reciprocal Tariff ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Federal Register :: Ending Certain Tariff Actions"
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/09/10/2025-17507/modifying-the-scope-of-reciprocal-tariffs-and-establishing-procedures-for-implementing-trade-and",
+        "source_category": "official",
+        "title": "Federal Register :: Modifying the Scope of Reciprocal Tariffs and ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+        "source_category": "official",
+        "title": "Federal Register :: Imposing a Temporary Import Surcharge To Address ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/entry-summary/section-301-trade-remedies/faqs",
+        "source_category": "official",
+        "title": "Section 301 Trade Remedies Frequently Asked Questions | U.S. Customs ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Vietnam is not in the enumerated list of countries receiving product-specific exemptions."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/fact-sheets/2025/october/fact-sheet-united-states-and-viet-nam-reach-framework-agreement-reciprocal-fair-and-balanced-trade",
+            "excerpts": [
+              "Framework for an Agreement on Reciprocal, Fair, and Balanced Trade \u2014 finalize outstanding issues."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Fact Sheet: The United States and Viet Nam Reach a Framework for ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "Section 232: Steel, Aluminum, Copper, Autos/Auto Parts \u2014 no plastic chapter entry."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "CBP Tariff Factsheet lists MHDVs but specific HTSUS scope consultation is required for HTS 3923.50.00."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "CBP Tariff Factsheet does not list wood/timber in 232 list as of factsheet date; confirmation needed."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[4]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "CBP Tariff Factsheet does not enumerate downstream plastic articles under 232 semiconductor scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[5]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "In light of recent events, the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193... Executive Order 14257, as amended... shall no longer be in effect and, as soon as practicable, shall no longer be collected."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          },
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2026/february/ambassador-greer-issues-statement-supreme-court-ieepa-decision",
+            "excerpts": [
+              "The Supreme Court's decision today addresses the constitutionality of only President Trump's Reciprocal and Fentanyl Tariffs."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ambassador Greer Issues Statement on Supreme Court IEEPA Decision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2026-03824.pdf",
+            "excerpts": [
+              "I impose, for a period of 150 days, a temporary import surcharge of 10 percent ad valorem... effective February 24, 2026 and shall continue in effect through 12:01 a.m. eastern daylight time on July 24, 2026."
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "IMPOSING A TEMPORARY IMPORT SURCHARGE TO ADDRESS FUNDAMENTAL"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "Section 232: Steel 50% on imports of steel (including derivatives) of all countries, except UK (25%); Aluminum 50% on aluminum (including derivatives); Copper 50% on semi-finished copper products and intensive copper derivatives; Autos/Auto Parts 25% \u2014 no entry for HTS 3923."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2026/february/ambassador-greer-issues-statement-supreme-court-ieepa-decision",
+            "excerpts": [
+              "existing Section 301 tariffs on China range from 7.5 percent to 100 percent, depending on the product"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ambassador Greer Issues Statement on Supreme Court IEEPA Decision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2026/may/ustr-announces-section-301-investigation-vietnams-acts-policies-and-practices-related-intellectual",
+            "excerpts": [
+              "U.S. Trade Representative Jamieson Greer initiated an investigation of Vietnam under Section 301 of the Trade Act of 1974... what, if any, responsive action should be taken..."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "USTR Announces Section 301 Investigation of Vietnam\u2019s Acts, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[4]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/fact-sheets/2025/october/fact-sheet-united-states-and-viet-nam-reach-framework-agreement-reciprocal-fair-and-balanced-trade",
+            "excerpts": [
+              "Annex III to Executive Order 14346 of September 5, 2025, Potential Tariff Adjustments for Aligned Partners, to receive a zero percent reciprocal tariff rate."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Fact Sheet: The United States and Viet Nam Reach a Framework for ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[5]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2026/may/ustr-announces-section-301-investigation-vietnams-acts-policies-and-practices-related-intellectual",
+            "excerpts": [
+              "Initiation of investigation; no tariff action."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "USTR Announces Section 301 Investigation of Vietnam\u2019s Acts, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[6]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and",
+            "excerpts": [
+              "Executive Order 14257 of April 2, 2025 codified Vietnam reciprocal tariff at HTSUS 9903.02.69 at 20 percent."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Regulating Imports With a Reciprocal Tariff ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "Executive Order 14389 of February 20, 2026 ('Ending Certain Tariff Actions') terminates all IEEPA reciprocal tariffs imposed under EO 14257."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "EO 14389 ends IEEPA-based reciprocal tariffs previously authorized under EO 14257."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[7]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/09/10/2025-17507/modifying-the-scope-of-reciprocal-tariffs-and-establishing-procedures-for-implementing-trade-and",
+            "excerpts": [
+              "Executive Order 14346 of September 5, 2025 modifying scope of reciprocal tariffs maintained Vietnam at 20 percent."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Modifying the Scope of Reciprocal Tariffs and ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "EO 14389 ends all IEEPA reciprocal tariffs imposed under EO 14257, superseding EO 14346."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[8]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2026-03824.pdf",
+            "excerpts": [
+              "'March 24, 2026...for a period of 150 days, a temporary import surcharge of 10 percent ad valorem' with surcharges 'shall apply to all countries' except as specifically excluded; 'shall continue in effect through 12:01 a.m. eastern daylight time on July 24, 2026'."
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "IMPOSING A TEMPORARY IMPORT SURCHARGE TO ADDRESS FUNDAMENTAL"
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+            "excerpts": [
+              "Proclamation 11012 of February 24, 2026 imposed temporary 10% import surcharge under Section 122 for 150 days."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Imposing a Temporary Import Surcharge To Address ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[9]",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "CBP Tariff Factsheet: Section 232 covers Autos/Auto Parts, Copper, Steel, Aluminum sectors only."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[10]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "CBP Tariff Factsheet lists only Autos/Auto Parts, Copper, Steel, Aluminum for Section 232 scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[11]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2025-08/20250820_tariff_factsheet_0.pdf",
+            "excerpts": [
+              "CBP Tariff Factsheet: 232 scope limited to Autos/Auto Parts, Copper, Steel, Aluminum."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "New Tariff Requirements for 2025 Send questions to: traderemed..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[12]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/entry-summary/section-301-trade-remedies/faqs",
+            "excerpts": [
+              "CBP Section 301 guidance applies only to goods of Chinese origin under Chapter 99 subchapter III."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Section 301 Trade Remedies Frequently Asked Questions | U.S. Customs ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[13]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "For goods of all other investigated economies, the Trade Representative shall impose a tariff rate of 12.5 percent."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "low",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "No usable citation resolved for this value"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "The additional rates of duty are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern time on July 24, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "USTR Notice of Actions in Section 301 Investigations of Acts, Policies, and Practices of Various Economies Related to the Failure of Each Economy to Impose and Effectively Enforce a Prohibition on the Importation of Goods Produced with Forced Labor."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "USTR Notice of Actions in Section 301 Investigations of Acts, Policies, and Practices of Various Economies Related to the Failure of Each Economy to Impose and Effectively Enforce a Prohibition on the Importation of Goods Produced with Forced Labor."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "on or after 12:01 a.m. eastern time on July 24, 2026"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "tariff of 12.5 percent on products of Vietnam, with exemptions as provided in Annex I and Annex II, Part A \u2014 no terminal end date set in the Notice."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].ends",
+        "reasoning": "Information absence is supported by cited evidence"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Vietnam falls under the '(iii) 12.5 percent tariff rate: For goods of all other investigated economies' tier."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "'The Trade Representative has determined to impose 12.5 percent tariffs on products of Vietnam' under Section 301(b) and 304(a) of the Trade Act of 1974."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Notice of action \u2014 Section 301(b) and Section 304(a) of the Trade Act; tariffs on products of 60 investigated economies, Vietnam determination #60."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Source page path for USTR Section 301 forced-labor action."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Vietnam Section 301 tariffs effective at 12:01 AM Eastern Time on July 24, 2026 per USTR Notice of Action."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Annex II Part A lists HTSUS codes excluded from Section 301 forced-labor action; 3923.50.00 is NOT in the list."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Anx II Part A product-exclusion table contains codes 3901.90.90 through 3914.00.60 and 7101\u20137117; 3923.50.00 not on the list. Annex II Part (f) carve-outs (232 steel/aluminum/copper, autos/parts, semiconductors, MHDVs, wood, USMCA articles) do not cover 3923.50.00 plastic closures."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].description",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "the Trade Representative has determined to impose 12.5 percent tariffs on products of Vietnam, except as provided in Annex I and Annex II, Part A, of this Notice."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.data_as_of_date",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "Vietnam is listed in the 54 economies that 'have failed to impose and effectively enforce a prohibition on the importation of goods produced with forced labor' and is subject to 12.5 percent tariffs except as provided in Annex I and Annex II, Part A."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/4013.20.00_Thailand_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/4013.20.00_Thailand_United-States.overlay.json
@@ -1,0 +1,302 @@
+{
+  "lane": {
+    "hts_code": "4013.20.00",
+    "origin": "Thailand",
+    "destination": "United States",
+    "product": ""
+  },
+  "lane_key": "4013.20.00|Thailand|United States",
+  "doc_key": "4013.20.00|Thailand|United States",
+  "kind": "overlay",
+  "doc_id": "4013.20.00|Thailand|United States#overlay",
+  "researched_at": "2026-08-05T13:20:57.183634+00:00",
+  "elapsed_s": 343.3,
+  "text": "{\n  \"origin\": \"Thailand\",\n  \"hts_code\": \"4013.20.00\",\n  \"unverified\": [\n    \"No active Section 301 action on 4013.20.00 from Thailand could be verified beyond the open USTR-2026-0067/0068 investigation (initiated March 11, 2026); USTR has not issued a Section 301 determination or imposed a tariff on this product/origin pair to date. (No additional duty recordable; the open investigation is itself captured in confirmed_absent.)\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"EO 14389 signed February 20, 2026 (published February 25, 2026, 91 FR 9437, Doc. 2026-03832) terminating IEEPA reciprocal duties \u2014 the most recent action affecting this lane.\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"IEEPA Reciprocal Tariff (EO 14257/EO 14326): Thailand's 19% reciprocal rate terminated by EO 14389 of February 20, 2026 (91 FR 9437); effective Feb 20, 2026; no longer in effect and no longer collected. Confirmed terminated.\",\n    \"Section 232 (steel/aluminum/copper/auto/wood deriv.): HTS 4013.20.00 (rubber bicycle inner tubes) is not within the enumerated derivative-article scope of any active Section 232 proclamation; no Section 232 duty applied on this product.\",\n    \"Section 301 (original China-related Lists 1\\\\u20134 and subsequent modifications): HTS 4013.20.00 from Thailand is not on the Section 301 China-targeting tariff lists; the lists apply to imports of PRC origin, not Thailand. No active Section 301 duty applies to this product/origin pair.\",\n    \"Section 301 (USTR Docket USTR-2026-0067/0068 structural-excess-capacity investigation initiated March 11, 2026 against Thailand and 15 other economies): investigation open; USTR has not made a Section 301 affirmative determination nor imposed any Section 301 tariff on HTS 4013.20.00 from Thailand as of the research date. Not yet in force.\",\n    \"IEEPA Reciprocal Annex II (products excluded from the Thailand reciprocal duty): moot \\\\u2014 the underlying IEEPA reciprocal duty was terminated by EO 14389 (Feb 20, 2026); exclusion is no longer operative.\"\n  ],\n  \"additional_duties\": [],\n  \"origin_rules_notes\": \"HTS 4013.20.00 covers 'Inner tubes, of rubber: Of a kind used on bicycles.' Column 1 General (MFN) rate is 'Free' (not reported here per instructions). Section 232 product lists (steel/aluminum/copper/derivatives, autos and auto parts, timber/lumber, semiconductors, pharmaceuticals) do not include HTS 4013. Section 301 investigations of Thailand were initiated in 2026 (forced-labor, structural excess capacity) but, as of the research date, neither has resulted in an implemented duty on bicycle inner tubes. IEEPA reciprocal 19% rate on Thailand was terminated by EO 14389 (Feb 20, 2026, 91 FR 9437), following Supreme Court ruling in Learning Resources, Inc. v. Trump, 607 U.S. ___ (2026).\",\n  \"exclusions_in_force\": []\n}\n\nSources:\n- Federal Register :: Initiation of Section 301 Investigations: Acts, ... \u2014 https://federalregister.gov/documents/2026/03/17/2026-05214/initiation-of-section-301-investigations-acts-policies-and-practices-of-certain-economies-relating (primary)\n- Federal Register :: Ending Certain Tariff Actions \u2014 https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions (primary)\n- Further Modifying the Reciprocal Tariff Rates \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates (primary)\n- Fact Sheet: The United States and Thailand Reach a Framework for ... \u2014 https://ustr.gov/about/policy-offices/press-office/fact-sheets/2025/october/fact-sheet-united-states-and-thailand-reach-framework-agreement-reciprocal-trade (primary)\n- Federal Register :: Implementing Certain Tariff-Related Elements ... \u2014 https://federalregister.gov/documents/2026/05/28/2026-10571/implementing-certain-tariff-related-elements-of-a-trade-and-security-agreement-between-the-american (primary)\n- Trade Remedies | U.S. Customs and Border Protection \u2014 https://cbp.gov/trade/programs-administration/trade-remedies (primary)\n- How to Navigate the Section 301 Tariff Process | United States ... \u2014 https://ustr.gov/issue-areas/enforcement/section-301-investigations/search (primary)\n- International Emergency Economic Powers Act (IEEPA) Frequently ... \u2014 https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ (primary)\n- 4016.99.60.50 - Harmonized Tariff Schedule - USITC \u2014 https://hts.usitc.gov/search?query=4016996050 (primary)",
+  "metadata": {
+    "run_id": "task_run_2a485ce37ecb48a4b306b23f30761e75",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/03/17/2026-05214/initiation-of-section-301-investigations-acts-policies-and-practices-of-certain-economies-relating",
+        "source_category": "official",
+        "title": "Federal Register :: Initiation of Section 301 Investigations: Acts, ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Federal Register :: Ending Certain Tariff Actions"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+        "source_category": "official",
+        "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/about/policy-offices/press-office/fact-sheets/2025/october/fact-sheet-united-states-and-thailand-reach-framework-agreement-reciprocal-trade",
+        "source_category": "official",
+        "title": "Fact Sheet: The United States and Thailand Reach a Framework for ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/05/28/2026-10571/implementing-certain-tariff-related-elements-of-a-trade-and-security-agreement-between-the-american",
+        "source_category": "official",
+        "title": "Federal Register :: Implementing Certain Tariff-Related Elements ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/trade-remedies",
+        "source_category": "official",
+        "title": "Trade Remedies | U.S. Customs and Border Protection"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/search",
+        "source_category": "official",
+        "title": "How to Navigate the Section 301 Tariff Process | United States ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ",
+        "source_category": "official",
+        "title": "International Emergency Economic Powers Act (IEEPA) Frequently ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/search?query=4016996050",
+        "source_category": "official",
+        "title": "4016.99.60.50 - Harmonized Tariff Schedule - USITC"
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/03/17/2026-05214/initiation-of-section-301-investigations-acts-policies-and-practices-of-certain-economies-relating",
+            "excerpts": [
+              "public hearings ... May 5, 2026 ... [USTR] must determine whether the act, policy, or practice under investigation is actionable under section 301. If that determination is affirmative, the U.S. Trade Representative must determine whether action is appropriate, and if so, what action to take."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Initiation of Section 301 Investigations: Acts, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "In light of recent events, the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14257, as amended ... shall no longer be in effect and, as soon as practicable, shall no longer be collected"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "Annex I: Thailand 19 percent reciprocal tariff, adjusted"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          },
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/fact-sheets/2025/october/fact-sheet-united-states-and-thailand-reach-framework-agreement-reciprocal-trade",
+            "excerpts": [
+              "The United States will maintain a 19 percent reciprocal tariff rate for imports of Thailand"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Fact Sheet: The United States and Thailand Reach a Framework for ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/05/28/2026-10571/implementing-certain-tariff-related-elements-of-a-trade-and-security-agreement-between-the-american",
+            "excerpts": [
+              "Learning Resources, Inc. et al. v. Trump et al., 607 U.S. ___ (2026), as Learning Resources concluded only that the President lacked the authority under the International Emergency Economic Powers Act (IEEPA) to impose additional tariffs on imports into the United States"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Implementing Certain Tariff-Related Elements ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/trade-remedies",
+            "excerpts": [
+              "Section 232 Import Duties on ... Aluminum, Steel, and Copper ... Tariffs ... Timber, Lumber, and their Derivative Products"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Trade Remedies | U.S. Customs and Border Protection"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/search",
+            "excerpts": [
+              "Section 301 investigations \\u2014 China-related action (List 1, 2, 3, 4A)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "How to Navigate the Section 301 Tariff Process | United States ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/03/17/2026-05214/initiation-of-section-301-investigations-acts-policies-and-practices-of-certain-economies-relating",
+            "excerpts": [
+              "On March 11, 2026, the U.S. Trade Representative initiated section 301 investigations ... [Thailand is one of the sixteen] investigated economies. Public hearings scheduled May 5, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Initiation of Section 301 Investigations: Acts, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ",
+            "excerpts": [
+              "Annex-II.pdf \\u2013 List of excluded products from IEEPA Reciprocal tariffs"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "International Emergency Economic Powers Act (IEEPA) Frequently ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "The additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14257, as amended ... shall no longer be in effect"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[4]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "EO 14389 of February 20, 2026 (Ending Certain Tariff Actions), 91 FR 9437 (Feb. 25, 2026); 'the additional ad valorem duties imposed pursuant to IEEPA in ... Executive Order 14257 ... shall no longer be in effect and, as soon as practicable, shall no longer be collected.'"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.data_as_of_date",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/search?query=4016996050",
+            "excerpts": [
+              "4013.20.00 | [00] | Of a kind used on bicycles | No. | Free | 30%"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "4016.99.60.50 - Harmonized Tariff Schedule - USITC"
+          },
+          {
+            "url": "https://cbp.gov/trade/programs-administration/trade-remedies",
+            "excerpts": [
+              "CBP Trade Remedies page enumerates Section 232 only over Steel/Aluminum/Copper (and derivatives under 9903.82.02 and 9903.82.04-9903.82.19), Timber/Lumber, Semiconductors, Pharmaceuticals, and Autos/Auto Parts; rubber inner tubes HTS 4013 not listed."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Trade Remedies | U.S. Customs and Border Protection"
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "'the additional ad valorem duties imposed pursuant to IEEPA in ... Executive Order 14257 ... shall no longer be in effect and, as soon as practicable, shall no longer be collected'; 'This order does not affect ... duties imposed under section 232 ... and section 301.'"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/4013.20.00_United-States.rate.json
+++ b/apps/llamaindex-tariff-desk/data/samples/4013.20.00_United-States.rate.json
@@ -1,0 +1,154 @@
+{
+  "lane": {
+    "hts_code": "4013.20.00",
+    "origin": "Thailand",
+    "destination": "United States",
+    "product": ""
+  },
+  "lane_key": "4013.20.00|Thailand|United States",
+  "doc_key": "4013.20.00|United States",
+  "kind": "rate",
+  "doc_id": "4013.20.00|United States#rate",
+  "researched_at": "2026-08-05T13:15:45.915555+00:00",
+  "elapsed_s": 32.1,
+  "text": "{\n  \"origin\": \"Thailand\",\n  \"hts_code\": \"4013.20.00\",\n  \"source_url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease\",\n  \"destination\": \"United States\",\n  \"general_rate\": \"Free\",\n  \"htsus_revision\": \"Revision 15 (2026)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"retrieval_notes\": \"Read directly from the USITC HTSUS Chapter 40 document at hts.usitc.gov (Chapter 40, current release). No mirrors needed as the official schedule was successfully retrieved on the first attempt.\",\n  \"verified_against_official_schedule\": true\n}\n\nSources:\n- Harmonized Tariff Schedule of the United States Revision ... \u2014 https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease (primary)",
+  "metadata": {
+    "run_id": "task_run_93194987b01349ef88b72c41ac792cd9",
+    "agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "web_search_agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "effort": "medium",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease",
+        "source_category": "official",
+        "title": "Harmonized Tariff Schedule of the United States Revision ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes \u2014 CHAPTER 40 \u2014 Inner tubes, of rubber"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease",
+            "excerpts": [
+              "4013.20.00 00 | Of a kind used on bicycles | No. | Free | 30%"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.general_rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.htsus_revision",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease",
+            "excerpts": [
+              "retrieved: 2026-08-05"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) \u2014 Chapter 40 \u2014 page 40-18 \u2014 Inner tubes, of rubber \u2014 4013.20.00 Of a kind used on bicycles: No. | Free | 30%"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.retrieval_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease",
+            "excerpts": [
+              "Source URL: https://hts.usitc.gov/reststop/file?filename=Chapter+40&release=currentRelease \u2014 official USITC HTSUS publication, source_category=official"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.verified_against_official_schedule",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/4901.99.00_United-Kingdom_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/4901.99.00_United-Kingdom_United-States.overlay.json
@@ -1,0 +1,538 @@
+{
+  "lane": {
+    "hts_code": "4901.99.00",
+    "origin": "United Kingdom",
+    "destination": "United States",
+    "product": "printed books"
+  },
+  "lane_key": "4901.99.00|United Kingdom|United States",
+  "doc_key": "4901.99.00|United Kingdom|United States",
+  "kind": "overlay",
+  "doc_id": "4901.99.00|United Kingdom|United States#overlay",
+  "researched_at": "2026-08-05T12:36:29.443070+00:00",
+  "elapsed_s": 250.3,
+  "text": "{\n  \"origin\": \"United Kingdom\",\n  \"product\": \"printed books\",\n  \"hts_code\": \"4901.99.00\",\n  \"unverified\": [\n    \"Section 232 Pharmaceuticals \u2014 a Section 232 investigation on pharmaceuticals and pharmaceutical ingredients is contemplated under EO 14309 of June 16, 2025 (U.S.-UK Economic Prosperity Deal Sec. 1); whether a tariff proclamation with a rate has been issued for pharmaceutical products as of 2026-08-05 could not be verified from an official instrument in the corpus. Attempted: /pages/whitehouse.gov/presidential-actions-2025-06-implementing-the-general-terms--ea3364a4.md (referenced but no rate set); no source page confirmed a finished Section 232 pharmaceuticals tariff instrument with a rate covering HTS chapter 30 (the closest chapter; not 4901).\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"2025-11-20 \u2014 EO 14358 modified Annex II of EO 14257 to remove additional agricultural products from reciprocal scope (no change to 10% baseline for non-agricultural UK goods such as printed books).\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"Section 232 Steel (Proclamation 9705 of March 8, 2018 as amended; Proclamation 10896 of February 10, 2025; UK 25% rate per EO 14309) \u2014 out of scope: HTS 4901.99.00 is not a steel article or derivative under Chapters 72/73.\",\n    \"Section 232 Aluminum (Proclamation 9704 of March 8, 2018 as amended; Proclamation 10895 of February 10, 2025; UK 25% rate per EO 14309) \u2014 out of scope: HTS 4901.99.00 is not an aluminum article or derivative under Chapter 76.\",\n    \"Section 232 Autos and Auto Parts (Proclamation 10908 of March 26, 2025; UK within 100,000-vehicle quota at 10% total per EO 14309; 10% UK auto parts total effective June 30, 2025) \u2014 out of scope: HTS 4901.99.00 is not classified under HTS heading 8703 or 8708.\",\n    \"Section 232 Medium and Heavy-Duty Vehicles (Proclamation 10908 as amended; 25% Section 232 on MHDVs/parts, 10% on buses, effective November 1, 2025) \u2014 out of scope: HTS 4901.99.00 is not a medium or heavy-duty vehicle or part.\",\n    \"Section 232 Copper (Proclamation 10962 of July 30, 2025; 50% on semi-finished copper products and intensive copper derivatives effective August 1, 2025) \u2014 out of scope: HTS 4901.99.00 is not a copper article or copper-intensive derivative.\",\n    \"Section 232 Timber/Lumber and Derived Articles \u2014 UK 10% on upholstered wooden furniture, kitchen cabinets and vanities per EO 14309 of June 16, 2025 effective October 14, 2025 \u2014 out of scope: HTS 4901.99.00 (printed books) is not timber, lumber, upholstered wooden furniture, a kitchen cabinet, or a vanity.\",\n    \"Section 232 Semiconductors (25% on certain semiconductors and derivatives effective January 15, 2026) \u2014 out of scope: HTS 4901.99.00 is not a semiconductor article or derivative.\",\n    \"Section 301 China Tariff Actions (Lists 1, 2, 3, 4A; active USTR investigation; product exclusions extended through November 10, 2026 by 90 FR 50947) \u2014 out of scope: HTS 4901.99.00 is a UK-origin printed book; Section 301 tariffs apply only to People's Republic of China-origin goods.\",\n    \"IEEPA Fentanyl Tariff (EO 14195 of February 1, 2025; raised to 20% by EO 14228 of March 3, 2025; reduced to 10% effective November 10, 2025 by EO 14357 of November 4, 2025) \u2014 out of scope: applies only to People's Republic of China-origin articles; UK is not PRC.\",\n    \"Reciprocal Tariff country-specific rate (Annex I of EO 14257 as amended by EO 14326 of July 31, 2025 and EO 14346 of September 5, 2025) \u2014 confirmed not to apply: United Kingdom is not enumerated in the 95-country Annex I list (only EU, Japan, South Korea, Switzerland, Liechtenstein among close partners received negotiated replacement rates); UK falls under the 10% rest-of-countries baseline per Sec. 2(d) of EO 14326.\",\n    \"United Kingdom Civil Aircraft Exemption from IEEPA Reciprocal duties (per CBP overview as of October 14, 2025 and EO 14309 Sec. 3 Aerospace) \u2014 out of scope: HTS 4901.99.00 (printed books) is not a civil aircraft or civil aircraft part under the WTO Agreement on Trade in Civil Aircraft.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"10%\",\n      \"in_force\": true,\n      \"authority\": \"Executive Order 14257 of April 2, 2025 (Regulating Imports With a Reciprocal Tariff To Rectify Trade Practices That Contribute to Large and Persistent Annual United States Goods Trade Deficits), as amended by Executive Order 14326 of July 31, 2025; Executive Order 14346 of September 5, 2025; and Executive Order 14358 of November 20, 2025\",\n      \"source_url\": \"https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and\",\n      \"effective_date\": \"2025-04-05\"\n    }\n  ],\n  \"origin_rules_notes\": \"United Kingdom is not enumerated in Annex I of EO 14257 (or its successors EO 14326 and EO 14346). UK-origin goods fall under the universal rest-of-countries 10% IEEPA reciprocal rate. UK has no separate \\\"replacement\\\" rate agreement like the EU, Japan, South Korea, Switzerland, Liechtenstein; no Section 301 actions apply (China-only); no IEEPA fentanyl actions apply (China-only). Section 232 special UK rates (steel 25%, aluminum 25%, autos 10% within 100k quota, MHDV 10%, auto parts 10% total, upholstered wooden furniture 10%) cover specific steel/aluminum/auto/copper/timber/semiconductor chapters and do NOT extend to printed books (HTS 4901.99.00).\",\n  \"exclusions_in_force\": []\n}\n\nSources:\n- Implementing the General Terms of The United States of America-United ... \u2014 https://whitehouse.gov/presidential-actions/2025/06/implementing-the-general-terms-of-the-united-states-of-america-united-kingdom-economic-prosperity-deal (primary)\n- Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ... \u2014 https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs (primary)\n- Office of Trade | Trade Remedies U.S. Tariff Overview \u2014 https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf (primary)\n- China Section 301-Tariff Actions and Exclusion Process | United ... \u2014 https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions (primary)\n- Federal Register :: Notice of Modification of Section 301 Action: ... \u2014 https://federalregister.gov/documents/2025/11/13/2025-19873/notice-of-modification-of-section-301-action-chinas-targeting-of-the-maritime-logistics-and (primary)\n- Modifying Duties Addressing the Synthetic Opioid Supply Chain in ... \u2014 https://whitehouse.gov/presidential-actions/2025/11/modifying-duties-addressing-the-synthetic-opioid-supply-chain-in-the-peoples-republic-of-china (primary)\n- EXECUTIVE ORDER 14257 - - - - - - - \u2014 https://public-inspection.federalregister.gov/2025-06063.pdf (primary)\n- Federal Register :: Further Modifying the Reciprocal Tariff Rates \u2014 https://federalregister.gov/documents/2025/08/06/2025-15010/further-modifying-the-reciprocal-tariff-rates (primary)\n- Federal Register :: Regulating Imports With a Reciprocal Tariff ... \u2014 https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and (primary)\n- Modifying the Scope of the Reciprocal Tariff with Respect to Certain ... \u2014 https://whitehouse.gov/presidential-actions/2025/11/modifying-the-scope-of-the-reciprocal-tariff-with-respect-to-certain-agricultural-products (primary)",
+  "metadata": {
+    "run_id": "task_run_5c46c579080343c49a2b418a0ca0e2ee",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 96% and trust per claim ratio is 95%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2025/06/implementing-the-general-terms-of-the-united-states-of-america-united-kingdom-economic-prosperity-deal",
+        "source_category": "official",
+        "title": "Implementing the General Terms of The United States of America-United ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+        "source_category": "official",
+        "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+        "source_category": "official",
+        "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions",
+        "source_category": "official",
+        "title": "China Section 301-Tariff Actions and Exclusion Process | United ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/11/13/2025-19873/notice-of-modification-of-section-301-action-chinas-targeting-of-the-maritime-logistics-and",
+        "source_category": "official",
+        "title": "Federal Register :: Notice of Modification of Section 301 Action: ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-duties-addressing-the-synthetic-opioid-supply-chain-in-the-peoples-republic-of-china",
+        "source_category": "official",
+        "title": "Modifying Duties Addressing the Synthetic Opioid Supply Chain in ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://public-inspection.federalregister.gov/2025-06063.pdf",
+        "source_category": "other",
+        "title": "EXECUTIVE ORDER 14257 - - - - - - -"
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/08/06/2025-15010/further-modifying-the-reciprocal-tariff-rates",
+        "source_category": "official",
+        "title": "Federal Register :: Further Modifying the Reciprocal Tariff Rates"
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and",
+        "source_category": "official",
+        "title": "Federal Register :: Regulating Imports With a Reciprocal Tariff ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-the-scope-of-the-reciprocal-tariff-with-respect-to-certain-agricultural-products",
+        "source_category": "official",
+        "title": "Modifying the Scope of the Reciprocal Tariff with Respect to Certain ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/06/implementing-the-general-terms-of-the-united-states-of-america-united-kingdom-economic-prosperity-deal",
+            "excerpts": [
+              "the United States and the United Kingdom committed to negotiate significantly preferential treatment outcomes on pharmaceuticals and pharmaceutical ingredients that are products of the United Kingdom, contingent on the findings of an investigation regarding pharmaceuticals and pharmaceutical ingredients under section 232."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Implementing the General Terms of The United States of America-United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+            "excerpts": [
+              "Section 232 FAQs: 'Only HTS Codes defined in the Presidential Proclamation should be reported for additional duty.' Steel/aluminum duties target Chapter 72/73/76."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/06/implementing-the-general-terms-of-the-united-states-of-america-united-kingdom-economic-prosperity-deal",
+            "excerpts": [
+              "Sec. 4. Aluminum and Steel Articles and Their Derivative Articles \u2014 UK 25% applies to steel/aluminum articles and derivatives as products of the United Kingdom."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Implementing the General Terms of The United States of America-United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "Steel/Aluminum Section 232 \u2014 UK at 25%; printed books (HTS 4901) are not within Chapters 72/73/76 scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/06/implementing-the-general-terms-of-the-united-states-of-america-united-kingdom-economic-prosperity-deal",
+            "excerpts": [
+              "Sec. 4 establishes UK-specific tariff-rate quota for aluminum/steel articles and derivatives only."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Implementing the General Terms of The United States of America-United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "Autos and Auto Parts \u2014 HTS heading 8703 and parts covered; UK 10% within quota; printed books not in scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/06/implementing-the-general-terms-of-the-united-states-of-america-united-kingdom-economic-prosperity-deal",
+            "excerpts": [
+              "Sec. 2. Automobiles and Automobile Parts \u2014 covers HTSUS heading 8703 and parts of heading 8708; UK 10% within 100,000-unit quota."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Implementing the General Terms of The United States of America-United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "MHDVs \u2014 25% on MHDVs and their parts; 10% on buses; printed books (HTS 4901) are out of scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "Copper \u2014 50% on semi-finished copper products and intensive copper derivative products (copper content); printed books not in scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[4]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "Timber, Lumber, and their Derivative Products \u2014 10% on upholstered wooden furniture; completed kitchen cabinets, vanities, and their parts from the UK; printed books not covered."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[5]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "Semiconductors \u2014 25% on certain semiconductors and their derivatives; printed books (HTS 4901) are out of scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[6]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions",
+            "excerpts": [
+              "China Section 301-Tariff Actions and Exclusion Process \u2014 investigation targets PRC acts/policies; lists apply only to PRC origin."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "China Section 301-Tariff Actions and Exclusion Process | United ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2025/11/13/2025-19873/notice-of-modification-of-section-301-action-chinas-targeting-of-the-maritime-logistics-and",
+            "excerpts": [
+              "The actions taken in this investigation are suspended... through 11:59 p.m. Eastern Standard Time on November 9, 2026 \u2014 China maritime/shipbuilding; targeted at PRC origin only."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification of Section 301 Action: ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[7]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-duties-addressing-the-synthetic-opioid-supply-chain-in-the-peoples-republic-of-china",
+            "excerpts": [
+              "In Executive Order 14195 of February 1, 2025 \u2014 Imposing Duties To Address the Synthetic Opioid Supply Chain in the People's Republic of China... imposed an additional ad valorem rate of duty of 10 percent on articles that are products of the PRC."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Modifying Duties Addressing the Synthetic Opioid Supply Chain in ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[8]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2025-06063.pdf",
+            "excerpts": [
+              "ANNEX I \u2014 Country Reciprocal Tariff, Adjusted \u2014 list enumerates 57 countries by name; United Kingdom is not among the countries listed (Zimbabwe at 18% is the final entry on page 43722)."
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "EXECUTIVE ORDER 14257 - - - - - - -"
+          },
+          {
+            "url": "https://federalregister.gov/documents/2025/08/06/2025-15010/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "Sec. 2(d): Goods of any foreign trading partner that is not listed in Annex I to this order will be subject to an additional ad valorem rate of duty of 10 percent."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Further Modifying the Reciprocal Tariff Rates"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[9]",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "UK Economic Prosperity Deal \u2014 Civil aircraft exemption from 232 steel/aluminum and IEEPA Reciprocal duties (October 14, 2025)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/06/implementing-the-general-terms-of-the-united-states-of-america-united-kingdom-economic-prosperity-deal",
+            "excerpts": [
+              "Sec. 3. Aerospace \u2014 tariffs imposed through Proclamation 9704/9705 and EO 14257 shall no longer apply to products of the United Kingdom that fall under the WTO Agreement on Trade in Civil Aircraft."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Implementing the General Terms of The United States of America-United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[10]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "low",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "No usable citation resolved for this value"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "As of November 13, 2025: '10% to 41% for 95 countries (see list in Annex I on WhiteHouse.gov); 10% for rest of countries.'"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and",
+            "excerpts": [
+              "Sec. 3. Implementation. (a) Except as otherwise provided in this order, all articles imported into the customs territory of the United States shall be, consistent with law, subject to an additional ad valorem rate of duty of 10 percent. Such rates of duty shall apply with respect to goods entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern daylight time on April 5, 2025."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Regulating Imports With a Reciprocal Tariff ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and",
+            "excerpts": [
+              "Executive Order of April 2, 2025 \u2014 Regulating Imports With a Reciprocal Tariff To Rectify Trade Practices That Contribute to Large and Persistent Annual United States Goods Trade Deficits (90 FR 15041)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Regulating Imports With a Reciprocal Tariff ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2025/08/06/2025-15010/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "Sec. 2(d): Goods of any foreign trading partner that is not listed in Annex I to this order will be subject to an additional ad valorem rate of duty of 10 percent."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Further Modifying the Reciprocal Tariff Rates"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and",
+            "excerpts": [
+              "90 FR 15041; April 7, 2025."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Regulating Imports With a Reciprocal Tariff ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/04/07/2025-06063/regulating-imports-with-a-reciprocal-tariff-to-rectify-trade-practices-that-contribute-to-large-and",
+            "excerpts": [
+              "12:01 a.m. eastern daylight time on April 5, 2025."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Regulating Imports With a Reciprocal Tariff ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "CBP Publication No. 5328-0126, January 30, 2026"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-the-scope-of-the-reciprocal-tariff-with-respect-to-certain-agricultural-products",
+            "excerpts": [
+              "I have determined that it is necessary and appropriate to further modify the scope of products subject to the reciprocal tariff imposed under Executive Order 14257, as amended. Specifically, I have determined that certain agricultural products shall not be subject to the reciprocal tariff imposed under Executive 14257, as amended."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Modifying the Scope of the Reciprocal Tariff with Respect to Certain ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "As of November 13, 2025: '10% to 41% for 95 countries (see list in Annex I on WhiteHouse.gov); 10% for rest of countries.'"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          },
+          {
+            "url": "https://public-inspection.federalregister.gov/2025-06063.pdf",
+            "excerpts": [
+              "ANNEX I \u2014 Country Reciprocal Tariff, Adjusted \u2014 list of 57 countries excludes United Kingdom."
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "EXECUTIVE ORDER 14257 - - - - - - -"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/4901.99.00_United-States.rate.json
+++ b/apps/llamaindex-tariff-desk/data/samples/4901.99.00_United-States.rate.json
@@ -1,0 +1,163 @@
+{
+  "lane": {
+    "hts_code": "4901.99.00",
+    "origin": "United Kingdom",
+    "destination": "United States",
+    "product": "printed books"
+  },
+  "lane_key": "4901.99.00|United Kingdom|United States",
+  "kind": "rate",
+  "doc_id": "4901.99.00|United States#rate",
+  "researched_at": "2026-08-05T11:11:50.967249+00:00",
+  "elapsed_s": 78.6,
+  "text": "{\n  \"origin\": \"United Kingdom\",\n  \"product\": \"printed books\",\n  \"hts_code\": \"4901.99.00\",\n  \"source_url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease\",\n  \"destination\": \"United States\",\n  \"general_rate\": \"Free\",\n  \"htsus_revision\": \"Revision 15 (2026)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"retrieval_notes\": \"4901.99.00 (\\\"Other \u2014 printed books, brochures, leaflets and similar printed matter\\\") \u2014 Column 1 General (MFN) rate: Free. Read from USITC HTSUS Revision 15 (2026), annotated Chapter 49 (https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease). This is the base schedule rate only; Section 301 (\u00a79903.88), Section 232, IEEPA, and reciprocal-tariff overlays are not folded into this figure.\",\n  \"verified_against_official_schedule\": true\n}\n\nSources:\n- Harmonized Tariff Schedule of the United States Revision ... \u2014 https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease (primary)",
+  "metadata": {
+    "run_id": "task_run_a30e3133e73046d8a65a161019366ebb",
+    "agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "web_search_agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "effort": "medium",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+        "source_category": "official",
+        "title": "Harmonized Tariff Schedule of the United States Revision ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+            "excerpts": [
+              "4901.99.00 | Other | Free | Free *1/*"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+            "excerpts": [
+              "4901.99.00 | Other | Free | Free *1/*"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.general_rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.htsus_revision",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+            "excerpts": [
+              "<!-- corpus-meta {\"url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease\", \"title\": \"Harmonized Tariff Schedule of the United States Revision ...\", \"source_category\": \"official\", \"retrieved\": \"2026-08-05\", ... -->"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+            "excerpts": [
+              "4901.99.00 | Other | Free | Free *1/*"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.retrieval_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease",
+            "excerpts": [
+              "<!-- corpus-meta {\"url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+49&release=currentRelease\", \"title\": \"Harmonized Tariff Schedule of the United States Revision ...\", \"source_category\": \"official\", ... -->"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.verified_against_official_schedule",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      }
+    ]
+  },
+  "doc_key": "4901.99.00|United States",
+  "collapsed_from": [
+    "4901.99.00|United Kingdom|United States"
+  ]
+}

--- a/apps/llamaindex-tariff-desk/data/samples/6109.10.00_Bangladesh_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/6109.10.00_Bangladesh_United-States.overlay.json
@@ -1,0 +1,394 @@
+{
+  "lane": {
+    "hts_code": "6109.10.00",
+    "origin": "Bangladesh",
+    "destination": "United States",
+    "product": "cotton knit t-shirts"
+  },
+  "lane_key": "6109.10.00|Bangladesh|United States",
+  "doc_key": "6109.10.00|Bangladesh|United States",
+  "kind": "overlay",
+  "doc_id": "6109.10.00|Bangladesh|United States#overlay",
+  "researched_at": "2026-08-05T12:38:02.951762+00:00",
+  "elapsed_s": 358.8,
+  "text": "{\n  \"origin\": \"Bangladesh\",\n  \"product\": \"cotton knit t-shirts\",\n  \"hts_code\": \"6109.10.00\",\n  \"unverified\": [\n    \"Bangladesh Agreement on Reciprocal Trade (signed February 9, 2026) \u2014 Schedule 2 caps the ad valorem reciprocal rate on Bangladesh at 19% (zero on Annex III aligned-partner products), but per Article 6.6 the agreement \\\"shall enter into force 60 days after the date on which the Parties have exchanged written notifications certifying completion of their applicable legal procedures or on such other date as the Parties may decide.\\\" Attempted official sources: Federal Register (no proclamation or notice of entry into force found), White House presidential actions (no implementing executive order found in corpus), USTR site (presidential tariff actions listing and fact sheets show signing on Feb 9, 2026 but no entry-into-force notice). Cannot confirm entry into force before August 5, 2026; the 19% rate therefore cannot be verified to be in force today.\",\n    \"Bangladesh textile/apparel TRQs under Sec. 2 of the July 23, 2026 Section 301 forced-labor memorandum \u2014 directed to be established \\\"as soon as feasible\\\" and stated to be feasible by September 1, 2026; until TRQs are established, Sec. 2(c) imposes the Section 301 10% on specific textile and apparel of Bangladesh. As of research date the TRQs have not been established; only the 10% tracks any current effect on HTS 6109.10.00. Future TRQ volumes (which would allow zero Section 301 rate on covered apparel) were not located by source-value in Federal Register.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"Section 301 forced-labor tariff on all goods of Bangladesh became effective at 12:01 a.m. ET on July 24, 2026, per USTR Federal Register notice of actions in the Section 301 forced-labor investigations (institutional date: July 23, 2026).\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"Section 232 (steel/aluminum/copper/autos/lumber/aerospace/semiconductors) \u2014 out of scope for HTS 6109.10.00 (cotton knit t-shirts). No apparel subheading is covered by Section 232.\",\n    \"Section 122 temporary import surcharge (Proclamation of February 20, 2026) \u2014 10% on all imports of Bangladesh starting Feb 24, 2026 for 150 days; window closed July 24, 2026. Out of force on the research date.\",\n    \"Section 301 China List 3 (and other China-origin Section 301 actions) \u2014 out of scope by origin; goods are from Bangladesh, not China.\",\n    \"IEEPA Reciprocal Tariff (EO 14257 of April 2, 2025, as amended by EO 14326 of July 31, 2025 and EO 14346 of September 5, 2025; Bangladesh line 9903.02.05 at 20%) \u2014 struck down by Supreme Court IEEPA ruling; IEEPA ad valorem duties terminated by EO 14389 of February 20, 2026 (\\\"Ending Certain Tariff Actions\\\"); duties no longer collected. Fentanyl IEEPA tariffs (EO 14193/14194/14195) also terminated.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"10%\",\n      \"in_force\": true,\n      \"authority\": \"Presidential Memorandum of July 23, 2026 on Section 301 (forced-labor) investigations; USTR Federal Register notice of modification to the HTSUS implementing Sections 1(a)(i) and 2(c), 91 FR (FR Doc. 2026-15181)\",\n      \"source_url\": \"https://public-inspection.federalregister.gov/2026-15181.pdf\",\n      \"effective_date\": \"2026-07-24\"\n    }\n  ],\n  \"origin_rules_notes\": \"Bangladesh is named in the Section 301 (forced labor) list at 10% as one of the economies that \\\"have undertaken commitments in their respective Agreements on Reciprocal Trade regarding forced labor import prohibitions.\\\" The Section 301 textile TRQ mechanism for Bangladesh is described as feasible by September 1, 2026 but is not yet implemented; until then the Section 301 10% applies to specific textile and apparel of Bangladesh per Sec. 2(c). Bangladesh is not on the Section 232 scope list (steel/aluminum/copper/autos/lumber/aerospace/semiconductors). Bangladesh was subject to the IEEPA reciprocal EO 14257 at 20% (9903.02.05) until those IEEPA duties were terminated.\",\n  \"exclusions_in_force\": []\n}\n\nSources:\n- U.S. BGD Agreement on Reciprocal Trade ... \u2014 https://ustr.gov/sites/default/files/files/Press/Releases/2026/U.S.%20BGD%20Agreement%20on%20Reciprocal%20Trade%20Final%2009FEB2026%20LETTER.pdf (primary)\n- Presidential Tariff Actions | United States Trade Representative \u2014 https://ustr.gov/trade-topics/presidential-tariff-actions (primary)\n- Actions by the United States in the Investigations under Section ... \u2014 https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and (primary)\n- 1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ... \u2014 https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf (primary)\n- Office of Trade | Trade Remedies U.S. Tariff Overview \u2014 https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf (primary)\n- https://www.whitehouse.gov/presidential-actions/2026/02/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems/ \u2014 https://whitehouse.gov/presidential-actions/2026/02/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems (primary)\n- Ending Certain Tariff Actions \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions (primary)\n- 2026-15181.pdf \u2014 https://public-inspection.federalregister.gov/2026-15181.pdf (primary)",
+  "metadata": {
+    "run_id": "task_run_e7bb90b8a4904dffbde56f310ad59d0f",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 94% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/U.S.%20BGD%20Agreement%20on%20Reciprocal%20Trade%20Final%2009FEB2026%20LETTER.pdf",
+        "source_category": "official",
+        "title": "U.S. BGD Agreement on Reciprocal Trade ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/trade-topics/presidential-tariff-actions",
+        "source_category": "official",
+        "title": "Presidential Tariff Actions | United States Trade Representative"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+        "source_category": "official",
+        "title": "Actions by the United States in the Investigations under Section ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+        "source_category": "official",
+        "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+        "source_category": "official",
+        "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/02/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+        "source_category": "official",
+        "title": "https://www.whitehouse.gov/presidential-actions/2026/02/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems/"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Ending Certain Tariff Actions \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://public-inspection.federalregister.gov/2026-15181.pdf",
+        "source_category": "other",
+        "title": "2026-15181.pdf"
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/U.S.%20BGD%20Agreement%20on%20Reciprocal%20Trade%20Final%2009FEB2026%20LETTER.pdf",
+            "excerpts": [
+              "\"Article 6.6: Entry Into Force \u2014 This Agreement shall enter into force 60 days after the date on which the Parties have exchanged written notifications certifying completion of their applicable legal procedures or on such other date as the Parties may decide.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "U.S. BGD Agreement on Reciprocal Trade ..."
+          },
+          {
+            "url": "https://ustr.gov/trade-topics/presidential-tariff-actions",
+            "excerpts": [
+              "USTR Presidential Tariff Actions listing enumerates the Bangladesh signing artifacts but does not include a subsequent proclamation implementing or bringing the Agreement into force on the Federal Register side; the only FR documents referring to the Agreement are the Bangladesh agreement text and the IEEPA-strike EO 14389 cross-references."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Presidential Tariff Actions | United States Trade Representative"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+            "excerpts": [
+              "\"After considering the relevant issues and factors and weighing the relevant considerations, including potential economic harm and efficacy of tariffs, I determine that establishing these TRQs is not feasible at this time, but that establishing these TRQs will be feasible by September 1, 2026.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Actions by the United States in the Investigations under Section ..."
+          },
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"Until the Trade Representative establishes the TRQs described in subsections (a) and (b) of this section, the Trade Representative shall impose the applicable section 301 tariffs provided for in section 1(a) of this memorandum (here, 10 percent) on imports of specific textile and apparel of Bangladesh, Cambodia, Indonesia, and Malaysia\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "\"Section 232 scope: Steel; Aluminum; Copper Semicon; Autos and Auto Parts; Medium- and Heavy-Duty Vehicles; Timber, Lumber, and their Derivative Products. No textile/apparel subheading listed.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+            "excerpts": [
+              "\"The HTSUS shall be modified as provided in Annex I to this proclamation. The modifications shall be effective...on or after 12:01 a.m. eastern standard time on February 24, 2026, and shall continue in effect through 12:01 a.m. eastern daylight time on July 24, 2026\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://www.whitehouse.gov/presidential-actions/2026/02/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems/"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "\"China/Hong Kong...10% on all goods Additional 10% IEEPA Reciprocal rate\" (applies to People's Republic of China origin, not Bangladesh)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "\"In light of recent events, the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193, as amended; Executive Order 14194, as amended; Executive Order 14195, as amended; Executive Order 14245; Executive Order 14257, as amended...shall no longer be in effect and, as soon as practicable, shall no longer be collected.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+            "excerpts": [
+              "\"The Trade Representative may modify or terminate the tariffs, exemptions, or TRQs for an economy, as appropriate\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Actions by the United States in the Investigations under Section ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "Information absence is supported by cited evidence"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+            "excerpts": [
+              "\"The Trade Representative shall impose a tariff of 10 percent on goods of Argentina, Bangladesh, Cambodia...\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Actions by the United States in the Investigations under Section ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2026-15181.pdf",
+            "excerpts": [
+              "\"The additional rates of duty are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern time on July 24, 2026\""
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "2026-15181.pdf"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+            "excerpts": [
+              "\"On July 23, 2026\u2014after considering and taking account of the information and advice provided by the Trade Representative...\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Actions by the United States in the Investigations under Section ..."
+          },
+          {
+            "url": "https://public-inspection.federalregister.gov/2026-15181.pdf",
+            "excerpts": [
+              "\"Accordingly, additional rates of duty are imposed as set forth in the Annex to this notice.\""
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "2026-15181.pdf"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2026-15181.pdf",
+            "excerpts": [
+              "FR Doc. 2026-15181 (forced labor Section 301 final action notice)"
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "2026-15181.pdf"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2026-15181.pdf",
+            "excerpts": [
+              "\"on or after 12:01 a.m. eastern time on July 24, 2026\""
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "2026-15181.pdf"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2026-15181.pdf",
+            "excerpts": [
+              "\"The additional rates of duty are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern time on July 24, 2026\""
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "2026-15181.pdf"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+            "excerpts": [
+              "\"The Trade Representative shall impose a tariff of 10 percent on goods of Argentina, Bangladesh, Cambodia, Canada, Ecuador, El Salvador, Guatemala, Honduras, India, Indonesia, Jordan, Malaysia, Mexico, Pakistan, Sri Lanka, the United Kingdom, and Trinidad and Tobago.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Actions by the United States in the Investigations under Section ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.data_as_of_date",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+            "excerpts": [
+              "\"10 percent tariff rate: The Trade Representative shall impose a tariff of 10 percent on goods of Argentina, Bangladesh, Cambodia, Canada, Ecuador, El Salvador, Guatemala, Honduras, India, Indonesia, Jordan, Malaysia, Mexico, Pakistan, Sri Lanka, the United Kingdom, and Trinidad and Tobago.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Actions by the United States in the Investigations under Section ..."
+          },
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"Until the Trade Representative establishes the TRQs described in subsections (a) and (b) of this section, the Trade Representative shall impose the applicable section 301 tariffs provided for in section 1(a) of this memorandum (here, 10 percent) on imports of specific textile and apparel of Bangladesh, Cambodia, Indonesia, and Malaysia that will be covered by the TRQs for each of those economies.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/6109.10.00_India_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/6109.10.00_India_United-States.overlay.json
@@ -1,0 +1,524 @@
+{
+  "lane": {
+    "hts_code": "6109.10.00",
+    "origin": "India",
+    "destination": "United States",
+    "product": "cotton knit t-shirts"
+  },
+  "lane_key": "6109.10.00|India|United States",
+  "doc_key": "6109.10.00|India|United States",
+  "kind": "overlay",
+  "doc_id": "6109.10.00|India|United States#overlay",
+  "researched_at": "2026-07-06T14:02:29.057708+00:00",
+  "elapsed_s": 234.3,
+  "text": "{\n  \"origin\": \"India\",\n  \"product\": \"cotton knit t-shirts\",\n  \"hts_code\": \"6109.10.00\",\n  \"unverified\": [\n    \"Specific HTS subheading exclusions for India in Annex I/II of the Section 301 forced-labor Notice of Actions (FR Doc. 2026-15181) could not be exhaustively enumerated from corpus; the India determination states \\\"except as provided in Annex I and Annex II, Part A\\\"; universe of textile/apparel subheadings (incl. 6109.10.00) covered by the 10% tariff not separately enumerated as exempt. TRQs for textiles were established only for Bangladesh, Cambodia, Indonesia, Malaysia (NOT India). Specimen verification of India's Annex product list not retrieved.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"2026-02-07: IEEPA India Russian Oil surcharge (25%) terminated; reciprocal tariff of 25% remains in force per CBP February 2026 tariff overview.\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"Section 232 (steel/aluminum/copper/autos/MHDV/timber) \u2014 out of scope: HTS 6109.10.00 (cotton knit T-shirts) is apparel, not a metal/auto/timber product.\",\n    \"Section 301 China (Lists 1/2/3/4/4A, including under EO 14257 and EO 14298 modifications) \u2014 out of scope: action cover only goods of People's Republic of China, not India.\",\n    \"IEEPA India-specific (EO 14329 of August 6, 2025 \u2014 additional 25% on India for Russian Federation oil purchases) \u2014 terminated: the additional 25% was removed by an Executive Order signed February 6, 2026 (when India agreed to stop purchasing Russian oil), and the underlying EO 14329 IEEPA duties were then terminated by EO 14389 of February 20, 2026.\",\n    \"Section 122 Temporary Import Surcharge (Proclamation 11012 of February 20, 2026) \u2014 instrument's effective window has closed: imposed for 150 days, effective February 24, 2026 through 12:01 a.m. EDT on July 24, 2026. Today (August 5, 2026) is after the 150-day maximum.\",\n    \"IEEPA Reciprocal Tariff (EO 14257 of April 2, 2025, as amended) \u2014 terminated February 20, 2026 by Executive Order 14389. For India the rate had been 25% (Aug 2025), reduced to 18% per February 6, 2026 US-India Joint Statement; collection ended upon EO 14389.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"10%\",\n      \"in_force\": true,\n      \"authority\": \"Section 301 of the Trade Act of 1974 - Forced Labor Investigations; USTR Notice of Actions, FR Doc. 2026-15181, 91 FR 47319 (July 28, 2026), per Presidential Memorandum of July 23, 2026\",\n      \"source_url\": \"https://federalregister.gov/documents/2026/07/28/2026-15181\",\n      \"effective_date\": \"2026-07-24\"\n    },\n    {\n      \"ends\": null,\n      \"rate\": \"25%\",\n      \"in_force\": true,\n      \"authority\": \"EO 14257 (Regulating Imports With a Reciprocal Tariff), as amended by EO 14326; HTSUS 9903.02.26\",\n      \"source_url\": \"https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=\",\n      \"effective_date\": \"2025-08-07\"\n    }\n  ],\n  \"origin_rules_notes\": \"India reciprocal rate (25%) under EO 14257/E0 14326 encompasses textile and apparel including HTS 6109.10.00 cotton knit t-shirts per CBP unstacking; Feb 6, 2026 US-India Joint Statement frames a future 18% rate and partial removals (pharma/gems/aircraft parts) but does not affect cotton knit t-shirts.\",\n  \"exclusions_in_force\": []\n}\n\nSources:\n- 1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ... \u2014 https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf (primary)\n- Actions by the United States in the Investigations under Section ... \u2014 https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and (primary)\n- Office of Trade | Trade Remedies U.S. Tariff Overview \u2014 https://cbp.gov/sites/default/files/2026-02/U.S.%20Tariff%20Overview%20February%202026_0.pdf (primary)\n- Annex I-A: 50% Section 232 Tariff on Full Value Note \u2014 https://whitehouse.gov/wp-content/uploads/2026/04/ANNEXES-I-A-I-B-II-III-IV.pdf (primary)\n- How to Navigate the Section 301 Tariff Process | United States ... \u2014 https://ustr.gov/issue-areas/enforcement/section-301-investigations/search (primary)\n- Fact Sheet: The United States and India Announce Historic Trade ... \u2014 https://whitehouse.gov/fact-sheets/2026/02/fact-sheet-the-united-states-and-india-announce-historic-trade-deal (primary)\n- Ending Certain Tariff Actions \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions (primary)\n- Federal Register :: Imposing a Temporary Import Surcharge To Address ... \u2014 https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems (primary)\n- Federal Register :: Notice of Actions in Section 301 Investigations ... \u2014 https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies (primary)\n- EXECUTIVE ORDER 14326 - - - - - - - \u2014 https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907= (primary)\n- International Emergency Economic Powers Act (IEEPA) Frequently ... \u2014 https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ (primary)\n- United States-India Joint Statement \u2013 The White House \u2014 https://whitehouse.gov/briefings-statements/2026/02/united-states-india-joint-statement (primary)",
+  "metadata": {
+    "run_id": "task_run_f2866e6ca26e4249b6a730c7c315a69c",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 92% and trust per claim ratio is 95%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+        "source_category": "official",
+        "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+        "source_category": "official",
+        "title": "Actions by the United States in the Investigations under Section ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/sites/default/files/2026-02/U.S.%20Tariff%20Overview%20February%202026_0.pdf",
+        "source_category": "official",
+        "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/wp-content/uploads/2026/04/ANNEXES-I-A-I-B-II-III-IV.pdf",
+        "source_category": "official",
+        "title": "Annex I-A: 50% Section 232 Tariff on Full Value Note"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/search",
+        "source_category": "official",
+        "title": "How to Navigate the Section 301 Tariff Process | United States ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/fact-sheets/2026/02/fact-sheet-the-united-states-and-india-announce-historic-trade-deal",
+        "source_category": "official",
+        "title": "Fact Sheet: The United States and India Announce Historic Trade ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Ending Certain Tariff Actions \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+        "source_category": "official",
+        "title": "Federal Register :: Imposing a Temporary Import Surcharge To Address ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies",
+        "source_category": "official",
+        "title": "Federal Register :: Notice of Actions in Section 301 Investigations ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=",
+        "source_category": "other",
+        "title": "EXECUTIVE ORDER 14326 - - - - - - -"
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ",
+        "source_category": "official",
+        "title": "International Emergency Economic Powers Act (IEEPA) Frequently ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/briefings-statements/2026/02/united-states-india-joint-statement",
+        "source_category": "official",
+        "title": "United States-India Joint Statement \u2013 The White House"
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"# 24. India: Determination of Action in Investigation ... Trade Representative has determined to impose 10 percent tariffs on products of India, except as provided in Annex I and Annex II, Part A, of this Notice\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/07/actions-by-the-united-states-in-the-investigations-under-section-301-of-the-trade-act-of-1974-of-the-acts-policies-and-practices-of-60-economies-related-to-the-failure-of-each-economy-to-impose-and",
+            "excerpts": [
+              "\"Sec. 2. Tariff-Rate Quotas. (a) ... establish TRQs for Bangladesh, Cambodia, Indonesia, and Malaysia, with an initial duration of 3 years\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Actions by the United States in the Investigations under Section ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-02/U.S.%20Tariff%20Overview%20February%202026_0.pdf",
+            "excerpts": [
+              "\"Section 232 ... Autos/Auto Parts ... MHDVs/Parts ... Copper ... Aluminum ... Steel ... Timber/Lumber\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          },
+          {
+            "url": "https://whitehouse.gov/wp-content/uploads/2026/04/ANNEXES-I-A-I-B-II-III-IV.pdf",
+            "excerpts": [
+              "\"50% ad valorem Section 232 tariff shall apply to the full value of the following articles\" (steel, aluminum, copper derivative articles)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Annex I-A: 50% Section 232 Tariff on Full Value Note"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/search",
+            "excerpts": [
+              "\"China Section 301-Tariff Actions and Exclusion Process ... List 1 (Action) ... List 2 (Action) ... List 3 (Modification) ... List 4 (Modification)\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "How to Navigate the Section 301 Tariff Process | United States ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/fact-sheets/2026/02/fact-sheet-the-united-states-and-india-announce-historic-trade-deal",
+            "excerpts": [
+              "\"President Trump agreed to remove the additional 25% tariff on imports from India in recognition of India's commitment to stop purchasing Russian Federation oil. Accordingly, the President signed an Executive Order last Friday removing that additional 25% tariff.\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Fact Sheet: The United States and India Announce Historic Trade ..."
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "\"Executive Order 14329 ... shall no longer be in effect and, as soon as practicable, shall no longer be collected\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+            "excerpts": [
+              "\"I impose, for a period of 150 days, a temporary import surcharge of 10 percent ad valorem ... The modifications shall be effective ... on or after 12:01 a.m. eastern standard time on February 24, 2026, and shall continue in effect through 12:01 a.m. eastern daylight time on July 24, 2026\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Imposing a Temporary Import Surcharge To Address ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "\"the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14257, as amended ... shall no longer be in effect and, as soon as practicable, shall no longer be collected\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          },
+          {
+            "url": "https://whitehouse.gov/fact-sheets/2026/02/fact-sheet-the-united-states-and-india-announce-historic-trade-deal",
+            "excerpts": [
+              "\"the United States will lower the Reciprocal Tariff on India from 25% to 18%\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Fact Sheet: The United States and India Announce Historic Trade ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[4]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies",
+            "excerpts": [
+              "\"The Trade Representative may modify or terminate the tariffs, exemptions, or TRQs for an economy, as appropriate and subject to my specific direction\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Actions in Section 301 Investigations ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "Information absence is supported by cited evidence"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies",
+            "excerpts": [
+              "\"Trade Representative has determined to impose 10 percent tariffs on products of India, except as provided in Annex I and Annex II, Part A, of this Notice\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Actions in Section 301 Investigations ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies",
+            "excerpts": [
+              "\"The additional rates of duty are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern time on July 24, 2026\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Actions in Section 301 Investigations ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies",
+            "excerpts": [
+              "\"Notice of Actions in Section 301 Investigations of Acts, Policies, and Practices of Various Economies Related to the Failure of Each Economy To Impose and Effectively Enforce a Prohibition on the Importation of Goods Produced With Forced Labor\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Actions in Section 301 Investigations ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies",
+            "excerpts": [
+              "A Notice by the Trade Representative, Office of United States on 07/28/2026"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Actions in Section 301 Investigations ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/07/28/2026-15181/notice-of-actions-in-section-301-investigations-of-acts-policies-and-practices-of-various-economies",
+            "excerpts": [
+              "\"on or after 12:01 a.m. eastern time on July 24, 2026\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Actions in Section 301 Investigations ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "low",
+        "path": "$.additional_duties[1].ends",
+        "reasoning": "No usable citation resolved for this value"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=",
+            "excerpts": [
+              "India | 25%; 9903.02.26 ... articles the product of India ... The duty provided in the applicable subheading + 25%"
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "EXECUTIVE ORDER 14326 - - - - - - -"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].rate",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-02/U.S.%20Tariff%20Overview%20February%202026_0.pdf",
+            "excerpts": [
+              "25% Reciprocal rate remains (India, as of Feb 7, 2026)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=",
+            "excerpts": [
+              "Executive Order 14257 of April 2, 2025 (Regulating Imports With a Reciprocal Tariff...), as amended... imposing additional ad valorem duties on goods of certain trading partners at the rates set forth in Annex I"
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "EXECUTIVE ORDER 14326 - - - - - - -"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].authority",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=",
+            "excerpts": [
+              "2025-15010 EO 14326 Further Modifying the Reciprocal Tariff Rates"
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "EXECUTIVE ORDER 14326 - - - - - - -"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].source_url",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=",
+            "excerpts": [
+              "effective with respect to goods entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern daylight time 7 days after the date of this order"
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "EXECUTIVE ORDER 14326 - - - - - - -"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].effective_date",
+        "reasoning": "Backed by a primary source (other)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-02/U.S.%20Tariff%20Overview%20February%202026_0.pdf",
+            "excerpts": [
+              "As of February 7, 2026: 25% Russian Oil rate for India no longer in effect, 25% Reciprocal rate remains."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ",
+            "excerpts": [
+              "Research date: 2026-08-05"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "International Emergency Economic Powers Act (IEEPA) Frequently ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-02/U.S.%20Tariff%20Overview%20February%202026_0.pdf",
+            "excerpts": [
+              "India 25% reciprocal + 25% IEEPA Russian Oil rate; Feb 7, 2026 Russian Oil surcharge no longer in effect, 25% Reciprocal remains."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          },
+          {
+            "url": "https://whitehouse.gov/briefings-statements/2026/02/united-states-india-joint-statement",
+            "excerpts": [
+              "The United States will apply a reciprocal tariff rate of 18 percent under Executive Order 14257 of April 2, 2025... on originating goods of India, including textile and apparel... and... will remove the reciprocal tariff on... generic pharmaceuticals, gems and diamonds, and aircraft parts."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "United States-India Joint Statement \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  },
+  "backdated_for_demo": {
+    "original_researched_at": "2026-08-05T12:33:37.121942+00:00",
+    "why": "shipped past its TTL so the freshness guard has a real expired fact to withhold; figures and citations unchanged"
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/6109.10.00_United-States.rate.json
+++ b/apps/llamaindex-tariff-desk/data/samples/6109.10.00_United-States.rate.json
@@ -1,0 +1,164 @@
+{
+  "lane": {
+    "hts_code": "6109.10.00",
+    "origin": "Bangladesh",
+    "destination": "United States",
+    "product": "cotton knit t-shirts"
+  },
+  "lane_key": "6109.10.00|Bangladesh|United States",
+  "kind": "rate",
+  "doc_id": "6109.10.00|United States#rate",
+  "researched_at": "2026-08-05T11:10:47.726828+00:00",
+  "elapsed_s": 32.0,
+  "text": "{\n  \"origin\": \"Bangladesh\",\n  \"product\": \"cotton knit t-shirts\",\n  \"hts_code\": \"6109.10.00\",\n  \"source_url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease\",\n  \"destination\": \"United States\",\n  \"general_rate\": \"16.5%\",\n  \"htsus_revision\": \"Revision 15 (2026)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"retrieval_notes\": \"Read directly from the official USITC Chapter 61 PDF (https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease), which the document header identifies as the Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes. The 16.5% General rate for HTS 6109.10.00 (cotton T-shirts, singlets, tank tops and similar garments) is the Column 1 MFN rate; the adjacent \\\"Free (AU, BH, CL, CO, IL, JO, KR, MA, OM, P, PA, PE, S, SG)\\\" column is the Special (FTA) rate and does not alter the General rate. Bangladesh is not in any Free Trade Agreement list on this line, so the General rate is the applicable base duty. Section 301, Section 232, IEEPA, and reciprocal-tariff overlays are intentionally excluded per task scope.\",\n  \"verified_against_official_schedule\": true\n}\n\nSources:\n- Harmonized Tariff Schedule of the United States Revision ... \u2014 https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease (primary)",
+  "metadata": {
+    "run_id": "task_run_15acb1740e5c40528a31ff60f3cd9f2a",
+    "agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "web_search_agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "effort": "medium",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+        "source_category": "official",
+        "title": "Harmonized Tariff Schedule of the United States Revision ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+            "excerpts": [
+              "| 6109.10.00 | Of cotton | 16.5% | Free (AU, BH, CL, CO, IL, JO, KR, MA, OM, P, PA, PE, S, SG) |"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.general_rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.htsus_revision",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+            "excerpts": [
+              "retrieved: 2026-08-05"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+            "excerpts": [
+              "source_category: official \u2014 extract fetched from hts.usitc.gov Chapter 61 PDF (release=currentRelease)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.verified_against_official_schedule",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+61&release=currentRelease",
+            "excerpts": [
+              "| 6109.10.00 | Of cotton | 16.5% | Free (AU, BH, CL, CO, IL, JO, KR, MA, OM, P, PA, PE, S, SG) |"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Harmonized Tariff Schedule of the United States Revision ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.retrieval_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      }
+    ]
+  },
+  "doc_key": "6109.10.00|United States",
+  "collapsed_from": [
+    "6109.10.00|Bangladesh|United States",
+    "6109.10.00|India|United States"
+  ]
+}

--- a/apps/llamaindex-tariff-desk/data/samples/7604.29.10_China_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/7604.29.10_China_United-States.overlay.json
@@ -1,0 +1,490 @@
+{
+  "lane": {
+    "hts_code": "7604.29.10",
+    "origin": "China",
+    "destination": "United States",
+    "product": "aluminum extrusions"
+  },
+  "lane_key": "7604.29.10|China|United States",
+  "doc_key": "7604.29.10|China|United States",
+  "kind": "overlay",
+  "doc_id": "7604.29.10|China|United States#overlay",
+  "researched_at": "2026-08-05T12:33:52.512898+00:00",
+  "elapsed_s": 249.7,
+  "text": "{\n  \"origin\": \"China\",\n  \"product\": \"aluminum extrusions\",\n  \"hts_code\": \"7604.29.10\",\n  \"unverified\": [\n    \"Whether a Section 232 product-specific exclusion (post 2025-07676 reopening) is currently in force for HTS 7604.29.10 as of 2026-08-05 could not be verified. Attempted: searched Federal Register, White House, CBP, and USTR for specific product-exclusion determinations covering 7604.29.10; none found in the corpus.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"Proclamation 11032 (further modifying Section 232 regimes) effective 2026-06-08 \u2014 most recent modification affecting aluminum extrusions 7604.29.10.\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"IEEPA reciprocal tariff (EO 14257) on China-origin HTS 7604.29.10 \u2014 confirmed not applicable. Articles and derivatives of steel and aluminum in Chapter 76 subject to Section 232 duties are expressly excluded from the reciprocal tariffs pursuant to HTSUS heading 9903.01.33 (April 7, 2025, 90 FR 15041), and CBP confirms Section 232 subheadings cannot simultaneously be subject to IEEPA reciprocal tariffs.\",\n    \"Section 232 General Approved Exclusion GAE.5.A for HTS 7604.29.1010 \u2014 confirmed terminated. GAE list July 1, 2024 removed 7604.21.0010 and 7604.29.1010 from the section 232 aluminum GAE list (CBP Quota Bulletin QB-24-721). The product-specific Section 232 exclusion process re-opened May 2, 2025 (FRN 2025-07676, 90 FR 18541) does not include a blanket in-force exclusion for 7604.29.10.\",\n    \"The 178 Section 301 product-specific exclusions (COVID-related and solar/wind machinery) previously extended through November 10, 2026 \u2014 confirmed not to cover HTS 7604.29.10. USTR press release and Federal Register notice confirm the 178-extension list does not include aluminum extrusions 7604.29.10.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"50%\",\n      \"in_force\": true,\n      \"authority\": \"Section 232, Proclamation 11021 of April 2, 2026 (Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, and Copper Into the United States), as further modified by Proclamation 11032 of June 1, 2026; amending Proclamation 9704 of March 8, 2018, Proclamation 10895 of February 10, 2025, and Proclamation 10947 of June 3, 2025.\",\n      \"source_url\": \"https://www.whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states/\",\n      \"effective_date\": \"2026-04-06\"\n    },\n    {\n      \"ends\": null,\n      \"rate\": \"25%\",\n      \"in_force\": true,\n      \"authority\": \"Section 301, USTR modification in the Four-Year Review of actions taken in the Section 301 investigation of China's acts, policies, and practices related to technology transfer, intellectual property, and innovation; 89 FR 76581 (September 18, 2024), Annex A (subheading 7604.29.10 at 25% from 2024); applied via HTSUS heading 9903.91.01.\",\n      \"source_url\": \"https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer\",\n      \"effective_date\": \"2024-09-27\"\n    }\n  ],\n  \"origin_rules_notes\": \"Steel and aluminum articles in Chapter 76 from China are subject to multiple stacked overlays: Section 232 (50% under Proc. 11021/11032, full customs value), Section 301 (25% increased in 2024 Four-Year Review, applied via 9903.91.01). IEEPA reciprocal tariffs do not stack in this case because HTSUS 9903.01.33 expressly excludes steel and aluminum articles subject to Section 232 from the reciprocal tariff; per EO 14289 Section 4(b), Section 301 duties remain stackable with Section 232.\",\n  \"exclusions_in_force\": [\n    {\n      \"expires\": \"2026-11-10\",\n      \"source_url\": \"https://ustr.gov/about/policy-offices/press-office/press-releases/2025/november/ustr-extends-exclusions-china-section-301-tariffs-related-forced-technology-transfer-investigation\",\n      \"description\": \"USTR extended 178 Section 301 product-specific exclusions through November 10, 2026 (Federal Register notice 90 FR 55232 published December 1, 2025). These do NOT cover HTS 7604.29.10 aluminum extrusions; they cover specific products such as respirators, certain solar manufacturing equipment, and other COVID-era items. Cited only to record that the underlying Section 301 regime continues in force on the research date.\"\n    }\n  ]\n}\n\nSources:\n- Federal Register :: Adoption and Procedures of the Section 232 ... \u2014 https://federalregister.gov/documents/2025/05/02/2025-07676/adoption-and-procedures-of-the-section-232-steel-and-aluminum-tariff-inclusions-process (primary)\n- Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ... \u2014 https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs (primary)\n- QB 24-721 2024 First and Second Period Tariff Rate Quota (TRQ) ... \u2014 https://cbp.gov/trade/quota/bulletins/qb-24-721-2024 (primary)\n- Federal Register :: Notice of Product Exclusion Extensions: China's ... \u2014 https://federalregister.gov/documents/2025/12/01/2025-21671/notice-of-product-exclusion-extensions-chinas-acts-policies-and-practices-related-to-technology (primary)\n- Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ... \u2014 https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states (primary)\n- USTR Extends Exclusions from China Section 301 Tariffs Related ... \u2014 https://ustr.gov/about/policy-offices/press-office/press-releases/2025/november/ustr-extends-exclusions-china-section-301-tariffs-related-forced-technology-transfer-investigation (primary)\n- Federal Register :: Notice of Modification: China's Acts, Policies ... \u2014 https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer (primary)\n- Further Adjusting the Tariff Regimes for Imports of Aluminum, Steel, ... \u2014 https://whitehouse.gov/presidential-actions/2026/06/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states (primary)\n- Federal Register :: Addressing Certain Tariffs on Imported Articles \u2014 https://federalregister.gov/documents/2025/05/02/2025-07835/addressing-certain-tariffs-on-imported-articles (primary)",
+  "metadata": {
+    "run_id": "task_run_5b37351483c8495089daaf577e79bcae",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 92% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/05/02/2025-07676/adoption-and-procedures-of-the-section-232-steel-and-aluminum-tariff-inclusions-process",
+        "source_category": "official",
+        "title": "Federal Register :: Adoption and Procedures of the Section 232 ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+        "source_category": "official",
+        "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/quota/bulletins/qb-24-721-2024",
+        "source_category": "official",
+        "title": "QB 24-721 2024 First and Second Period Tariff Rate Quota (TRQ) ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/12/01/2025-21671/notice-of-product-exclusion-extensions-chinas-acts-policies-and-practices-related-to-technology",
+        "source_category": "official",
+        "title": "Federal Register :: Notice of Product Exclusion Extensions: China's ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+        "source_category": "official",
+        "title": "Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2025/november/ustr-extends-exclusions-china-section-301-tariffs-related-forced-technology-transfer-investigation",
+        "source_category": "official",
+        "title": "USTR Extends Exclusions from China Section 301 Tariffs Related ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+        "source_category": "official",
+        "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/06/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states",
+        "source_category": "official",
+        "title": "Further Adjusting the Tariff Regimes for Imports of Aluminum, Steel, ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2025/05/02/2025-07835/addressing-certain-tariffs-on-imported-articles",
+        "source_category": "official",
+        "title": "Federal Register :: Addressing Certain Tariffs on Imported Articles"
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/05/02/2025-07676/adoption-and-procedures-of-the-section-232-steel-and-aluminum-tariff-inclusions-process",
+            "excerpts": [
+              "Adoption and Procedures of the Section 232 Steel and Aluminum Tariff Exclusion Process \u2014 opened the BIS Section 232 product-specific exclusion process on May 2, 2025, but no specific exclusion determination for HTS 7604.29.10 was identified in the corpus."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Adoption and Procedures of the Section 232 ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+            "excerpts": [
+              "Articles and derivatives of steel and aluminum subject to Section 232 duties are excluded from the reciprocal tariffs; pursuant to heading 9903.01.33, HTSUS."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/quota/bulletins/qb-24-721-2024",
+            "excerpts": [
+              "Removed July 1, 2024: 7601.20.9080; 7604.21.0010; 7604.29.1010; 7604.29.5090; 7607.11.6010; 7609.00.0000"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "QB 24-721 2024 First and Second Period Tariff Rate Quota (TRQ) ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/12/01/2025-21671/notice-of-product-exclusion-extensions-chinas-acts-policies-and-practices-related-to-technology",
+            "excerpts": [
+              "this notice announces the U.S. Trade Representative's determination to extend the 178 current exclusions"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Product Exclusion Extensions: China's ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Proclamation 11021 of April 2, 2026, clause (2)(a): effective from April 6, 2026, the applicable additional ad valorem rate of duty for all aluminum and steel articles and certain derivative articles shall be 50 percent, unless a lower rate of duty applies pursuant to clause (2)(b) or (2)(c) of this proclamation."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "Information absence is supported by cited evidence"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "clause (2)(a): 50 percent, unless a lower rate of duty applies pursuant to clause (2)(b) or (2)(c) of this proclamation"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Proclamation 11021 was signed April 2, 2026 by President Donald J. Trump and is in effect on the research date (2026-08-05), being last modified further by Proclamation 11032 of June 1, 2026 (effective June 8, 2026)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "In Proclamation 9704 of March 8, 2018..., I found, under section 232 of the Trade Expansion Act of 1962, as amended, 19 U.S.C. 1862 (section 232), that aluminum, steel, and copper are being imported into the United States in such quantities or under such circumstances as to threaten to impair the national security... NOW, THEREFORE, I, DONALD J. TRUMP, President of the United States of America... do hereby proclaim..."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Source page for Proclamation 11021 of April 2, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/04/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "(1) Effective with respect to goods entered for consumption or withdrawn from warehouse for consumption on or after 12:01 a.m. eastern daylight time on April 6, 2026, the additional ad valorem duty imposed pursuant to section 232 on aluminum articles and aluminum derivative articles under Proclamation 9704... shall apply to the full customs value..."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Strengthening Actions Taken to Adjust Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2025/november/ustr-extends-exclusions-china-section-301-tariffs-related-forced-technology-transfer-investigation",
+            "excerpts": [
+              "USTR press release of November 26, 2025 extended the 178 Section 301 product exclusions \u2014 scheduled to expire on November 29, 2025 \u2014 through November 10, 2026, indicating that the underlying Section 301 actions remain maintained."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "USTR Extends Exclusions from China Section 301 Tariffs Related ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].ends",
+        "reasoning": "Information absence is supported by cited evidence"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "Annex A row: 7604.29.10 | Aluminum alloy, profiles (o/than hollow profiles) | 25 | 2024"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2025/november/ustr-extends-exclusions-china-section-301-tariffs-related-forced-technology-transfer-investigation",
+            "excerpts": [
+              "USTR press releases and the Kuala Lumpur Arrangement indicate the Section 301 actions remain in effect. The 178 product-specific exclusions were extended through November 10, 2026, demonstrating the underlying actions remain operative."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "USTR Extends Exclusions from China Section 301 Tariffs Related ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "in connection with the Four-Year Review of actions taken in the section 301 investigation of China's acts, policies, and practices related to technology transfer, intellectual property, and innovation, and in accordance with the specific direction of the President, the U.S. Trade Representative has determined to: modify the actions being taken in the investigation by imposing additional section 301 duties or increasing the rate of existing section 301 duties, on certain products of China in strategic sectors"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "Federal Register source for USTR's notice of modification in the Section 301 Four-Year Review (89 FR 76581)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "Tariff increases in 2024 are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after September 27, 2024."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[1].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/12/01/2025-21671/notice-of-product-exclusion-extensions-chinas-acts-policies-and-practices-related-to-technology",
+            "excerpts": [
+              "the United States would further extend the 178 exclusions scheduled to expire on November 29, 2025, until November 10, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Product Exclusion Extensions: China's ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].expires",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/about/policy-offices/press-office/press-releases/2025/november/ustr-extends-exclusions-china-section-301-tariffs-related-forced-technology-transfer-investigation",
+            "excerpts": [
+              "USTR press release of November 26, 2025 announcing the extension of the 178 Section 301 product exclusions through November 10, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "USTR Extends Exclusions from China Section 301 Tariffs Related ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2025/12/01/2025-21671/notice-of-product-exclusion-extensions-chinas-acts-policies-and-practices-related-to-technology",
+            "excerpts": [
+              "this notice announces the U.S. Trade Representative's determination to extend the 178 current exclusions."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Product Exclusion Extensions: China's ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].description",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/06/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Proclamation 11032 of June 1, 2026 \u2014 further adjusting the Section 232 tariff regimes for aluminum, steel and copper; effective with respect to goods entered for consumption on or after 12:01 a.m. eastern daylight time on June 8, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Adjusting the Tariff Regimes for Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/06/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Research-date reasoning from the corpus; proclamations in force effective before today's date 2026-08-05."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Adjusting the Tariff Regimes for Imports of Aluminum, Steel, ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+            "excerpts": [
+              "Articles and derivatives of steel and aluminum subject to Section 232 duties are excluded from the reciprocal tariffs; pursuant to heading 9903.01.33, HTSUS."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2025/05/02/2025-07835/addressing-certain-tariffs-on-imported-articles",
+            "excerpts": [
+              "An article that is subject to duties pursuant to an action listed in section 2 of this order may still be subject to other applicable duties, taxes, fees, exactions, and charges, such as, but not limited to... duties imposed pursuant to section 301 of the Trade Act of 1974, as amended."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Addressing Certain Tariffs on Imported Articles"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/7604.29.10_Mexico_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/7604.29.10_Mexico_United-States.overlay.json
@@ -1,0 +1,430 @@
+{
+  "lane": {
+    "hts_code": "7604.29.10",
+    "origin": "Mexico",
+    "destination": "United States",
+    "product": "aluminum extrusions"
+  },
+  "lane_key": "7604.29.10|Mexico|United States",
+  "doc_key": "7604.29.10|Mexico|United States",
+  "kind": "overlay",
+  "doc_id": "7604.29.10|Mexico|United States#overlay",
+  "researched_at": "2026-08-05T12:32:19.164233+00:00",
+  "elapsed_s": 156.3,
+  "text": "{\n  \"origin\": \"Mexico\",\n  \"product\": \"aluminum extrusions\",\n  \"hts_code\": \"7604.29.10\",\n  \"unverified\": [\n    \"Whether any active BIS-approved Section 232 product-specific exclusion currently covers Mexico-origin HTS 7604.29.10 aluminum extrusions; the corpus has no positive evidence of such an exclusion, but absence in the corpus is not proof.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"2026-06-08 \u2014 Proclamation 11032 of June 1, 2026 (FR Doc 2026-11314) effective June 8, 2026 maintains the 50% Section 232 aluminum article rate from Proclamation 11021 of April 2, 2026 for Annex I-A goods including HTS 7604.\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"Section 301 List 1/2/3/4/4A (China-origin only, USTR): does not apply to Mexico-origin HTS 7604.29.10.\",\n    \"IEEPA Mexico (EO 14194 of February 1, 2025): terminated by EO 14389 of February 20, 2026.\",\n    \"IEEPA Reciprocal (EO 14257 of April 2, 2025, as amended): terminated by EO 14389 of February 20, 2026.\",\n    \"Section 232 Mexico country exemption under Proclamation 9893 (May 19, 2019) and Proclamation 10782 (July 10, 2024): superseded by Proclamation 10895 (Feb 10, 2025), Proclamation 10947 (June 3, 2025), Proclamation 11021 (April 2, 2026), and Proclamation 11032 (June 1, 2026); Mexico-origin aluminum articles now fully in scope of Section 232.\",\n    \"IEEPA Canada (EO 14193 of February 1, 2025): not applicable to Mexico-origin goods and now terminated by EO 14389 of February 20, 2026.\",\n    \"IEEPA China fentanyl (EO 14195 of February 1, 2025): terminated by EO 14389 of February 20, 2026.\",\n    \"IEEPA Brazil (EO 14323 of July 30, 2025): terminated by EO 14389 of February 20, 2026.\",\n    \"IEEPA Russia/secondary sanctions (EO 14329 of August 6, 2025): terminated by EO 14389 of February 20, 2026.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"50%\",\n      \"in_force\": true,\n      \"authority\": \"Proclamation 11021 of April 2, 2026 (Section 232, 91 FR 18201) as amended by Proclamation 11032 of June 1, 2026 (Section 232, 91 FR 34085)\",\n      \"source_url\": \"https://www.federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states\",\n      \"effective_date\": \"2026-04-06\"\n    }\n  ],\n  \"origin_rules_notes\": \"Mexico-origin aluminum extrusions classified under HTSUS 7604.29.10. Goods subject to USMCA preference may still be eligible for USMCA tariff treatment on the underlying duty; Section 232 applies on top of any USMCA preferential rate of duty, including on USMCA-qualifying goods.\",\n  \"exclusions_in_force\": []\n}\n\nSources:\n- Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ... \u2014 https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs (primary)\n- China Section 301-Tariff Actions and Exclusion Process | United ... \u2014 https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions (primary)\n- Ending Certain Tariff Actions \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions (primary)\n- Federal Register :: Adjusting Imports of Aluminum Into the United ... \u2014 https://federalregister.gov/documents/2024/07/15/2024-15632/adjusting-imports-of-aluminum-into-the-united-states (primary)\n- Federal Register :: Strengthening Actions Taken To Adjust Imports ... \u2014 https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states (primary)\n- Annex I-A: 50% Section 232 Tariff on Full Value Note \u2014 https://whitehouse.gov/wp-content/uploads/2026/04/ANNEXES-I-A-I-B-II-III-IV.pdf (primary)\n- Federal Register :: Further Adjusting the Tariff Regimes for Imports ... \u2014 https://federalregister.gov/documents/2026/06/04/2026-11314/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states (primary)",
+  "metadata": {
+    "run_id": "task_run_310795599df647ffaad4f5a48c1ae112",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 95% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+        "source_category": "official",
+        "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions",
+        "source_category": "official",
+        "title": "China Section 301-Tariff Actions and Exclusion Process | United ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Ending Certain Tariff Actions \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2024/07/15/2024-15632/adjusting-imports-of-aluminum-into-the-united-states",
+        "source_category": "official",
+        "title": "Federal Register :: Adjusting Imports of Aluminum Into the United ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+        "source_category": "official",
+        "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/wp-content/uploads/2026/04/ANNEXES-I-A-I-B-II-III-IV.pdf",
+        "source_category": "official",
+        "title": "Annex I-A: 50% Section 232 Tariff on Full Value Note"
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/06/04/2026-11314/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states",
+        "source_category": "official",
+        "title": "Federal Register :: Further Adjusting the Tariff Regimes for Imports ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+            "excerpts": [
+              "An exclusion is generally valid for one year from the date of signature, or until the granted quantity has been exhausted (whichever comes first)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions",
+            "excerpts": [
+              "Section 301 tariffs of the United States apply to imports from China that are identified on the lists published by USTR."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "China Section 301-Tariff Actions and Exclusion Process | United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "In light of recent events, the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193, as amended; Executive Order 14194, as amended; Executive Order 14195, as amended; Executive Order 14245; Executive Order 14257, as amended; Executive Order 14323, as amended; Executive Order 14329, as amended; Executive Order 14380; and Executive Order 14382 shall no longer be in effect and, as soon as practicable, shall no longer be collected."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193, as amended; Executive Order 14194, as amended; Executive Order 14195, as amended; Executive Order 14245; Executive Order 14257, as amended; Executive Order 14323, as amended; Executive Order 14329, as amended; Executive Order 14380; and Executive Order 14382 shall no longer be in effect and, as soon as practicable, shall no longer be collected."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/07/15/2024-15632/adjusting-imports-of-aluminum-into-the-united-states",
+            "excerpts": [
+              "Proclamation 10782 of July 10, 2024 ... Adjusting Imports of Aluminum Into the United States ... The President determined in Proclamation 9893 that ... excluded Mexico from the tariff proclaimed in Proclamation 9704, as amended. ... I have determined that it is appropriate to revisit the President's determination in Proclamation 9893 regarding the applicability of the tariff imposed in Proclamation 9704 to aluminum articles imports from Mexico."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Adjusting Imports of Aluminum Into the United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "Executive Order 14193 of February 1, 2025 (Imposing Duties To Address the Flow of Illicit Drugs Across Our Northern Border), as amended; Executive Order 14194 of February 1, 2025 ... shall no longer be in effect."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[4]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "Executive Order 14195 of February 1, 2025 (Imposing Duties To Address the Synthetic Opioid Supply Chain in the People's Republic of China), as amended; ... shall no longer be in effect."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[5]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "Executive Order 14323 of July 30, 2025 (Addressing Threats to the United States by the Government of Brazil), as amended; ... shall no longer be in effect."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[6]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "Executive Order 14329 of August 6, 2025 (Addressing Threats to the United States by the Government of the Russian Federation), as amended ... shall no longer be in effect."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[7]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "The full-value ad valorem tariffs on aluminum and steel articles ... shall be set at an ad valorem rate of duty of 50 percent, with reduced rates available for certain products from the United Kingdom given the ongoing discussions and for derivative articles made entirely with metals originating from the United States."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "Information absence is supported by cited evidence"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "(2)(a) 50 percent, unless a lower rate of duty applies pursuant to clause (2)(b) or (2)(c) of this proclamation;"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+          },
+          {
+            "url": "https://whitehouse.gov/wp-content/uploads/2026/04/ANNEXES-I-A-I-B-II-III-IV.pdf",
+            "excerpts": [
+              "(i) Articles of aluminum: | 7601 | 7604 | 7605 | 7606 | ... | 7607 | 7608 | 7609 | 7616.99.5160 | 7616.99.5170 |"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Annex I-A: 50% Section 232 Tariff on Full Value Note"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "(1) Effective with respect to goods entered for consumption or withdrawn from warehouse for consumption on or after 12:01 a.m. eastern daylight time on April 6, 2026, the additional ad valorem duty imposed pursuant to section 232 on aluminum articles and aluminum derivative articles under Proclamation 9704, as amended ... shall apply to the full customs value of the imported product, regardless of metal content. (2) Effective with respect to goods entered for consumption ... on or after 12:01 a.m. eastern daylight time on April 6, 2026, the applicable additional ad valorem rate of duty imposed pursuant to section 232 under Proclamation 9704, as amended ... for all aluminum and steel articles ... shall be: (a) 50 percent, unless a lower rate of duty applies pursuant to clause (2)(b) or (2)(c) of this proclamation;"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Proclamation 11021 of April 2, 2026 ... Strengthening Actions Taken To Adjust Imports of Aluminum, Steel, and Copper Into the United States"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/06/04/2026-11314/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Proclamation 11032 of June 1, 2026 ... Further Adjusting the Tariff Regimes for Imports of Aluminum, Steel, and Copper Into the United States"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Further Adjusting the Tariff Regimes for Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "/pages/federalregister.gov/documents-2026-04-09-2026-06960-strengthening-actions-taken--46d288f3.md"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "(1) Effective with respect to goods entered for consumption or withdrawn from warehouse for consumption on or after 12:01 a.m. eastern daylight time on April 6, 2026, the additional ad valorem duty imposed pursuant to section 232 on aluminum articles and aluminum derivative articles under Proclamation 9704, as amended ... shall apply to the full customs value of the imported product, regardless of metal content. (2) Effective with respect to goods entered for consumption ... on or after 12:01 a.m. eastern daylight time on April 6, 2026, the applicable additional ad valorem rate of duty imposed pursuant to section 232 under Proclamation 9704, as amended ... for all aluminum and steel articles ... shall be: (a) 50 percent, unless a lower rate of duty applies pursuant to clause (2)(b) or (2)(c) of this proclamation;"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/06/04/2026-11314/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "(1) Effective with respect to goods entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern daylight time on June 8, 2026, subchapter III of chapter 99 of the Harmonized Tariff Schedule of the United States (HTSUS) is modified as provided in Annex IV to this proclamation and the lists of products provided in Annex I-A, Annex I-B, Annex II, and Annex III of Proclamation 11021 are modified as set forth in the annexes to this proclamation. (2)(a) 25 percent, unless a lower rate of duty applies pursuant to clause (2)(b), (2)(c), or (2)(d) of this proclamation;"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Further Adjusting the Tariff Regimes for Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "Document Retrieval Date 2026-08-05."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Strengthening Actions Taken To Adjust Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs",
+            "excerpts": [
+              "Section 232 duties may not be waived due to a Free Trade Agreement."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Section 232 Tariffs on Steel and Aluminum Frequently Asked Questions ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/06/04/2026-11314/further-adjusting-the-tariff-regimes-for-imports-of-aluminum-steel-and-copper-into-the-united-states",
+            "excerpts": [
+              "(2)(d) For products of Canada and Mexico that qualify for preferential tariff treatment under the United States-Mexico-Canada Agreement, a duty of 25 percent shall apply only to the non-U.S. content of the product. For purposes of this clause, \"non-U.S. content\" means the total value of the product minus the value attributable to parts produced in the United States. Notwithstanding the foregoing, the total effective duty on the imported product assessed under this subclause shall not be less than 15 percent ad valorem, as detailed in Annex IV of this proclamation."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Further Adjusting the Tariff Regimes for Imports ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/7604.29.10_United-States.rate.json
+++ b/apps/llamaindex-tariff-desk/data/samples/7604.29.10_United-States.rate.json
@@ -1,0 +1,190 @@
+{
+  "lane": {
+    "hts_code": "7604.29.10",
+    "origin": "China",
+    "destination": "United States",
+    "product": "aluminum extrusions"
+  },
+  "lane_key": "7604.29.10|China|United States",
+  "kind": "rate",
+  "doc_id": "7604.29.10|United States#rate",
+  "researched_at": "2026-08-05T11:09:13.526370+00:00",
+  "elapsed_s": 78.6,
+  "text": "{\n  \"origin\": \"China\",\n  \"product\": \"aluminum extrusions\",\n  \"hts_code\": \"7604.29.10\",\n  \"source_url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease\",\n  \"destination\": \"United States\",\n  \"general_rate\": \"5%\",\n  \"htsus_revision\": \"Revision 15 (2026)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"retrieval_notes\": \"Rate read from the official USITC HTS Chapter 76 PDF for the current release (Revision 15, 2026 HTS Basic Edition published December 31, 2025). Mirrors attempted and successfully retrieved: hts.usitc.gov (reststop Chapter 76 PDF) and usitc.gov (tata/hts bychapter 1000c76.pdf). The rate is the base Column 1 General rate only; Section 301, Section 232, IEEPA, and reciprocal duty overlays are not included.\",\n  \"verified_against_official_schedule\": true\n}\n\nSources:\n- https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease \u2014 https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease (primary)\n- 2026 Basic Edition of the Harmonized Tariff Schedule of the United ... \u2014 https://usitc.gov/documents/announcements/2026_basic_edition_harmonized_tariff_schedule (primary)",
+  "metadata": {
+    "run_id": "task_run_705d005af42c48e6ba0c2f58f587e0be",
+    "agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "web_search_agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "effort": "medium",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease",
+        "source_category": "official",
+        "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease"
+      },
+      {
+        "type": "primary",
+        "url": "https://usitc.gov/documents/announcements/2026_basic_edition_harmonized_tariff_schedule",
+        "source_category": "official",
+        "title": "2026 Basic Edition of the Harmonized Tariff Schedule of the United ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes \u2014 CHAPTER 76."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease",
+            "excerpts": [
+              "7604.29.10 | Other profiles | 5% | Free (A*, AU, BH, CL, CO, D, E, IL, JO, KR, MA, OM, P, PA, PE, S, SG)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.general_rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease"
+          },
+          {
+            "url": "https://usitc.gov/documents/announcements/2026_basic_edition_harmonized_tariff_schedule",
+            "excerpts": [
+              "2026 HTS Basic Edition was published on December 31, 2025"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "2026 Basic Edition of the Harmonized Tariff Schedule of the United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.htsus_revision",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease",
+            "excerpts": [
+              "retrieved: 2026-08-05"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease",
+            "excerpts": [
+              "Column 1 General rate 5% for 7604.29.10 (Other profiles, aluminum alloys, Chapter 76)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease"
+          },
+          {
+            "url": "https://usitc.gov/documents/announcements/2026_basic_edition_harmonized_tariff_schedule",
+            "excerpts": [
+              "2026 HTS Basic Edition was published on December 31, 2025."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "2026 Basic Edition of the Harmonized Tariff Schedule of the United ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.retrieval_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease",
+            "excerpts": [
+              "USITC HTS Chapter 76, current release \u2014 Revision 15 (2026)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+76&release=currentRelease"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.verified_against_official_schedule",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      }
+    ]
+  },
+  "doc_key": "7604.29.10|United States",
+  "collapsed_from": [
+    "7604.29.10|China|United States",
+    "7604.29.10|Mexico|United States"
+  ]
+}

--- a/apps/llamaindex-tariff-desk/data/samples/8507.60.00_China_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/8507.60.00_China_United-States.overlay.json
@@ -1,0 +1,385 @@
+{
+  "lane": {
+    "hts_code": "8507.60.00",
+    "origin": "China",
+    "destination": "United States",
+    "product": "lithium-ion battery packs"
+  },
+  "lane_key": "8507.60.00|China|United States",
+  "doc_key": "8507.60.00|China|United States",
+  "kind": "overlay",
+  "doc_id": "8507.60.00|China|United States#overlay",
+  "researched_at": "2026-08-05T12:32:04.149742+00:00",
+  "elapsed_s": 141.3,
+  "text": "{\n  \"origin\": \"China\",\n  \"product\": \"lithium-ion battery packs\",\n  \"hts_code\": \"8507.60.00\",\n  \"unverified\": [\n    \"Pre-2024 Section 301 List 3 base rate prior to the Sept. 18, 2024 modification (i.e., the 10% from Sept. 24, 2018 and 25% from May 10, 2019 rate that initially covered 8507.60) \u2014 not separately verified; reported as superseded by the Jan. 1, 2026 modification.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"2026-02-20 \u2014 Termination of IEEPA duties on China by EO 14389 following Supreme Court decision in Learning Resources, Inc. v. Trump (607 U.S. __ (Feb. 20, 2026)); per CBP bulletin Vol. 60, No. 18 (July 8, 2026).\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"Section 232 (Trade Expansion Act of 1962) \u2014 No proclamation imposing tariffs on lithium-ion batteries (HTSUS 8507.60) is in force. The CBP U.S. Tariff Overview (Jan. 30, 2026) and CBP Trade-Remedies page enumerate active Section 232 actions (autos/auto parts, MHDVs/parts, steel, aluminum, copper, timber/lumber, semiconductors, pharmaceuticals) and do not list lithium-ion batteries under any Section 232 proclamation.\",\n    \"IEEPA China fentanyl tariff \u2014 Executive Order 14195 (Feb. 1, 2025), 10% additional ad valorem on imports of China (HTSUS 9903.01.20/9903.01.24), effective Feb. 4, 2025. Terminated by Executive Order 14389 (Feb. 20, 2026), \\\"Ending Certain Tariff Actions,\\\" 91 FR 9437, following Supreme Court decision Learning Resources, Inc. v. Trump (Feb. 20, 2026) holding IEEPA does not authorize the President to impose additional tariffs.\",\n    \"IEEPA reciprocal tariff on China \u2014 Executive Order 14257 (April 2, 2025), as amended by EO 14266 and suspended/modified by EO 14298 (May 12, 2025), EO 14334 (Aug. 11, 2025), and EO 14358 (Nov. 4, 2025) at the 10% rate (heading 9903.01.25). Terminated by Executive Order 14389 (Feb. 20, 2026), 91 FR 9437.\",\n    \"Section 122 temporary import surcharge \u2014 Proclamation 11012 (Feb. 20, 2026), 10% ad valorem surcharge on all imports, effective Feb. 24, 2026 through July 24, 2026 (150-day statutory maximum). Window closed before the research date of 2026-08-05 and is no longer in effect.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"25%\",\n      \"in_force\": true,\n      \"authority\": \"Section 301 (Trade Act of 1974) \u2014 List 3, as modified by USTR Notice of Modification, 89 FR 76581 (Sept. 18, 2024); HTSUS 8507.60.0020 effective Jan. 1, 2026\",\n      \"source_url\": \"https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer\",\n      \"effective_date\": \"2026-01-01\"\n    }\n  ],\n  \"origin_rules_notes\": \"Lithium-ion battery packs classified under HTS 8507.60.00 \u2014 a generic description that resolves to the 10-digit statistical reporting numbers 8507.60.0010 (batteries used as primary power source for electrically powered vehicles of subheadings 8703.40, 8703.50, 8703.60, 8703.70 or 8703.80) or 8507.60.0020 (other lithium-ion batteries). The \\\"lithium-ion battery packs\\\" classification defaults to 8507.60.0020 unless used as primary EV power source.\",\n  \"exclusions_in_force\": [\n    {\n      \"expires\": \"2026-11-10\",\n      \"source_url\": \"https://whitehouse.gov/presidential-actions/2025/11/modifying-reciprocal-tariff-rates-consistent-with-the-economic-and-trade-arrangement-between-the-united-states-and-the-peoples-republic-of-china\",\n      \"description\": \"Heading 9903.01.63 and subdivision (v)(xvii)(10) of U.S. note 2 to subchapter III of chapter 99 of the HTSUS treated as suspended for heightened reciprocal-tariff rates on PRC until 12:01 a.m. eastern standard time on November 10, 2026. The window closed Feb. 20, 2026, by termination of EO 14257 (as amended) via EO 14389.\"\n    }\n  ]\n}\n\nSources:\n- Federal Register :: Notice of Modification: China's Acts, Policies ... \u2014 https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer (primary)\n- Office of Trade | Trade Remedies U.S. Tariff Overview \u2014 https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf (primary)\n- Ending Certain Tariff Actions \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions (primary)\n- U.S. Customs and Border Protection \u25c6 19 CFR PART 10 CBP DEC. 26\u201312 \u2014 https://cbp.gov/sites/default/files/2026-07/260708_bulletin_vol_60_no_18.pdf (primary)\n- Modifying Reciprocal Tariff Rates Consistent with the Economic ... \u2014 https://whitehouse.gov/presidential-actions/2025/11/modifying-reciprocal-tariff-rates-consistent-with-the-economic-and-trade-arrangement-between-the-united-states-and-the-peoples-republic-of-china (primary)\n- Federal Register :: Imposing a Temporary Import Surcharge To Address ... \u2014 https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems (primary)",
+  "metadata": {
+    "run_id": "task_run_5a1a712bce6d43d6a9517e08d5c31dd5",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 95% and trust per claim ratio is 94%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+        "source_category": "official",
+        "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+        "source_category": "official",
+        "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Ending Certain Tariff Actions \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/sites/default/files/2026-07/260708_bulletin_vol_60_no_18.pdf",
+        "source_category": "official",
+        "title": "U.S. Customs and Border Protection \u25c6 19 CFR PART 10 CBP DEC. 26\u201312"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-reciprocal-tariff-rates-consistent-with-the-economic-and-trade-arrangement-between-the-united-states-and-the-peoples-republic-of-china",
+        "source_category": "official",
+        "title": "Modifying Reciprocal Tariff Rates Consistent with the Economic ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+        "source_category": "official",
+        "title": "Federal Register :: Imposing a Temporary Import Surcharge To Address ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "USTR modification timeline (Determination to Modify the Actions) supersedes prior List 3 instrument for HTS 8507.60 to new 25% rate effective 2024/2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "U.S. Tariff Overview, CBP Pub. No. 5328-0126 (01/30/2026) lists active Section 232 actions for Autos/Auto Parts, MHDVs/Parts, Steel, Aluminum, Copper, Timber/Lumber; semiconductors effective Jan. 15, 2026. No Section 232 lithium-ion battery entry appears."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "In light of recent events, the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193, as amended; Executive Order 14194, as amended; Executive Order 14195, as amended; ... shall no longer be in effect and, as soon as practicable, shall no longer be collected."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          },
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-07/260708_bulletin_vol_60_no_18.pdf",
+            "excerpts": [
+              "On February 20, 2026, the United States Supreme Court decided Learning Resources, Inc. v. Trump, 607 U.S. __ (2026), holding that the International Emergency Economic Powers Act (IEEPA) ... does not authorize the President to impose additional tariffs."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "U.S. Customs and Border Protection \u25c6 19 CFR PART 10 CBP DEC. 26\u201312"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "Executive Order 14257 of April 2, 2025 (Regulating Imports With a Reciprocal Tariff To Rectify Trade Practices That Contribute to Large and Persistent Annual United States Goods Trade Deficits), as amended"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-reciprocal-tariff-rates-consistent-with-the-economic-and-trade-arrangement-between-the-united-states-and-the-peoples-republic-of-china",
+            "excerpts": [
+              "I have determined that it is necessary and appropriate to deal with the national emergency declared in Executive Order 14257 by implementing the Arrangement between the United States and the PRC. Therefore, I determine that it is necessary and appropriate to continue the suspension of the heightened reciprocal tariffs on imports of the PRC until 12:01 a.m. eastern standard time on November 10, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Modifying Reciprocal Tariff Rates Consistent with the Economic ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03824/imposing-a-temporary-import-surcharge-to-address-fundamental-international-payments-problems",
+            "excerpts": [
+              "I impose, for a period of 150 days, a temporary import surcharge of 10 percent ad valorem ... effective February 24, 2026. ... shall continue in effect through 12:01 a.m. eastern daylight time on July 24, 2026, unless the surcharge imposed in this proclamation is expressly suspended, modified, or terminated on an earlier date."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Imposing a Temporary Import Surcharge To Address ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "low",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "No usable citation resolved for this value"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "8507.60.0020 | Lithium-ion batteries: Other | 25 | 2026"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "Tariff increases in 2026 are applicable with respect to products that are entered for consumption on or after January 1 of the corresponding year."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "USTR has determined to: modify the actions being taken in the investigation by imposing additional section 301 duties or increasing the rate of existing section 301 duties, on certain products of China in strategic sectors."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "Listing of rates per 89 FR 76581."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "Tariff increases in 2026 are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after January 1 of the corresponding year."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-reciprocal-tariff-rates-consistent-with-the-economic-and-trade-arrangement-between-the-united-states-and-the-peoples-republic-of-china",
+            "excerpts": [
+              "Heading 9903.01.63 and subdivision (v)(xvii)(10) of U.S. note 2 to subchapter III of chapter 99 of the Harmonized Tariff Schedule of the United States shall continue to be suspended until 12:01 a.m. eastern standard time on November 10, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Modifying Reciprocal Tariff Rates Consistent with the Economic ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].expires",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/11/modifying-reciprocal-tariff-rates-consistent-with-the-economic-and-trade-arrangement-between-the-united-states-and-the-peoples-republic-of-china",
+            "excerpts": [
+              "EO 14358 (Nov. 4, 2025) source URL."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Modifying Reciprocal Tariff Rates Consistent with the Economic ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "EO 14389 (Feb. 20, 2026) terminated the additional duties imposed under IEEPA in EO 14257, as amended."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.exclusions_in_force[0].description",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-07/260708_bulletin_vol_60_no_18.pdf",
+            "excerpts": [
+              "On February 20, 2026, the United States Supreme Court decided Learning Resources, Inc. v. Trump, 607 U.S. __ (2026), holding that the International Emergency Economic Powers Act (IEEPA), 50 U.S.C. 1701 et seq., does not authorize the President to impose additional tariffs. ... E.O. 14389 of February 20, 2026 (Ending Certain Tariff Actions) terminated the additional duties that had been imposed under IEEPA"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "U.S. Customs and Border Protection \u25c6 19 CFR PART 10 CBP DEC. 26\u201312"
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "E.O. 14389 terminated EO 14257, as amended (and EO 14195, as amended)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.data_as_of_date",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "8507.60.0010 | Lithium-ion batteries of a kind used as the primary source of electrical power for electrically powered vehicles of subheadings 870340, 870350, 870360, 870370 or 870380 | 25% timing 2024 ; 8507.60.0020 | Lithium-ion batteries: Other | 25% timing 2026"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/8507.60.00_United-States.rate.json
+++ b/apps/llamaindex-tariff-desk/data/samples/8507.60.00_United-States.rate.json
@@ -1,0 +1,164 @@
+{
+  "lane": {
+    "hts_code": "8507.60.00",
+    "origin": "China",
+    "destination": "United States",
+    "product": "lithium-ion battery packs"
+  },
+  "lane_key": "8507.60.00|China|United States",
+  "kind": "rate",
+  "doc_id": "8507.60.00|United States#rate",
+  "researched_at": "2026-08-05T11:07:54.904500+00:00",
+  "elapsed_s": 125.4,
+  "text": "{\n  \"origin\": \"China\",\n  \"product\": \"lithium-ion battery packs\",\n  \"hts_code\": \"8507.60.00\",\n  \"source_url\": \"https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15\",\n  \"destination\": \"United States\",\n  \"general_rate\": \"3.4%\",\n  \"htsus_revision\": \"Revision 15 (2026)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"retrieval_notes\": \"Read USITC HTS Chapter 85 (Revision 15, 2026) at hts.usitc.gov/reststop/file?filename=Chapter+85; both the currentRelease mirror and the explicit 2026HTSRev15 mirror were retrieved successfully and contain identical schedule text. The rate is consistent with neighboring non-lead-acid 8507 subheadings (8507.50, 8507.80, 8507.90.80 also 3.4%; lead-acid 8507.10/8507.20/8507.90.40 are 3.5%). No Section 301, Section 232, IEEPA, or reciprocal duty overlay is folded into the figure reported here.\",\n  \"verified_against_official_schedule\": true\n}\n\nSources:\n- https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15 \u2014 https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15 (primary)",
+  "metadata": {
+    "run_id": "task_run_f509294ac27b4807a62473b185b898bf",
+    "agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "web_search_agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "effort": "medium",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15",
+        "source_category": "official",
+        "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15"
+      }
+    ],
+    "claims": [
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes | 8507.60.00 | Lithium-ion batteries | No kg | 3.4% | Free (A, AU, B, BH, C, CL, CO, D, E, IL, JO, KR, MA, OM, P, PA, PE, S, SG)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15",
+            "excerpts": [
+              "8507.60.00 | Lithium-ion batteries | No kg | 3.4% | Free (A, AU, B, BH, C, CL, CO, D, E, IL, JO, KR, MA, OM, P, PA, PE, S, SG)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.general_rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.htsus_revision",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15",
+            "excerpts": [
+              "retrieved: 2026-08-05"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15",
+            "excerpts": [
+              "8507.10.00 ... 3.5% | 8507.50.00 ... 3.4% | 8507.60.00 ... 3.4% | 8507.80.82 ... 3.4%"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.retrieval_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes | 8507.60.00 | Lithium-ion batteries | No kg | 3.4%"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=2026HTSRev15"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.verified_against_official_schedule",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      }
+    ]
+  },
+  "doc_key": "8507.60.00|United States",
+  "collapsed_from": [
+    "8507.60.00|China|United States",
+    "8507.60.00|Vietnam|United States"
+  ]
+}

--- a/apps/llamaindex-tariff-desk/data/samples/8507.60.00_Vietnam_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/8507.60.00_Vietnam_United-States.overlay.json
@@ -1,0 +1,376 @@
+{
+  "lane": {
+    "hts_code": "8507.60.00",
+    "origin": "Vietnam",
+    "destination": "United States",
+    "product": "lithium-ion battery packs"
+  },
+  "lane_key": "8507.60.00|Vietnam|United States",
+  "doc_key": "8507.60.00|Vietnam|United States",
+  "kind": "overlay",
+  "doc_id": "8507.60.00|Vietnam|United States#overlay",
+  "researched_at": "2026-08-05T12:37:15.908796+00:00",
+  "elapsed_s": 203.4,
+  "text": "{\n  \"origin\": \"Vietnam\",\n  \"product\": \"lithium-ion battery packs\",\n  \"hts_code\": \"8507.60.00\",\n  \"unverified\": [\n    \"No duty overlay on Vietnam-origin HTS 8507.60 could be confirmed in force on 2026-08-05. Searched Federal Register notices (federalregister.gov, public-inspection.federalregister.gov), USTR publications (Fact Sheet 2025-10 Vietnam framework; Section 301 Tariff Actions listing only China-origin Lists 1\u20134), White House presidential actions (bilateral framework EO 14346 of Sept 5 2025; agricultural-carveout EO of Nov 14 2025; semiconductors Proc. 11002; processed-critical-minerals Proc. 11010; EO 14389 ending IEEPA on Feb 20 2026), and CBP guidance (IEEPA FAQ; IEEPA Duty Refunds; Liberation Day statement). No instrument found that still attaches an overlay to Vietnam-origin HTS 8507.60 on this date.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"USTR Final Action Federal Register Notice, Section 301 Forced Labor Investigation (Docket Nos. USTR-2026-0265/0266), Vietnam HTSUS heading 9903.05.84, imposing 12.5% additional ad valorem on products of Vietnam effective 12:01 a.m. ET on July 24, 2026.\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"Section 301 China (Lists 1\u20134, including the Sep 18, 2024 modification that imposed 25% on HTS 8507.60.0010 EV lithium-ion batteries and 25% on HTS 8507.60.0020 other lithium-ion batteries): instrument's own scope is products of China. Vietnam-origin HTS 8507.60 is outside this scope, so the Section 301 China action does not collect on this lane. Cited instruments: USTR Notice of Modification, 89 FR 76580 (Sept. 18, 2024) and USTR \\\"China Section 301-Tariff Actions and Exclusion Process\\\" page listing only Lists 1, 2, 3, 4 all targeting China.\",\n    \"Section 232 on HTS 8507.60 lithium-ion batteries: no operative Section 232 proclamation in the corpus covers finished lithium-ion battery packs (HTS 8507). Section 232 actions target steel (Proc. 9776 et seq.), aluminum, autos/auto parts (Proc. 10908), copper, semiconductors (Proc. 11002, Jan 14 2026, HTS 8541/8542 only), timber/lumber (Proc. 10976), pharmaceuticals (Proc. 11020), and processed critical minerals (Proc. 11010, Jan 14 2026); none lists HTS 8507.60 in its Annex. Disqualified: out of product scope.\",\n    \"IEEPA Reciprocal tariff on Vietnam-origin goods (20%) under EO 14257 (April 2, 2025) as amended by EO 14326 (July 31, 2025), HTSUS heading 9903.02.69: terminated by EO 14389 \\\"Ending Certain Tariff Actions\\\" signed February 20, 2026, published at 91 FR 9437 (Feb. 25, 2026). EO 14389 Sec. 1 declares that the IEEPA ad valorem duties under EO 14257 (and the other named IEEPA orders) \\\"shall no longer be in effect and, as soon as practicable, shall no longer be collected.\\\" Disqualified: terminated before the research date.\",\n    \"IEEPA Canada, IEEPA Mexico, IEEPA China/PRC, IEEPA Russia/Brazil/Cuba/Iran/Venezuelan oil under EO 14193, EO 14194, EO 14195, EO 14245, EO 14323, EO 14329, EO 14380, EO 14382: out of origin scope for Vietnam-origin goods (each instrument targets a different country); further terminated for all origins by EO 14389. Disqualified: out of origin scope.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": null,\n      \"rate\": \"12.5%\",\n      \"in_force\": true,\n      \"authority\": \"USTR Final Action FRN, Section 301 Forced Labor Investigation (Docket Nos. USTR-2026-0265, USTR-2026-0266), 60-Economy Determination; for Vietnam, HTSUS heading 9903.05.84\",\n      \"source_url\": \"https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf\",\n      \"effective_date\": \"2026-07-24\"\n    }\n  ],\n  \"origin_rules_notes\": \"Product-and-origin-scoped overlays in force as of 2026-08-05: Section 301 (Forced-Labor track) on Vietnam-origin imports at +12.5% ad valorem (heading 9903.05.84), effective 2026-07-24, except for civil-aircraft articles meeting General Note 6 (under 9903.05.88), informational materials / donations (9903.05.87), pharmaceutical products (9903.05.89), aluminum/steel/copper articles (9903.05.90), and other Part A/Part B specifics; lithium-ion battery packs under HTSUS 8507.60.00 are NOT on any exempt list for general commercial use. China-origin Section 301 (Lists 1-4) does not apply \u2014 out of origin scope. No Section 232 proclamation covers 8507.60 from any origin. IEEPA Reciprocal 20% on Vietnam under EO 14257/EO 14326 was terminated by EO 14389 effective 2026-02-20; IEEPA-derived duties do not apply.\",\n  \"exclusions_in_force\": []\n}\n\nSources:\n- International Emergency Economic Powers Act (IEEPA) Frequently ... \u2014 https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ (primary)\n- China Section 301-Tariff Actions and Exclusion Process | United ... \u2014 https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions (primary)\n- Federal Register :: Notice of Modification: China's Acts, Policies ... \u2014 https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer (primary)\n- ADJUSTING IMPORTS OF SEMICONDUCTORS, SEMICONDUCTOR MANUFACTURING ... \u2014 https://whitehouse.gov/presidential-actions/2026/01/adjusting-imports-of-semiconductors-semiconductor-manufacturing-equipment-and-their-derivative-products-into-the-united-states (primary)\n- Adjusting Imports of Processed Critical Minerals and Their Derivative ... \u2014 https://whitehouse.gov/presidential-actions/2026/01/adjusting-imports-of-processed-critical-minerals-and-their-derivative-products-into-the-united-states (primary)\n- Federal Register :: Ending Certain Tariff Actions \u2014 https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions (primary)\n- EXECUTIVE ORDER 14326 - - - - - - - \u2014 https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907= (primary)\n- 1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ... \u2014 https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf (primary)",
+  "metadata": {
+    "run_id": "task_run_995afc49fb4b48f1ae22daed4f66999c",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 94% and trust per claim ratio is 92%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ",
+        "source_category": "official",
+        "title": "International Emergency Economic Powers Act (IEEPA) Frequently ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions",
+        "source_category": "official",
+        "title": "China Section 301-Tariff Actions and Exclusion Process | United ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+        "source_category": "official",
+        "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/01/adjusting-imports-of-semiconductors-semiconductor-manufacturing-equipment-and-their-derivative-products-into-the-united-states",
+        "source_category": "official",
+        "title": "ADJUSTING IMPORTS OF SEMICONDUCTORS, SEMICONDUCTOR MANUFACTURING ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/01/adjusting-imports-of-processed-critical-minerals-and-their-derivative-products-into-the-united-states",
+        "source_category": "official",
+        "title": "Adjusting Imports of Processed Critical Minerals and Their Derivative ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Federal Register :: Ending Certain Tariff Actions"
+      },
+      {
+        "type": "primary",
+        "url": "https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=",
+        "source_category": "other",
+        "title": "EXECUTIVE ORDER 14326 - - - - - - -"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+        "source_category": "official",
+        "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/programs-administration/trade-remedies/IEEPA-FAQ",
+            "excerpts": [
+              "CBP IEEPA FAQ page; last modified dates show reciprocal tariffs were in flux through Feb 2026; no Vietnam 8507 overlay in current unstacking chart."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "International Emergency Economic Powers Act (IEEPA) Frequently ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions",
+            "excerpts": [
+              "\"China Section 301-Tariff Actions and Exclusion Process\" \u2014 Lists 1, 2, 3, 4 \u2014 China-only scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "China Section 301-Tariff Actions and Exclusion Process | United ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer",
+            "excerpts": [
+              "\"The U.S. Trade Representative proposed increasing tariffs on 8507.60.0010 ... and 8507.60.0020 ...\" \u2014 products of China HTSUS."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Notice of Modification: China's Acts, Policies ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/01/adjusting-imports-of-semiconductors-semiconductor-manufacturing-equipment-and-their-derivative-products-into-the-united-states",
+            "excerpts": [
+              "Proc. 11002 covers \"imports of semiconductors (semiconductors or chips), semiconductor manufacturing equipment, and their derivative products\" \u2014 Annex excludes HTS 8507.60."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "ADJUSTING IMPORTS OF SEMICONDUCTORS, SEMICONDUCTOR MANUFACTURING ..."
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/01/adjusting-imports-of-processed-critical-minerals-and-their-derivative-products-into-the-united-states",
+            "excerpts": [
+              "Proc. 11010 covers \"imports of processed critical minerals and their derivative products (PCMDPs)\" \u2014 covers inputs (lithium, cobalt, nickel) but not finished HTS 8507.60 battery packs."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Adjusting Imports of Processed Critical Minerals and Their Derivative ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "\"the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193 ... EO 14257, as amended ... shall no longer be in effect and, as soon as practicable, shall no longer be collected.\" Signed Feb 20, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          },
+          {
+            "url": "https://public-inspection.federalregister.gov/2025-15010.pdf?1754406907=",
+            "excerpts": [
+              "EO 14326 set Vietnam at 20% via heading 9903.02.69 (now terminated)."
+            ],
+            "source_category": "other",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "EXECUTIVE ORDER 14326 - - - - - - -"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "EO 14389 lists EO 14193, 14194, 14195, 14245, 14323, 14329, 14380, 14382 by name; all terminated; not applicable to Vietnam in any event."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "low",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "No usable citation resolved for this value"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"the Trade Representative has determined to impose 12.5 percent tariffs on products of Vietnam, except as provided in Annex I and Annex II, Part A\" (Heading 9903.05.84: Vietnam articles the product of Vietnam, + 12.5%)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"The additional rates of duty are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern time on July 24, 2026\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"# 9903.05.84 ... articles the product of Vietnam, as provided for in U.S. note 52 to this subchapter ... The duty provided in the applicable subheading\" / \"+ 12.5%\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"Notice of Actions in Section 301 Investigations of Acts, Policies, and Practices of Various Economies Related to the Failure of Each Economy to Impose and Effectively Enforce a Prohibition on the Importation of Goods Produced with Forced Labor\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"DATES: The additional rates of duty are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern time on July 24, 2026\""
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"DATES: The additional rates of duty are applicable with respect to products that are entered for consumption, or withdrawn from warehouse for consumption, on or after 12:01 a.m. eastern time on July 24, 2026\" \u2014 heading 9903.05.84 Vietnam + 12.5%."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.data_as_of_date",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/files/Press/Releases/2026/FLIP%20301%20Investigation%20Final%20Action%20FRN%207-23-26%20FINAL.pdf",
+            "excerpts": [
+              "\"on or after 12:01 a.m. eastern time on July 24, 2026\" and \"12.5 percent tariffs on products of Vietnam\" (Heading 9903.05.84 applies to \"articles the product of Vietnam\")."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/02/25/2026-03832/ending-certain-tariff-actions",
+            "excerpts": [
+              "\"the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193 ... EO 14257, as amended ... shall no longer be in effect and, as soon as practicable, shall no longer be collected.\" Signed Feb 20, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Ending Certain Tariff Actions"
+          },
+          {
+            "url": "https://ustr.gov/issue-areas/enforcement/section-301-investigations/tariff-actions",
+            "excerpts": [
+              "\"China Section 301-Tariff Actions and Exclusion Process\" \u2014 Lists 1, 2, 3, 4 \u2014 China-only scope."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "China Section 301-Tariff Actions and Exclusion Process | United ..."
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/01/adjusting-imports-of-semiconductors-semiconductor-manufacturing-equipment-and-their-derivative-products-into-the-united-states",
+            "excerpts": [
+              "Section 232 Proc. 11002 (semiconductors/chips, Jan 14 2026) covers HTS 8541/8542 only \u2014 not 8507.60."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "ADJUSTING IMPORTS OF SEMICONDUCTORS, SEMICONDUCTOR MANUFACTURING ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/8541.43.00_Malaysia_United-States.overlay.json
+++ b/apps/llamaindex-tariff-desk/data/samples/8541.43.00_Malaysia_United-States.overlay.json
@@ -1,0 +1,363 @@
+{
+  "lane": {
+    "hts_code": "8541.43.00",
+    "origin": "Malaysia",
+    "destination": "United States",
+    "product": "photovoltaic modules"
+  },
+  "lane_key": "8541.43.00|Malaysia|United States",
+  "doc_key": "8541.43.00|Malaysia|United States",
+  "kind": "overlay",
+  "doc_id": "8541.43.00|Malaysia|United States#overlay",
+  "researched_at": "2026-08-05T12:37:47.228998+00:00",
+  "elapsed_s": 250.1,
+  "text": "{\n  \"origin\": \"Malaysia\",\n  \"product\": \"photovoltaic modules\",\n  \"hts_code\": \"8541.43.00\",\n  \"unverified\": [\n    \"Antidumping/countervailing duty (AD/CVD) orders on photovoltaic cells/modules from Malaysia \u2014 searched CBP, USTR, Federal Register; no AD/CVD order applicable specifically to HTS 8541.43.00 from Malaysia was found in scope. AD/CVD was attempted via Federal Register search but not surfaced; ordered to AD/CVD not within the four overlays requested, noted here only as what was attempted.\"\n  ],\n  \"destination\": \"United States\",\n  \"last_changed\": \"2025-10 \u2014 US-Malaysia reciprocal-tariff trade agreement affirmed 19% cap binding from EO 14326 of July 31, 2025 (Annex II to trade deal, Schedule 2)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"confirmed_absent\": [\n    \"Section 201 CSPV safeguard (Presidential Proclamation 10339, 87 FR 7357, Feb 9, 2022): terminated February 6, 2026 \u2014 relief window closed before research date 2026-08-05. CBP QB 25-507 2025 and ITC Investigation No. TA-201-075 (Evaluation) notice (FR 2026-05170, Mar 17, 2026) confirm termination; CBP no longer assesses 14% additional duty on Malaysia-origin modules under HTSUS 9903.45.25.\",\n    \"Section 232 on photovoltaic modules: no Section 232 proclamation covers HTS 8541.43.00. Section 232 actions identified by CBP in the post-IEEPA regime cover steel, aluminum, copper, autos/auto parts, medium- and heavy-duty vehicles, timber/lumber, and semiconductors only \u2014 not solar modules/cells. Out of scope for this product/origin.\",\n    \"Section 301 (Four-Year Review modifications): 50% rate on HTSUS 8541.43.00 operates only for products of the People's Republic of China per USTR notice of modification and notes 20(d) to HTSUS subchapter III, chapter 99. USTR explicitly found the listed rates apply to China-origin goods; the rate structure under chapter 99 heading 9903.91.03 is keyed to China. Malaysia is not China \u2014 out of scope.\",\n    \"IEEPA reciprocal tariff (EO 14257 of April 2, 2025, Regulating Imports with a Reciprocal Tariff) as applied to Malaysia (19% rate, per Annex of Further Modifying Reciprocal Tariffs): terminated February 20, 2026 by EO 14389 (Ending Certain Tariff Actions) following Learning Resources, Inc. v. Trump, 607 U.S. ___ (2026) Supreme Court ruling that IEEPA does not authorize reciprocal tariffs. CBP refunds pending under FR 2026-13771. EO 14389 expressly preserves Section 232 and Section 301 duties.\"\n  ],\n  \"additional_duties\": [\n    {\n      \"ends\": \"2026-08-05\",\n      \"rate\": \"19%\",\n      \"in_force\": true,\n      \"authority\": \"EO 14326 Annex I\",\n      \"source_url\": \"https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates\",\n      \"effective_date\": \"2025-08-07\"\n    }\n  ],\n  \"origin_rules_notes\": \"Solar CSPV cells/modules covered by HTSUS 8541.42.0010 and 8541.43.0010; same scope also covers entries under 8501.71-8501.80 and 8507.20 series. Crystalline silicon photovoltaic cells, whether or not assembled into modules, from Malaysia are subject to antidumping order A-557-830 and countervailing duty order C-557-831 (effective Dec 4, 2024). Crystalline silicon, \u226520 micrometers thick, with p/n junction; thin film (a-Si, CdTe, CIGS) and certain small off-grid panels excluded.\",\n  \"exclusions_in_force\": []\n}\n\nSources:\n- QB 25-507 2025 Solar Cells and Modules | U.S. Customs and Border ... \u2014 https://cbp.gov/trade/quota/bulletins/qb-25-507-2025 (primary)\n- Federal Register :: Crystalline Silicon Photovoltaic Cells Whether ... \u2014 https://federalregister.gov/documents/2026/03/17/2026-05170/crystalline-silicon-photovoltaic-cells-whether-or-not-partially-or-fully-assembled-into-other (primary)\n- Office of Trade | Trade Remedies U.S. Tariff Overview \u2014 https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf (primary)\n- 1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ... \u2014 https://ustr.gov/sites/default/files/Section%20301%20Modifications%20Determination%20FRN%20(Sept%2012%202024)%20(FINAL).pdf (primary)\n- Ending Certain Tariff Actions \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions (primary)\n- Federal Register :: Agency Information Collection Activities; ... \u2014 https://federalregister.gov/documents/2026/07/08/2026-13771/agency-information-collection-activities-extension-court-ordered-refunds-under-the-international (primary)\n- Further Modifying the Reciprocal Tariff Rates \u2013 The White House \u2014 https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates (primary)\n- I-1 Annex I Schedule 1 Tariff Schedule of Malaysia General Notes 1. \u2014 https://whitehouse.gov/wp-content/uploads/2025/10/final.pdf (primary)\n- Federal Register :: Crystalline Silicon Photovoltaic Cells, Whether ... \u2014 https://federalregister.gov/documents/2024/10/15/2024-23678/crystalline-silicon-photovoltaic-cells-whether-or-not-assembled-into-modules-from-malaysia (primary)",
+  "metadata": {
+    "run_id": "task_run_a7b6d8fa0f004d3996964b4fb2fb0929",
+    "agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "web_search_agent_id": "wsa_13693a14508a4a4d8f54190306466dfa",
+    "effort": "high",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/trade/quota/bulletins/qb-25-507-2025",
+        "source_category": "official",
+        "title": "QB 25-507 2025 Solar Cells and Modules | U.S. Customs and Border ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/03/17/2026-05170/crystalline-silicon-photovoltaic-cells-whether-or-not-partially-or-fully-assembled-into-other",
+        "source_category": "official",
+        "title": "Federal Register :: Crystalline Silicon Photovoltaic Cells Whether ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+        "source_category": "official",
+        "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+      },
+      {
+        "type": "primary",
+        "url": "https://ustr.gov/sites/default/files/Section%20301%20Modifications%20Determination%20FRN%20(Sept%2012%202024)%20(FINAL).pdf",
+        "source_category": "official",
+        "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+        "source_category": "official",
+        "title": "Ending Certain Tariff Actions \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2026/07/08/2026-13771/agency-information-collection-activities-extension-court-ordered-refunds-under-the-international",
+        "source_category": "official",
+        "title": "Federal Register :: Agency Information Collection Activities; ..."
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+        "source_category": "official",
+        "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+      },
+      {
+        "type": "primary",
+        "url": "https://whitehouse.gov/wp-content/uploads/2025/10/final.pdf",
+        "source_category": "official",
+        "title": "I-1 Annex I Schedule 1 Tariff Schedule of Malaysia General Notes 1."
+      },
+      {
+        "type": "primary",
+        "url": "https://federalregister.gov/documents/2024/10/15/2024-23678/crystalline-silicon-photovoltaic-cells-whether-or-not-assembled-into-modules-from-malaysia",
+        "source_category": "official",
+        "title": "Federal Register :: Crystalline Silicon Photovoltaic Cells, Whether ..."
+      }
+    ],
+    "claims": [
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/trade/quota/bulletins/qb-25-507-2025",
+            "excerpts": [
+              "The merchandise covered by the quota may also be subject to antidumping and countervailing duties. (no specific Malaysia AD/CVD order for 8541.43 confirmed in retrieved CBP materials)"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "QB 25-507 2025 Solar Cells and Modules | U.S. Customs and Border ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.unverified[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2026/03/17/2026-05170/crystalline-silicon-photovoltaic-cells-whether-or-not-partially-or-fully-assembled-into-other",
+            "excerpts": [
+              "the Commission has instituted investigation No. TA-201-075, Crystalline Silicon Photovoltaic (\"CSPV\") Cells (Whether or Not Partially or Fully Assembled Into Other Products) (\"CSPV products\"), for the purpose of evaluating the effectiveness of the relief action imposed by the President on imports of CSPV products under section 203 of the Act, which terminated on February 6, 2026."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Crystalline Silicon Photovoltaic Cells Whether ..."
+          },
+          {
+            "url": "https://cbp.gov/trade/quota/bulletins/qb-25-507-2025",
+            "excerpts": [
+              "Quota Period for CSPV Cells: February 7, 2025, through February 6, 2026. ... If entered during the period from February 7, 2025, through February 6, 2026: 14.00%"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "QB 25-507 2025 Solar Cells and Modules | U.S. Customs and Border ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[0]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://cbp.gov/sites/default/files/2026-01/U.S.%20Tariff%20Overview%20January%202026_0_0.pdf",
+            "excerpts": [
+              "Section 232 categories listed: Autos and Auto Parts, Medium- and Heavy-Duty Vehicles, Steel, Aluminum, Copper, Semiconductors, Timber/Lumber. No entry for photovoltaic modules or 8541.43.00."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Office of Trade | Trade Remedies U.S. Tariff Overview"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[1]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://ustr.gov/sites/default/files/Section%20301%20Modifications%20Determination%20FRN%20(Sept%2012%202024)%20(FINAL).pdf",
+            "excerpts": [
+              "8541.42.00 Photovoltaic cells, not assembled in modules or made up into panels 50% 2024; 8541.43.00 Photovoltaic cells assembled in modules or made up into panels 50% 2024 ... applies to products of China that are classified in the following 8-digit subheadings, effective with respect to goods entered for consumption ... on or after ... September 27, 2024: 1. 8541.42.00 2. 8541.43.00"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "1 Billing Code 3390-F4 OFFICE OF THE UNITED STATES TRADE ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[2]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2026/02/ending-certain-tariff-actions",
+            "excerpts": [
+              "the additional ad valorem duties imposed pursuant to IEEPA in Executive Order 14193, as amended; ... Executive Order 14257, as amended; ... shall no longer be in effect and, as soon as practicable, shall no longer be collected. ... This order does not affect any other duties, including duties imposed under section 232 of the Trade Expansion Act of 1962, as amended, and section 301 of the Trade Act of 1974, as amended."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Ending Certain Tariff Actions \u2013 The White House"
+          },
+          {
+            "url": "https://federalregister.gov/documents/2026/07/08/2026-13771/agency-information-collection-activities-extension-court-ordered-refunds-under-the-international",
+            "excerpts": [
+              "On February 20, 2026, the U.S. Supreme Court ruled in Learning Resources, Inc. v. Trump that all tariffs imposed by the President under the International Emergency Economic Powers Act (IEEPA) ... were unlawful. ... The tariffs assessed under IEEPA from February 3, 2025 to February 24, 2026 total an estimated $166 billion."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Agency Information Collection Activities; ..."
+          },
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "Malaysia | 19%"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.confirmed_absent[3]",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "Reciprocal Tariff, Adjusted Malaysia 19% \u2014 Annex I contains no end date; remains in effect on the research date."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].ends",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "Annex I lists Malaysia at 19% under Reciprocal Tariff, Adjusted."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "These modifications shall be effective with respect to goods entered for consumption ... on or after 12:01 a.m. eastern daylight time 7 days after the date of this order."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].in_force",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "Executive Order 14326 ... IEEPA ... Malaysia | 19%."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].authority",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "https://www.whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates/"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/presidential-actions/2025/07/further-modifying-the-reciprocal-tariff-rates",
+            "excerpts": [
+              "effective ... on or after 12:01 a.m. eastern daylight time 7 days after the date of this order."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Further Modifying the Reciprocal Tariff Rates \u2013 The White House"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.additional_duties[0].effective_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://whitehouse.gov/wp-content/uploads/2025/10/final.pdf",
+            "excerpts": [
+              "For all other originating goods of Malaysia, the additional ad valorem rate provided for in Executive Order 14257 of April 2, 2025, as amended, shall be no higher than 19 percent."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "I-1 Annex I Schedule 1 Tariff Schedule of Malaysia General Notes 1."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.last_changed",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.data_as_of_date",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://federalregister.gov/documents/2024/10/15/2024-23678/crystalline-silicon-photovoltaic-cells-whether-or-not-assembled-into-modules-from-malaysia",
+            "excerpts": [
+              "The merchandise covered by this investigation is crystalline silicon photovoltaic cells, and modules, laminates, and panels, consisting of crystalline silicon photovoltaic cells, whether or not partially or fully assembled into other products ... Merchandise covered by the investigation is currently classified in the Harmonized Tariff Schedule of the United States (HTSUS) under subheadings 8541.42.0010 and 8541.43.0010."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "Federal Register :: Crystalline Silicon Photovoltaic Cells, Whether ..."
+          }
+        ],
+        "confidence": "high",
+        "path": "$.origin_rules_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      }
+    ]
+  }
+}

--- a/apps/llamaindex-tariff-desk/data/samples/8541.43.00_United-States.rate.json
+++ b/apps/llamaindex-tariff-desk/data/samples/8541.43.00_United-States.rate.json
@@ -1,0 +1,163 @@
+{
+  "lane": {
+    "hts_code": "8541.43.00",
+    "origin": "Malaysia",
+    "destination": "United States",
+    "product": "photovoltaic modules"
+  },
+  "lane_key": "8541.43.00|Malaysia|United States",
+  "kind": "rate",
+  "doc_id": "8541.43.00|United States#rate",
+  "researched_at": "2026-08-05T11:13:09.100004+00:00",
+  "elapsed_s": 109.9,
+  "text": "{\n  \"origin\": \"Malaysia\",\n  \"product\": \"photovoltaic modules\",\n  \"hts_code\": \"8541.43.00\",\n  \"source_url\": \"https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85\",\n  \"destination\": \"United States\",\n  \"general_rate\": \"Free\",\n  \"htsus_revision\": \"Revision 15 (2026)\",\n  \"data_as_of_date\": \"2026-08-05\",\n  \"retrieval_notes\": \"Read the published HTSUS Chapter 85 PDF directly from hts.usitc.gov (the official USITC mirror) for the current release; the chapter header self-identifies as \\\"Harmonized Tariff Schedule of the United States Revision 15 (2026)\\\". The 8541.43.00 line on page 85-79 reads: \\\"Photovoltaic cells assembled in modules or made up into panels | Free | 35%\\\" under a column header pair \\\"Rates of Duty | General | Special\\\", so the \\\"Free\\\" is the Column 1 General (MFN) rate and the 35% is in the Special column. Neighbouring subheadings in the same column (8541.41.00, 8541.42.00, 8541.49.10, 8541.49.80, 8541.51.00) all show \\\"Free\\\" in the General column, which is consistent and confirms the column assignment. Section 301 / Section 232 / IEEPA / reciprocal duties are policy overlays in chapter 99 and are not part of the Column 1 General rate. Mirrors attempted: (1) hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85 \u2014 read directly, success; (2) the HTS archive landing page at htS.usitc.gov/download (the dynamic search) was referenced but not separately needed because the chapter PDF was retrieved; (3) the USITC harmonized_tariff_information/hts/archive/list landing page on usitc.gov was read to confirm the Revision 15 release date.\",\n  \"verified_against_official_schedule\": true\n}\n\nSources:\n- https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85 \u2014 https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease (primary)",
+  "metadata": {
+    "run_id": "task_run_cffa7efe4a0b4535acac3d84d750c13b",
+    "agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "web_search_agent_id": "wsa_b91debd3c49c48abbcfc36ee3196c892",
+    "effort": "medium",
+    "output_type": "json",
+    "confidence": "high",
+    "reasoning": "High confidence - cells fill rate is 100% and trust per claim ratio is 100%",
+    "sources": [
+      {
+        "type": "primary",
+        "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+        "source_category": "official",
+        "title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85"
+      }
+    ],
+    "claims": [
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.hts_code",
+        "reasoning": ""
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes \u2014 Chapter 85, page 85-79, tariff rate line for subheading 8541.43.00."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.source_url",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+            "excerpts": [
+              "| 8541.43.00 | Photovoltaic cells assembled in modules or made up into panels | Free | 35% | \u2014 column header pair on page 85-39 reads \"Rates of Duty | General | Special\", so the \"Free\" entry is the Column 1 General (MFN) rate."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.general_rate",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+            "excerpts": [
+              "Harmonized Tariff Schedule of the United States Revision 15 (2026) Annotated for Statistical Reporting Purposes"
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.htsus_revision",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+            "excerpts": [
+              "Source document retrieved 2026-08-05 (corpus-meta header)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.data_as_of_date",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+            "excerpts": [
+              "Direct read of HTSUS Chapter 85 (Revision 15, 2026), page 85-79, row 8541.43.00: \"Photovoltaic cells assembled in modules or made up into panels | Free | 35%\"."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.retrieval_notes",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [
+          {
+            "url": "https://hts.usitc.gov/reststop/file?filename=Chapter+85&release=currentRelease",
+            "excerpts": [
+              "Rate read directly from the official USITC HTSUS chapter document at hts.usitc.gov (Chapter 85 PDF, current release)."
+            ],
+            "source_category": "official",
+            "source_intent": "official",
+            "source_type": "primary",
+            "title": "https://hts.usitc.gov/reststop/file?release=currentRelease&filename=Chapter+85"
+          }
+        ],
+        "confidence": "high",
+        "path": "$.verified_against_official_schedule",
+        "reasoning": "Backed by a primary source (official)"
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.origin",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.product",
+        "reasoning": ""
+      },
+      {
+        "citations": [],
+        "confidence": "pre_existing",
+        "path": "$.destination",
+        "reasoning": ""
+      }
+    ]
+  },
+  "doc_key": "8541.43.00|United States",
+  "collapsed_from": [
+    "8541.43.00|Malaysia|United States"
+  ]
+}

--- a/apps/llamaindex-tariff-desk/desk/agents_config.py
+++ b/apps/llamaindex-tariff-desk/desk/agents_config.py
@@ -1,0 +1,478 @@
+"""The two Web Search Agent configs, per DESIGN.md §3.
+
+Single source of truth: `setup_agents.py` provisions from these, and the runtime
+reuses the schemas for validation. Two agents, not one, because smoke runs showed
+a single broad task lets base-rate retrieval degrade silently into `unverified`
+(see LOG.md 2026-08-05).
+
+Note the v2 field name: the system prompt is `skill`, not `domain_expertise`.
+"""
+
+# --- tariff-schedule-rate -------------------------------------------------
+# Stable facts. TTL measured in months.
+
+RATE_SCHEMA = {
+    "type": "object",
+    "additionalProperties": True,
+    "properties": {
+        "hts_code": {
+            "type": "string",
+            "description": "HTS subheading as supplied, e.g. 8507.60.00",
+        },
+        "general_rate": {
+            "type": "string",
+            "description": (
+                "Column 1 General (MFN) rate quoted exactly as the schedule states "
+                "it, e.g. '3.4%' or 'Free'. Always a string, never a number."
+            ),
+        },
+        "htsus_revision": {
+            "type": ["string", "null"],
+            "description": (
+                "Revision the rate was read from, as the document self-identifies "
+                "it. null, never omit."
+            ),
+        },
+        "source_url": {
+            "type": ["string", "null"],
+            "description": "URL of the schedule page or chapter PDF the rate was read from.",
+        },
+        "verified_against_official_schedule": {"type": "boolean"},
+        "retrieval_notes": {"type": ["string", "null"]},
+        "data_as_of_date": {
+            "type": "string",
+            "description": "ISO 8601 date the rate was read.",
+        },
+    },
+}
+
+RATE_SKILL = """You are a licensed customs broker reading tariff schedules for a compliance team \
+that will be audited on your answer.
+
+## Where to search
+The official Harmonized Tariff Schedule of the United States published by the USITC at
+hts.usitc.gov, including its chapter PDFs, is the only acceptable source for a base rate.
+CBP publications may be used to confirm a reading, never to substitute for it.
+
+## Field rules
+Report the Column 1 General (MFN) rate only. Section 301, Section 232, IEEPA, and reciprocal
+tariffs are policy overlays handled by a different agent — never fold them into this rate.
+Quote the rate exactly as the schedule states it, including "Free". Name the HTSUS revision the
+document self-identifies as.
+
+## Methodology
+Read the rate in context and sanity-check it against neighbouring subheadings in the same
+chapter before reporting it.
+
+## Missing data
+If the official schedule cannot be retrieved, set verified_against_official_schedule to false,
+leave general_rate as "not verified", and state in retrieval_notes which official mirrors were
+attempted. Never estimate a rate and never substitute a broker or forwarder figure. Use null,
+never omit a field."""
+
+RATE_GOALS = [
+    "Reports the Column 1 General (MFN) rate exactly as the official schedule states it, as a string",
+    "Sets verified_against_official_schedule to true only when the rate was read from a usitc.gov document",
+    "Names the HTSUS revision the source document self-identifies as",
+    "Excludes all Section 301, Section 232, IEEPA and reciprocal duties from general_rate",
+    "On retrieval failure, reports 'not verified' and lists the mirrors attempted rather than estimating",
+]
+
+RATE_SOURCES = {
+    "allow": [
+        {
+            "title": "USITC Harmonized Tariff Schedule",
+            "domains": ["hts.usitc.gov", "usitc.gov", "www.usitc.gov"],
+            "order": 0,
+        },
+        {
+            "title": "US Customs and Border Protection",
+            "domains": ["cbp.gov", "www.cbp.gov", "rulings.cbp.gov"],
+            "order": 1,
+        },
+    ],
+    "block": [],
+    "prioritize": "the official HTSUS chapter documents published by the USITC",
+    "avoid": "customs-broker blogs, freight-forwarder marketing pages, and news summaries",
+}
+
+RATE_QUESTIONS = [
+    "What is the Column 1 General rate for HTS 8507.60.00?",
+    "What is the base MFN duty rate for HTS 6109.10.00?",
+    "What is the Column 1 General rate for HTS 4901.99.00?",
+    "What is the base rate for the statistical suffix 8507.60.0020, and which 8-digit rate line does it fall under?",
+]
+
+RATE_AGENT = {
+    "display_name": "Tariff Schedule Rate",
+    "description": "Reads the Column 1 General (MFN) rate for an HTS subheading from the official HTSUS.",
+    "icon": "🧾",
+    "use_case": "enrichment",
+    "effort": "medium",
+    "skill": RATE_SKILL,
+    "goals": RATE_GOALS,
+    "sources": RATE_SOURCES,
+    "output_schema": RATE_SCHEMA,
+    "suggested_questions": RATE_QUESTIONS,
+}
+
+# --- tariff-policy-overlay -----------------------------------------------
+# Volatile facts. TTL measured in days.
+
+OVERLAY_SCHEMA = {
+    "type": "object",
+    "additionalProperties": True,
+    "properties": {
+        "hts_code": {"type": "string"},
+        "origin": {"type": "string"},
+        "destination": {"type": "string"},
+        "additional_duties": {
+            "type": "array",
+            "description": (
+                "ONLY overlays in force on the research date. Terminated, expired "
+                "and out-of-scope instruments belong in confirmed_absent, never here."
+            ),
+            "items": {
+                "type": "object",
+                "additionalProperties": True,
+                "required": ["authority", "rate", "in_force"],
+                "properties": {
+                    "authority": {
+                        "type": "string",
+                        "description": (
+                            "The legal instrument only, e.g. 'EO 14326' or 'Section 301 "
+                            "List 3'. Instrument name and citation, no commentary."
+                        ),
+                    },
+                    "rate": {
+                        "type": "string",
+                        "description": (
+                            "The bare rate, e.g. '25%' or '7.5%'. No prose, no "
+                            "parenthetical explanation, no status text."
+                        ),
+                    },
+                    "in_force": {
+                        "type": "boolean",
+                        "description": (
+                            "True only if this duty is collectible on the research "
+                            "date. If it was terminated, has expired, or does not "
+                            "cover this product, it is not in force and does not "
+                            "belong in this array."
+                        ),
+                    },
+                    "effective_date": {"type": "string"},
+                    "ends": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "Date the instrument stops applying, if it has one. "
+                            "null when open-ended."
+                        ),
+                    },
+                    "source_url": {"type": "string"},
+                },
+            },
+        },
+        "exclusions_in_force": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "description": {"type": "string"},
+                    "expires": {"type": ["string", "null"]},
+                    "source_url": {"type": "string"},
+                },
+            },
+        },
+        "origin_rules_notes": {"type": ["string", "null"]},
+        "last_changed": {
+            "type": ["string", "null"],
+            "description": "Most recent action affecting this lane, with its instrument and date.",
+        },
+        "unverified": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Components that could not be confirmed against an official source.",
+        },
+        "confirmed_absent": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Overlays checked and confirmed NOT to apply. Distinct from unverified.",
+        },
+        "data_as_of_date": {"type": "string"},
+    },
+}
+
+OVERLAY_SKILL = """You are a trade-policy analyst tracking duty overlays for an importer who will \
+make sourcing decisions from your answer.
+
+## Where to search
+Federal Register notices, USTR publications, White House presidential actions and executive
+orders, and CBP guidance. An overlay is only in force if an official instrument says so.
+
+## Field rules
+Report each duty component separately with the instrument that created it and its effective
+date. Never blend components into a single percentage. Do not report the Column 1 General (MFN)
+base rate — a different agent owns it.
+
+additional_duties is a list of duties an importer actually pays on the research date. Nothing
+else goes in it. Before adding an entry, apply all three tests:
+  1. Is the instrument still operative, or was it terminated or superseded?
+  2. Has its effective window ended? Compare its end date to the research date — an
+     instrument whose window closed yesterday is not in force today.
+  3. Does it cover this product and this origin, by its own stated scope?
+An instrument failing any test goes in confirmed_absent, naming the instrument and what
+disqualified it. Never record it as an additional duty with a 0% rate or an explanatory note.
+
+rate holds a bare percentage and nothing else. authority holds the instrument and its citation
+and nothing else. Status belongs in in_force and ends, never in prose inside another field.
+
+## Methodology
+Establish current state, not history: where an instrument has been modified or terminated by a
+later one, report the latest state and cite both. Compute absolute dates from any relative
+reference, and state the research date you are reasoning from. Use ISO 8601.
+
+## Missing data
+Distinguish three cases explicitly and never collapse them: (a) an overlay in force, which goes
+in additional_duties with in_force true, (b) an overlay checked and confirmed not to apply —
+terminated, expired, or out of scope — which goes in confirmed_absent, and (c) an overlay you
+could not verify, which goes in unverified with what you attempted. Never invent an instrument,
+a rate, or a date. Use null, never omit a field.
+
+An empty additional_duties list is a legitimate, complete answer when only the base rate
+applies. Do not pad it with instruments you ruled out."""
+
+OVERLAY_GOALS = [
+    "Every entry in additional_duties is collectible on the research date, with in_force true — terminated, expired and out-of-scope instruments appear in confirmed_absent instead",
+    "Each additional_duties entry carries a bare rate and a bare instrument citation, with no status prose inside either field",
+    "Sets ends to the date an instrument stops applying, or null when open-ended, and never lists an instrument whose window has already closed",
+    "Never blends overlay components into a single combined rate, and never includes the MFN base rate",
+    "Places unverifiable overlays in unverified with what was attempted — never conflated with confirmed_absent",
+    "Cites an official instrument for every overlay claimed to be in force",
+]
+
+OVERLAY_SOURCES = {
+    "allow": [
+        {
+            "title": "Federal Register",
+            "domains": ["federalregister.gov", "www.federalregister.gov"],
+            "order": 0,
+        },
+        {"title": "USTR", "domains": ["ustr.gov", "www.ustr.gov"], "order": 1},
+        {
+            "title": "White House presidential actions",
+            "domains": ["whitehouse.gov", "www.whitehouse.gov"],
+            "order": 2,
+        },
+        {
+            "title": "US Customs and Border Protection",
+            "domains": ["cbp.gov", "www.cbp.gov", "rulings.cbp.gov"],
+            "order": 3,
+        },
+        {
+            "title": "USITC",
+            "domains": ["hts.usitc.gov", "usitc.gov", "www.usitc.gov"],
+            "order": 4,
+        },
+    ],
+    "block": [],
+    "prioritize": "official instruments — register notices, executive orders, and agency determinations",
+    "avoid": "news summaries, law-firm marketing posts, and broker commentary",
+}
+
+OVERLAY_QUESTIONS = [
+    "Which duty overlays are currently in force for HTS 8507.60.00 imported from Vietnam into the United States?",
+    "Which duty overlays apply to HTS 8507.60.00 from China into the United States?",
+    "Is any exclusion still in force for HTS 7604.29.10 from Mexico into the United States?",
+    "Which overlays apply to HTS 4901.99.00 from the United Kingdom into the United States?",
+]
+
+OVERLAY_AGENT = {
+    "display_name": "Tariff Policy Overlay",
+    "description": "Establishes which duty overlays (301/232/IEEPA/reciprocal) are in force for a lane, with instruments and dates.",
+    "icon": "⚖️",
+    "use_case": "enrichment",
+    "effort": "high",
+    "skill": OVERLAY_SKILL,
+    "goals": OVERLAY_GOALS,
+    "sources": OVERLAY_SOURCES,
+    "output_schema": OVERLAY_SCHEMA,
+    "suggested_questions": OVERLAY_QUESTIONS,
+}
+
+AGENTS = {"rate": RATE_AGENT, "overlay": OVERLAY_AGENT}
+
+# Effort per fact class, chosen from measurement rather than preference.
+#
+# rate    = medium. Correct and `verified_against_official_schedule: true` on every
+#           run; one official source, one number. Higher tiers buy nothing.
+# overlay = high.   At medium the agent was confidently wrong three ways: expired
+#           instruments listed as in force, a duty asserted while its own
+#           terminating order sat in `unverified`, and duties described in prose
+#           while the structured array was empty. At high (2026-08-05 test) it
+#           structured the China duties correctly and found the terminating order
+#           medium had missed across three runs. Cost ~2.4x (≈220s vs ≈95s).
+EFFORT = {"rate": "medium", "overlay": "high"}
+
+# TTLs per DESIGN.md §2 — the reason there are two agents at all.
+TTL_DAYS = {"rate": 90, "overlay": 7}
+
+
+# --- hts-code-candidates --------------------------------------------------
+# A lookup helper, not a corpus fact class. Answers "which tariff codes might
+# cover this product?" so a reader who doesn't know HTS notation can get started.
+# Deliberately returns CANDIDATES with citations: classification is a human
+# decision and a wrong code yields a confidently wrong duty for the wrong product.
+
+HTS_SCHEMA = {
+    "type": "object",
+    "additionalProperties": True,
+    "properties": {
+        "candidates": {
+            "type": "array",
+            "description": "Plausible subheadings, most likely first. 2-5 entries.",
+            "items": {
+                "type": "object",
+                "additionalProperties": True,
+                "required": ["hts_code", "description"],
+                "properties": {
+                    "hts_code": {
+                        "type": "string",
+                        "description": (
+                            "A full statistical line in dotted form — 8 or 10 digits, "
+                            "e.g. '6404.11.20' or '8507.60.0020'. A duty rate only "
+                            "exists at this level. Return a 4-digit heading or 6-digit "
+                            "subheading ONLY when the description is too vague to reach "
+                            "a line, and then set is_full_rate_line to false."
+                        ),
+                    },
+                    "is_full_rate_line": {
+                        "type": "boolean",
+                        "description": (
+                            "True only for an 8- or 10-digit line that carries its own "
+                            "Rates of Duty entry. False for a heading or subheading, "
+                            "whose rate columns are blank."
+                        ),
+                    },
+                    "narrowing_needed": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "When is_full_rate_line is false, the specific detail needed "
+                            "to reach a rate line — e.g. 'upper material and whether it "
+                            "is sports footwear'. null when the line is already full."
+                        ),
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The schedule's own wording for this line, quoted.",
+                    },
+                    "why_it_might_fit": {
+                        "type": "string",
+                        "description": "One sentence tying the product to this line.",
+                    },
+                    "chapter": {"type": ["string", "null"]},
+                    "source_url": {"type": "string"},
+                },
+            },
+        },
+        "what_would_settle_it": {
+            "type": ["string", "null"],
+            "description": (
+                "What a person would need to check or decide to choose between the "
+                "candidates — material, function, end use, or a CBP ruling."
+            ),
+        },
+        "data_as_of_date": {"type": "string"},
+    },
+}
+
+HTS_SKILL = """You are a customs classification assistant helping someone who does not \
+know tariff notation find where their product might sit in the schedule.
+
+## Where to search
+Only the official Harmonized Tariff Schedule of the United States published by the
+USITC at hts.usitc.gov, including its chapter documents. Quote the schedule's own
+wording for each line.
+
+## Field rules
+Return 2 to 5 candidates, most likely first, and prefer **full statistical lines** — 8
+or 10 digits, the level that actually carries a Rates of Duty entry. A 4-digit heading
+or 6-digit subheading has blank rate columns, so returning one gives the reader a code
+no rate can be attached to.
+
+If the description is too vague to reach a line, you may return the heading, but set
+is_full_rate_line to false and put the missing detail in narrowing_needed. Prefer to
+offer full lines for the most likely readings — for footwear described only as
+"sneakers", give the specific lines for textile-upper and for rubber-upper sports
+footwear rather than the headings that contain them.
+
+Quote each line's description verbatim from the schedule rather than paraphrasing it.
+Give the URL of the chapter document you read it from.
+
+## Methodology
+Work from what the product is made of and what it does. Where the schedule
+distinguishes lines by material, end use, or a statistical suffix, surface the
+distinction as separate candidates rather than picking one.
+
+## The boundary you must not cross
+You are NOT classifying the product. You are showing a person where to look. Never
+present one candidate as the answer, never say a code "is" the correct one, and always
+fill what_would_settle_it with what a human still has to decide. If the product
+description is too vague to narrow down, return the broader headings and say so."""
+
+HTS_GOALS = [
+    "Returns 2 to 5 candidates, most likely first, never a single answer",
+    "Prefers full 8- or 10-digit statistical lines, which are the only level carrying a duty rate",
+    "Sets is_full_rate_line false for any heading or subheading returned, with the missing detail in narrowing_needed",
+    "Quotes each candidate's description verbatim from the official schedule",
+    "Cites the usitc.gov chapter document each candidate was read from",
+    "Fills what_would_settle_it with the distinction a human still has to decide",
+    "Surfaces material, end-use and statistical-suffix distinctions as separate candidates",
+]
+
+HTS_SOURCES = {
+    # Wider than the rate agent's allow list, and for a specific reason: the schedule
+    # is organised BY CODE, so it answers "what is the rate for 8507.60.00" well and
+    # "which code covers a drinks bottle" badly. CBP's ruling database is searchable by
+    # product description and every ruling names the subheading it classified under —
+    # which is the resource a person would actually use for a reverse lookup.
+    "allow": [
+        {
+            "title": "USITC Harmonized Tariff Schedule",
+            "domains": ["hts.usitc.gov", "usitc.gov", "www.usitc.gov"],
+            "order": 0,
+        },
+        {
+            "title": "CBP rulings (CROSS) and classification guidance",
+            "domains": ["rulings.cbp.gov", "cbp.gov", "www.cbp.gov"],
+            "order": 1,
+        },
+    ],
+    "block": [],
+    "prioritize": "the official HTSUS chapter documents published by the USITC",
+    "avoid": "customs-broker blogs, freight-forwarder marketing pages, and news summaries",
+}
+
+HTS_QUESTIONS = [
+    "Which tariff lines might cover canvas sneakers with rubber soles?",
+    "Which tariff codes might cover lithium-ion battery packs?",
+    "Which tariff codes might cover cotton knit t-shirts?",
+    "Which tariff codes might cover aluminium extrusions for window frames?",
+    "Which tariff codes might cover a stainless steel insulated drinks bottle?",
+]
+
+HTS_AGENT = {
+    "display_name": "HTS Code Candidates",
+    "description": "Suggests candidate HTS subheadings for a plain-language product description, with citations.",
+    "icon": "🔍",
+    "use_case": "research",
+    "effort": "medium",
+    "skill": HTS_SKILL,
+    "goals": HTS_GOALS,
+    "sources": HTS_SOURCES,
+    "output_schema": HTS_SCHEMA,
+    "suggested_questions": HTS_QUESTIONS,
+}
+
+AGENTS["hts"] = HTS_AGENT
+EFFORT["hts"] = "medium"

--- a/apps/llamaindex-tariff-desk/desk/classify.py
+++ b/apps/llamaindex-tariff-desk/desk/classify.py
@@ -156,5 +156,5 @@ def find_candidates(product: str, force: bool = False) -> dict[str, Any]:
     }
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     (CACHE_DIR / f"{slugify(product)}.json").write_text(
-        json.dumps(record, indent=2, default=str))
+        json.dumps(record, indent=2, default=str), encoding="utf-8")
     return record

--- a/apps/llamaindex-tariff-desk/desk/classify.py
+++ b/apps/llamaindex-tariff-desk/desk/classify.py
@@ -43,6 +43,7 @@ from typing import Any
 from llama_index.tools.nimble import NimbleAgentRunError, NimbleAgentToolSpec
 
 from .agents_config import HTS_SCHEMA
+from .io import read_json
 
 HERE = Path(__file__).parent.parent
 CACHE_DIR = HERE / "data" / "hts_lookups"
@@ -72,8 +73,6 @@ def use_live() -> bool:
 def cached(product: str) -> dict[str, Any] | None:
     """A previous lookup for this product, or None. Unreadable files are skipped
     rather than raised — a corrupt cache entry must not break the lookup box."""
-    from .research import read_json
-
     name = f"{slugify(product)}.json"
     for path in (CACHE_DIR / name, SAMPLE_DIR / name):
         if path.exists():

--- a/apps/llamaindex-tariff-desk/desk/classify.py
+++ b/apps/llamaindex-tariff-desk/desk/classify.py
@@ -1,0 +1,154 @@
+"""Plain-language product -> candidate tariff codes, with citations.
+
+Most people have no idea what an HTS code is, which makes the rest of the app
+unusable to them. This is the way in: describe the product, get a short list of
+candidate subheadings quoted from the official schedule, pick one.
+
+Two deliberate choices:
+
+  * **No text parsing.** The agent returns structured JSON via `output_schema`, and
+    `claims` are keyed by JSON path, so each candidate carries its own citation. An
+    earlier sketch used Nimble Search plus a regex over the result snippets; letting
+    the platform do the extraction is both less code and better evidence.
+  * **Candidates, never a decision.** Classification is a human call — a wrong code
+    yields a confidently wrong duty for the wrong product. The agent is instructed to
+    return 2-5 options and to say what a person still has to decide.
+
+`medium` effort — about 2 minutes, against the corpus agents' 4. `low` was tried first
+and produced nothing: it searched but filled no candidates.
+
+Two findings from getting this working, both worth knowing:
+
+  * **`input_data` steers the agent into row-enrichment mode.** Passing
+    `{"product": ...}` made it echo the row back with no research at all — one
+    `pre_existing` claim, zero sources. The product description belongs in the task
+    text. `input_data` is for rows you want fields filled on, not for a subject you
+    want researched.
+  * **A reverse lookup needs different sources than a forward one.** The tariff
+    schedule is organised BY CODE, so restricting to `usitc.gov` answered "rate for
+    8507.60.00" well and "which code covers a drinks bottle" not at all. CBP's ruling
+    database is searchable by product description and every ruling names the
+    subheading it classified under — which is what a person would actually use.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from llama_index.tools.nimble import NimbleAgentRunError, NimbleAgentToolSpec
+
+from .agents_config import HTS_SCHEMA
+
+HERE = Path(__file__).parent.parent
+CACHE_DIR = HERE / "data" / "hts_lookups"
+SAMPLE_DIR = HERE / "data" / "hts_samples"
+
+TASK = (
+    "Which HTS subheadings of the Harmonized Tariff Schedule of the United States "
+    "might cover this product? Return 2 to 5 candidates, most likely first, quoting "
+    "each line's description verbatim from the official schedule and citing the "
+    "chapter document you read it from. Do not choose one — say what a person still "
+    "has to decide between them."
+)
+
+TIMEOUT_S = 600
+POLL_INTERVAL_S = 5
+
+
+def slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", (text or "").strip().lower()).strip("-")
+    return slug[:70] or "query"
+
+
+def use_live() -> bool:
+    return os.environ.get("USE_LIVE", "false").strip().lower() in {"1", "true", "yes"}
+
+
+def cached(product: str) -> dict[str, Any] | None:
+    name = f"{slugify(product)}.json"
+    for path in (CACHE_DIR / name, SAMPLE_DIR / name):
+        if path.exists():
+            return json.loads(path.read_text())
+    return None
+
+
+def find_candidates(product: str, force: bool = False) -> dict[str, Any]:
+    """Candidate codes for a product description.
+
+    Returns {candidates, what_would_settle_it, citations, from_cache, elapsed_s} or
+    {error} — never raises into the UI, because a failed lookup should not take the
+    page down.
+    """
+    product = (product or "").strip()
+    if not product:
+        return {"error": "Describe the product first."}
+
+    if not force:
+        hit = cached(product)
+        if hit:
+            return {**hit, "from_cache": True}
+
+    if not use_live():
+        return {"error": ("`USE_LIVE=false`, so lookups replay cached results only, and "
+                          "this product isn't cached. Set `USE_LIVE=true` to look it up.")}
+
+    agent_id = os.environ.get("NIMBLE_HTS_AGENT_ID")
+    if not agent_id:
+        return {"error": "NIMBLE_HTS_AGENT_ID is not set — run setup_agents.py."}
+
+    tool = NimbleAgentToolSpec(
+        agent_id=agent_id, effort="medium",
+        timeout=TIMEOUT_S, poll_interval=POLL_INTERVAL_S,
+    )
+    started = time.monotonic()
+    try:
+        doc = tool.run(f"{TASK}\n\nProduct: {product}", output_schema=HTS_SCHEMA)
+    except NimbleAgentRunError as err:
+        return {"error": f"{type(err).__name__}: {err}"}
+    except Exception as err:  # noqa: BLE001 — a lookup must not break the page
+        return {"error": f"{type(err).__name__}: {err}"}
+
+    elapsed = round(time.monotonic() - started, 1)
+    meta = dict(doc.metadata or {})
+    text = doc.text or ""
+    try:
+        content = json.loads(text.split("\nSources:")[0].strip())
+    except json.JSONDecodeError:
+        return {"error": "The agent's answer was not the structured shape expected.",
+                "raw": text[:800]}
+
+    # Attach each candidate's own citation, keyed by JSON path. This is what
+    # output_schema buys: provenance per row, no parsing.
+    claims = {c.get("path"): c for c in (meta.get("claims") or []) if c.get("path")}
+    candidates = []
+    for idx, candidate in enumerate(content.get("candidates") or []):
+        claim = (claims.get(f"$.candidates[{idx}].hts_code")
+                 or claims.get(f"$.candidates[{idx}].description")
+                 or claims.get(f"$.candidates[{idx}]"))
+        citation = ((claim or {}).get("citations") or [{}])[0]
+        candidates.append({
+            **candidate,
+            "citation_url": citation.get("url") or candidate.get("source_url"),
+            "citation_title": citation.get("title"),
+            "citation_excerpt": (citation.get("excerpts") or [None])[0],
+            "confidence": (claim or {}).get("confidence"),
+        })
+
+    record = {
+        "product": product,
+        "candidates": candidates,
+        "what_would_settle_it": content.get("what_would_settle_it"),
+        "overall_confidence": meta.get("confidence"),
+        "run_id": meta.get("run_id"),
+        "elapsed_s": elapsed,
+        "from_cache": False,
+    }
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    (CACHE_DIR / f"{slugify(product)}.json").write_text(
+        json.dumps(record, indent=2, default=str))
+    return record

--- a/apps/llamaindex-tariff-desk/desk/classify.py
+++ b/apps/llamaindex-tariff-desk/desk/classify.py
@@ -70,10 +70,16 @@ def use_live() -> bool:
 
 
 def cached(product: str) -> dict[str, Any] | None:
+    """A previous lookup for this product, or None. Unreadable files are skipped
+    rather than raised — a corrupt cache entry must not break the lookup box."""
+    from .research import read_json
+
     name = f"{slugify(product)}.json"
     for path in (CACHE_DIR / name, SAMPLE_DIR / name):
         if path.exists():
-            return json.loads(path.read_text())
+            record = read_json(path)
+            if record is not None:
+                return record
     return None
 
 

--- a/apps/llamaindex-tariff-desk/desk/delta.py
+++ b/apps/llamaindex-tariff-desk/desk/delta.py
@@ -1,0 +1,92 @@
+"""What changed between two research runs of the same fact.
+
+The change log is the app's best evidence that a refreshed corpus is worth having,
+so the diff is computed from the structured content rather than by eyeballing prose.
+Embedding-free and pure — unit-tested.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Fields compared directly, per fact class.
+SCALAR_FIELDS = {
+    "rate": ["general_rate", "htsus_revision", "verified_against_official_schedule"],
+    "overlay": ["last_changed", "origin_rules_notes"],
+}
+
+# Lists of objects compared as sets of identity tuples.
+LIST_FIELDS = {
+    "overlay": {
+        "additional_duties": ("authority", "rate", "effective_date"),
+        "exclusions_in_force": ("description", "expires"),
+    },
+}
+
+
+def _identity(item: dict[str, Any], fields: tuple[str, ...]) -> tuple:
+    return tuple(str(item.get(f) or "").strip() for f in fields)
+
+
+def _label(item: dict[str, Any], fields: tuple[str, ...]) -> str:
+    parts = [str(item.get(f)) for f in fields if item.get(f)]
+    return " · ".join(parts) if parts else "(empty)"
+
+
+def diff_content(kind: str, before: dict[str, Any] | None,
+                 after: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Ordered list of changes. Empty list means nothing material moved."""
+    if after is None:
+        return []
+    if before is None:
+        return [{"type": "added", "field": "*", "before": None,
+                 "after": "first research of this fact"}]
+
+    changes: list[dict[str, Any]] = []
+
+    for field in SCALAR_FIELDS.get(kind, []):
+        old, new = before.get(field), after.get(field)
+        if str(old or "").strip() != str(new or "").strip():
+            changes.append({"type": "changed", "field": field,
+                            "before": old, "after": new})
+
+    for field, id_fields in LIST_FIELDS.get(kind, {}).items():
+        old_items = before.get(field) or []
+        new_items = after.get(field) or []
+        old_map = {_identity(i, id_fields): i for i in old_items if isinstance(i, dict)}
+        new_map = {_identity(i, id_fields): i for i in new_items if isinstance(i, dict)}
+        for key in new_map.keys() - old_map.keys():
+            changes.append({"type": "added", "field": field, "before": None,
+                            "after": _label(new_map[key], id_fields),
+                            "source_url": new_map[key].get("source_url")})
+        for key in old_map.keys() - new_map.keys():
+            changes.append({"type": "removed", "field": field,
+                            "before": _label(old_map[key], id_fields), "after": None})
+
+    # Coverage movement matters even when no value changed: a fact that slipped
+    # into `unverified` is a real regression the reader should see.
+    for field in ("unverified", "confirmed_absent"):
+        old_n = len(before.get(field) or [])
+        new_n = len(after.get(field) or [])
+        if old_n != new_n:
+            changes.append({"type": "coverage", "field": field,
+                            "before": old_n, "after": new_n})
+
+    return changes
+
+
+def summarize(kind: str, doc_key: str, changes: list[dict[str, Any]]) -> str:
+    """One human line for the change log."""
+    if not changes:
+        return f"{doc_key} [{kind}] unchanged"
+    parts = []
+    for change in changes:
+        if change["type"] == "changed":
+            parts.append(f"{change['field']}: {change['before']} → {change['after']}")
+        elif change["type"] == "added":
+            parts.append(f"+{change['field']}: {change['after']}")
+        elif change["type"] == "removed":
+            parts.append(f"−{change['field']}: {change['before']}")
+        elif change["type"] == "coverage":
+            parts.append(f"{change['field']} {change['before']}→{change['after']}")
+    return f"{doc_key} [{kind}] " + "; ".join(parts)

--- a/apps/llamaindex-tariff-desk/desk/delta.py
+++ b/apps/llamaindex-tariff-desk/desk/delta.py
@@ -24,8 +24,19 @@ LIST_FIELDS = {
 }
 
 
+def _norm(value: Any) -> str:
+    """Comparable text for a field value, keeping falsy values distinct.
+
+    `str(value or "")` turns False, 0 and None all into "", which hides real
+    movement: `verified_against_official_schedule` is explicitly allowed to be false
+    on a retrieval failure, so a change from missing to false is exactly the kind of
+    thing a change log exists to show.
+    """
+    return "" if value is None else str(value).strip()
+
+
 def _identity(item: dict[str, Any], fields: tuple[str, ...]) -> tuple:
-    return tuple(str(item.get(f) or "").strip() for f in fields)
+    return tuple(_norm(item.get(f)) for f in fields)
 
 
 def _label(item: dict[str, Any], fields: tuple[str, ...]) -> str:
@@ -46,7 +57,7 @@ def diff_content(kind: str, before: dict[str, Any] | None,
 
     for field in SCALAR_FIELDS.get(kind, []):
         old, new = before.get(field), after.get(field)
-        if str(old or "").strip() != str(new or "").strip():
+        if _norm(old) != _norm(new):
             changes.append({"type": "changed", "field": field,
                             "before": old, "after": new})
 

--- a/apps/llamaindex-tariff-desk/desk/freshness.py
+++ b/apps/llamaindex-tariff-desk/desk/freshness.py
@@ -1,0 +1,171 @@
+"""The freshness guard — the piece that makes this RAG rather than a search box.
+
+A normal vector store answers from whatever it holds and never mentions that the
+fact is four months old. Here every node carries `researched_at` and a `ttl_days`
+set by its fact class (rate: 90 days, overlay: 7), and expired nodes cannot be
+answered from silently.
+
+Two enforcement points, deliberately:
+  1. `FreshnessPostprocessor` annotates retrieved nodes and, in strict mode, drops
+     expired ones so the synthesizer cannot quote them at all.
+  2. `freshness_preamble()` puts the dates into the prompt, so an answer built from
+     surviving nodes still has to state when each fact was researched.
+
+Pure date arithmetic — no embeddings, no network. Unit-tested in tests/.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.core.schema import NodeWithScore, QueryBundle
+
+from .agents_config import TTL_DAYS
+
+STALE_KEY = "is_stale"
+AGE_KEY = "age_days"
+
+
+def parse_stamp(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed
+
+
+def ttl_for(kind: str | None) -> int:
+    """TTL in days for a fact class. Unknown kinds get the strictest TTL."""
+    if kind in TTL_DAYS:
+        return TTL_DAYS[kind]
+    return min(TTL_DAYS.values())
+
+
+def age_in_days(researched_at: Any, now: datetime | None = None) -> float | None:
+    stamp = parse_stamp(researched_at)
+    if stamp is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    return round((now - stamp).total_seconds() / 86400, 2)
+
+
+def is_stale(researched_at: Any, kind: str | None, now: datetime | None = None) -> bool:
+    """A fact with no usable timestamp is stale — absence of proof is not freshness."""
+    stamp = parse_stamp(researched_at)
+    if stamp is None:
+        return True
+    now = now or datetime.now(timezone.utc)
+    return now - stamp >= timedelta(days=ttl_for(kind))
+
+
+@dataclass
+class FreshnessVerdict:
+    kind: str | None
+    researched_at: str | None
+    age_days: float | None
+    ttl_days: int
+    stale: bool
+
+    def describe(self) -> str:
+        if self.researched_at is None:
+            return f"{self.kind or 'fact'}: no research date recorded — treat as stale"
+        age = "today" if (self.age_days or 0) < 1 else f"{self.age_days:g} days ago"
+        state = "STALE" if self.stale else "fresh"
+        return (
+            f"{self.kind or 'fact'}: researched {age} "
+            f"({self.researched_at[:10]}), TTL {self.ttl_days}d — {state}"
+        )
+
+
+def assess(metadata: dict[str, Any], now: datetime | None = None) -> FreshnessVerdict:
+    kind = metadata.get("kind")
+    researched_at = metadata.get("researched_at")
+    return FreshnessVerdict(
+        kind=kind,
+        researched_at=researched_at if isinstance(researched_at, str) else None,
+        age_days=age_in_days(researched_at, now=now),
+        ttl_days=ttl_for(kind),
+        stale=is_stale(researched_at, kind, now=now),
+    )
+
+
+class FreshnessPostprocessor(BaseNodePostprocessor):
+    """Annotate every retrieved node with its freshness; optionally drop stale ones.
+
+    strict=True is the app's default: an expired node is withheld from the
+    synthesizer entirely, so the UI offers to re-research instead of quietly
+    serving an old rate. strict=False keeps stale nodes but marks them, which is
+    what the "show me anyway" path uses.
+    """
+
+    strict: bool = True
+    now: datetime | None = None
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "FreshnessPostprocessor"
+
+    def _postprocess_nodes(
+        self,
+        nodes: list[NodeWithScore],
+        query_bundle: QueryBundle | None = None,
+    ) -> list[NodeWithScore]:
+        kept: list[NodeWithScore] = []
+        for nws in nodes:
+            verdict = assess(nws.node.metadata or {}, now=self.now)
+            nws.node.metadata[STALE_KEY] = verdict.stale
+            nws.node.metadata[AGE_KEY] = verdict.age_days
+            if verdict.stale and self.strict:
+                continue
+            kept.append(nws)
+        return kept
+
+
+def freshness_preamble(nodes: list[NodeWithScore], now: datetime | None = None) -> str:
+    """Prompt text forcing the answer to carry its own dates.
+
+    Without this, a synthesizer happily reports a rate with no indication of when
+    it was true — which is the exact failure this whole app exists to prevent.
+    """
+    if not nodes:
+        return ""
+    lines = []
+    for nws in nodes:
+        meta = nws.node.metadata or {}
+        label = meta.get("doc_key") or meta.get("lane_key") or "fact"
+        lines.append(f"- {label} — {assess(meta, now=now).describe()}")
+    return (
+        "Freshness of the retrieved facts:\n"
+        + "\n".join(lines)
+        + "\n\nState the research date alongside every figure you report, and name the "
+        "source it came from. If a fact is marked STALE, say so plainly rather than "
+        "presenting it as current. Never present a value graded pre_existing as a "
+        "researched fact — those are echoes of the question's own input."
+    )
+
+
+def stale_report(records: list[dict[str, Any]], now: datetime | None = None) -> list[dict[str, Any]]:
+    """Per-record freshness, newest first — powers the sidebar and 'what's stale?'."""
+    rows = []
+    for record in records:
+        verdict = assess(
+            {"kind": record.get("kind"), "researched_at": record.get("researched_at")},
+            now=now,
+        )
+        rows.append({
+            "doc_key": record.get("doc_key") or record.get("lane_key"),
+            "lane_key": record.get("lane_key"),
+            "kind": record.get("kind"),
+            "researched_at": verdict.researched_at,
+            "age_days": verdict.age_days,
+            "ttl_days": verdict.ttl_days,
+            "stale": verdict.stale,
+            "confidence": (record.get("metadata") or {}).get("confidence"),
+        })
+    rows.sort(key=lambda r: (not r["stale"], -(r["age_days"] or 0)))
+    return rows

--- a/apps/llamaindex-tariff-desk/desk/ingest.py
+++ b/apps/llamaindex-tariff-desk/desk/ingest.py
@@ -29,6 +29,8 @@ from typing import Any, Iterable
 
 from llama_index.core import Document
 
+from .io import read_json
+
 HERE = Path(__file__).parent.parent
 RUNS_DIR = HERE / "data" / "runs"
 SAMPLES_DIR = HERE / "data" / "samples"
@@ -66,10 +68,9 @@ def load_records(directory: Path | None = None) -> list[dict[str, Any]]:
     if not directory.exists():
         return records
     for path in sorted(directory.glob("*.json")):
-        try:
-            records.append(json.loads(path.read_text(encoding="utf-8")))
-        except json.JSONDecodeError:
-            continue
+        record = read_json(path)
+        if record is not None:
+            records.append(record)
     records.sort(key=lambda r: r.get("researched_at") or "", reverse=True)
     return records
 

--- a/apps/llamaindex-tariff-desk/desk/ingest.py
+++ b/apps/llamaindex-tariff-desk/desk/ingest.py
@@ -1,0 +1,304 @@
+"""Run records -> LlamaIndex Documents -> a persisted, refreshable index.
+
+Everything above the index build is embedding-free and unit-tested. Only
+`build_index` / `load_index` touch an embedding model.
+
+The key discipline (DESIGN.md §5): a Document's `doc_id` is stable across
+re-research, so `refresh_ref_docs()` upserts in place and only re-embeds what
+actually changed. Rate documents are keyed origin-free.
+
+**On trusting the agent's output.** An earlier version of this file carried four
+text heuristics that tried to detect when an answer contradicted itself — regexes
+over prose, instrument-ID matching between fields, negation detection. Each one
+produced false positives (one flagged a duty as unconfirmed because an unrelated
+*exclusion* was unverified; another broke on the dot in "8507.60"), and together
+they buried the thing this cookbook is meant to show. Nimble already returns
+`confidence`, per-path `claims` with citations, and an `unverified` list. Surfacing
+that verbatim is both more honest and more useful than inferring meaning from
+sentences. What remains here reads *structured* fields the agent explicitly set —
+no guessing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from llama_index.core import Document
+
+HERE = Path(__file__).parent.parent
+RUNS_DIR = HERE / "data" / "runs"
+SAMPLES_DIR = HERE / "data" / "samples"
+STORAGE_DIR = HERE / "storage"
+
+# Grades that mean "this came from the question, not from research".
+ECHO_GRADES = {"pre_existing"}
+
+
+def active_dir() -> Path:
+    """The one corpus directory everything must agree on.
+
+    The index, the sidebar and the corpus engine have to read the same records or
+    they contradict each other — an earlier version had the corpus engine reporting
+    "all facts are inside their TTL" while the retrieval guard was withholding a
+    stale one, because one read `data/runs/` and the other `data/samples/`.
+    """
+    choice = os.environ.get("DESK_CORPUS", "").strip().lower()
+    if choice == "runs":
+        return RUNS_DIR
+    if choice == "samples":
+        return SAMPLES_DIR
+    live = os.environ.get("USE_LIVE", "false").strip().lower() in {"1", "true", "yes"}
+    if live and RUNS_DIR.exists() and any(RUNS_DIR.glob("*.json")):
+        return RUNS_DIR
+    if SAMPLES_DIR.exists() and any(SAMPLES_DIR.glob("*.json")):
+        return SAMPLES_DIR
+    return RUNS_DIR
+
+
+def load_records(directory: Path | None = None) -> list[dict[str, Any]]:
+    """Every saved run record, newest research first."""
+    directory = directory or active_dir()
+    records = []
+    if not directory.exists():
+        return records
+    for path in sorted(directory.glob("*.json")):
+        try:
+            records.append(json.loads(path.read_text()))
+        except json.JSONDecodeError:
+            continue
+    records.sort(key=lambda r: r.get("researched_at") or "", reverse=True)
+    return records
+
+
+# --- reading the trust payload --------------------------------------------
+
+
+def split_claims(metadata: dict[str, Any]) -> tuple[list[dict], list[dict]]:
+    """(researched, echoes) — echoes are `pre_existing`, zero-citation input mirrors.
+
+    Verified in smoke 1: `$.product`, `$.origin` and `$.hts_code` come back graded
+    `pre_existing` with no citations because they were supplied in `input_data`.
+    Presenting them as researched facts would be a lie of omission.
+    """
+    researched, echoes = [], []
+    for claim in metadata.get("claims") or []:
+        grade = (claim.get("confidence") or "").strip().lower()
+        has_citations = bool(claim.get("citations"))
+        (echoes if (grade in ECHO_GRADES and not has_citations) else researched).append(claim)
+    return researched, echoes
+
+
+def source_urls(metadata: dict[str, Any]) -> list[str]:
+    return [s.get("url") for s in (metadata.get("sources") or []) if s.get("url")]
+
+
+def primary_source_count(metadata: dict[str, Any]) -> int:
+    return sum(1 for s in (metadata.get("sources") or []) if s.get("type") == "primary")
+
+
+def parsed_content(record: dict[str, Any]) -> dict[str, Any] | None:
+    """The structured answer. `output_type` is json, so the text leads with JSON."""
+    text = record.get("text") or ""
+    head = text.split("\nSources:")[0].strip()
+    try:
+        value = json.loads(head)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def claim_index(metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """JSON path -> claim, so the UI can cite an individual cell.
+
+    This is why `output_schema` is worth using: with it, claims are keyed by path
+    (`$.additional_duties[0].rate`); without it they are keyed by prose callout and
+    cannot be attached to a field.
+    """
+    out = {}
+    for claim in metadata.get("claims") or []:
+        key = claim.get("path")
+        if key:
+            out[key] = claim
+    return out
+
+
+def split_duties(content: dict[str, Any] | None,
+                 as_of: str | None = None) -> tuple[list[dict], list[dict]]:
+    """(in_force, not_in_force) from `additional_duties`.
+
+    Two checks only, both reading fields the agent explicitly set:
+
+      * `in_force is False` — it told us this one doesn't apply
+      * `ends` earlier than the research date — the window has closed
+
+    Both exist because the schema asks for them, so this is schema validation, not
+    interpretation. Anything subtler than that is the reader's call, informed by the
+    `unverified` list and the citations — which is what the UI shows.
+    """
+    if not content:
+        return [], []
+    from .freshness import parse_stamp
+
+    cutoff = parse_stamp(as_of) or datetime.now(timezone.utc)
+    in_force, excluded = [], []
+    for duty in content.get("additional_duties") or []:
+        if not isinstance(duty, dict):
+            continue
+        reasons = []
+        if duty.get("in_force") is False:
+            reasons.append("the agent marked it not in force")
+        ends = parse_stamp(duty.get("ends"))
+        if ends is not None and ends < cutoff:
+            reasons.append(f"its window closed on {duty.get('ends')}")
+        if reasons:
+            excluded.append({**duty, "excluded_because": " and ".join(reasons)})
+        else:
+            in_force.append(duty)
+    return in_force, excluded
+
+
+# --- documents -------------------------------------------------------------
+
+
+def node_metadata(record: dict[str, Any]) -> dict[str, Any]:
+    """What every node carries — freshness, provenance and trust travel together."""
+    meta = record.get("metadata") or {}
+    content = parsed_content(record) or {}
+    researched, echoes = split_claims(meta)
+    in_force, excluded = split_duties(content, as_of=record.get("researched_at"))
+    lane = record.get("lane") or {}
+    return {
+        "doc_key": record.get("doc_key") or record.get("lane_key"),
+        "lane_key": record.get("lane_key"),
+        "kind": record.get("kind"),
+        "hts_code": lane.get("hts_code"),
+        # A rate Document is origin-free and applies to every origin of the code;
+        # carrying the origin of whichever lane researched it would scope it wrongly.
+        "origin": lane.get("origin") if record.get("kind") != "rate" else "any",
+        "destination": lane.get("destination"),
+        "product": lane.get("product") or "",
+        "researched_at": record.get("researched_at"),
+        "confidence": meta.get("confidence"),
+        "reasoning": meta.get("reasoning"),
+        "run_id": meta.get("run_id"),
+        "agent_id": meta.get("web_search_agent_id") or meta.get("agent_id"),
+        "effort": meta.get("effort"),
+        "source_urls": source_urls(meta),
+        "primary_sources": primary_source_count(meta),
+        "researched_claims": len(researched),
+        "echoed_claims": len(echoes),
+        "duties_in_force": len(in_force),
+        "duties_excluded": len(excluded),
+        # Coverage gaps matter as much as the answer: `confidence` does not capture
+        # them. A run can return `high` while leaving several facts unverified.
+        "unverified": content.get("unverified") or [],
+        "confirmed_absent": content.get("confirmed_absent") or [],
+    }
+
+
+def to_document(record: dict[str, Any]) -> Document:
+    """One saved run -> one Document with a stable doc_id."""
+    kind = record.get("kind") or "fact"
+    doc_id = record.get("doc_id") or f"{record.get('doc_key') or record.get('lane_key')}#{kind}"
+    lane = record.get("lane") or {}
+    meta = node_metadata(record)
+
+    if kind == "rate":
+        header = (
+            f"Base tariff schedule rate for HTS {lane.get('hts_code')} "
+            f"into {lane.get('destination')}"
+            "\nThis Column 1 General (MFN) rate applies to imports from ANY country of "
+            "origin. Any origin named in the source run below is incidental to how the "
+            "research was triggered and does not limit the rate's scope."
+        )
+    else:
+        header = (
+            f"Duty policy overlays for HTS {lane.get('hts_code')} "
+            f"from {lane.get('origin')} into {lane.get('destination')}"
+        )
+    if lane.get("product"):
+        header += f" ({lane['product']})"
+
+    # The research date goes in the TEXT as well as the metadata, because an agent
+    # only ever sees a node's text — metadata is dropped on the way in.
+    body = (
+        f"{header}\n"
+        f"Researched: {record.get('researched_at')}\n"
+        f"Overall confidence: {meta.get('confidence')}\n\n"
+        f"{record.get('text') or ''}"
+    )
+    doc = Document(text=body, doc_id=doc_id, metadata=meta)
+    # Metadata is prepended to node text for embedding and counts against the chunk
+    # budget; the full payload overflows a 1024-token chunk outright. These stay on
+    # the node for the UI to read, they just aren't embedded.
+    bulky = ["unverified", "confirmed_absent", "reasoning", "source_urls",
+             "run_id", "agent_id"]
+    doc.excluded_embed_metadata_keys = list(bulky)
+    doc.excluded_llm_metadata_keys = list(bulky)
+    return doc
+
+
+def to_documents(records: Iterable[dict[str, Any]]) -> list[Document]:
+    return [to_document(r) for r in records]
+
+
+# --- index build (the only embedding-dependent part) ----------------------
+
+
+def _storage_exists(storage_dir: Path) -> bool:
+    return (storage_dir / "docstore.json").exists()
+
+
+def build_index(documents: list[Document], storage_dir: Path | None = None):
+    """Create or update the index, re-embedding only what changed."""
+    from llama_index.core import (
+        StorageContext, VectorStoreIndex, load_index_from_storage,
+    )
+
+    storage_dir = storage_dir or STORAGE_DIR
+    storage_dir.mkdir(parents=True, exist_ok=True)
+
+    if _storage_exists(storage_dir):
+        ctx = StorageContext.from_defaults(persist_dir=str(storage_dir))
+        index = load_index_from_storage(ctx)
+        # Stable doc_ids + upsert-by-hash: unchanged Documents are not re-embedded.
+        refreshed = index.refresh_ref_docs(documents)
+        index.storage_context.persist(persist_dir=str(storage_dir))
+        return index, refreshed
+
+    index = VectorStoreIndex.from_documents(documents)
+    index.storage_context.persist(persist_dir=str(storage_dir))
+    return index, [True] * len(documents)
+
+
+def load_index(storage_dir: Path | None = None):
+    from llama_index.core import StorageContext, load_index_from_storage
+
+    storage_dir = storage_dir or STORAGE_DIR
+    if not _storage_exists(storage_dir):
+        return None
+    ctx = StorageContext.from_defaults(persist_dir=str(storage_dir))
+    return load_index_from_storage(ctx)
+
+
+def coverage(records: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """What the corpus holds — drives the sidebar and 'what do you cover?'."""
+    records = records if records is not None else load_records()
+    lanes, codes = set(), set()
+    for r in records:
+        if r.get("kind") == "overlay" and r.get("lane_key"):
+            lanes.add(r["lane_key"])
+        code = (r.get("lane") or {}).get("hts_code")
+        if code:
+            codes.add(code)
+    return {
+        "records": len(records),
+        "lanes": sorted(lanes),
+        "hts_codes": sorted(codes),
+        "rate_docs": sum(1 for r in records if r.get("kind") == "rate"),
+        "overlay_docs": sum(1 for r in records if r.get("kind") == "overlay"),
+    }

--- a/apps/llamaindex-tariff-desk/desk/ingest.py
+++ b/apps/llamaindex-tariff-desk/desk/ingest.py
@@ -67,7 +67,7 @@ def load_records(directory: Path | None = None) -> list[dict[str, Any]]:
         return records
     for path in sorted(directory.glob("*.json")):
         try:
-            records.append(json.loads(path.read_text()))
+            records.append(json.loads(path.read_text(encoding="utf-8")))
         except json.JSONDecodeError:
             continue
     records.sort(key=lambda r: r.get("researched_at") or "", reverse=True)

--- a/apps/llamaindex-tariff-desk/desk/io.py
+++ b/apps/llamaindex-tariff-desk/desk/io.py
@@ -1,0 +1,73 @@
+"""Reading persisted state off disk, once, for everything that does it.
+
+Every module here reads JSON the app itself wrote, and a file the app wrote can
+still be unreadable: a process killed mid-write leaves it truncated, a sync tool
+can leave it locked, permissions can change. None of that should surface as a
+traceback in the middle of a question.
+
+This module exists because the guard was written three separate times and got it
+right once. `research.py` had a version that caught both JSONDecodeError and
+OSError; `ingest.load_records` caught only the first; `classify` and
+`recover_runs` caught neither. One implementation, imported everywhere.
+
+Deliberately dependency-free so any module can import it without cycles.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# How much of a log file to keep when tailing. Generous for a demo corpus and
+# bounded for one that has been refreshing on a schedule for a year.
+TAIL_BYTES = 256 * 1024
+
+
+def read_json(path: Path) -> dict[str, Any] | None:
+    """Parse a JSON file, or None if it is missing, truncated or unreadable.
+
+    Returns None rather than raising: a corrupt cache entry should cost the reader
+    that one fact, not the page they were looking at.
+    """
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError):
+        return None
+
+
+def read_json_lines(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
+    """Parse a JSONL file newest-last, reading at most the tail of it.
+
+    The change log grows by one line per refreshed fact forever. Reading the whole
+    file to show the last handful of entries is fine at demo size and wasteful at
+    any real size, so only the tail is read. Unparseable lines are skipped, which
+    includes the partial first line a tail read can produce.
+    """
+    if not path.exists():
+        return []
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            if size > TAIL_BYTES:
+                fh.seek(size - TAIL_BYTES)
+                fh.readline()          # discard the partial line the seek landed in
+            raw = fh.read().decode("utf-8", errors="replace")
+    except OSError:
+        return []
+
+    lines = raw.splitlines()
+    if limit is not None:
+        lines = lines[-(limit * 4):]   # room for unparseable lines before slicing
+    entries = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            entries.append(parsed)
+    return entries

--- a/apps/llamaindex-tariff-desk/desk/io.py
+++ b/apps/llamaindex-tariff-desk/desk/io.py
@@ -25,15 +25,20 @@ TAIL_BYTES = 256 * 1024
 
 
 def read_json(path: Path) -> dict[str, Any] | None:
-    """Parse a JSON file, or None if it is missing, truncated or unreadable.
+    """Parse a JSON object from a file, or None.
 
-    Returns None rather than raising: a corrupt cache entry should cost the reader
-    that one fact, not the page they were looking at.
+    None covers every way this can fail to produce something a caller can use:
+    missing, truncated, unreadable, or valid JSON that is not an object. That last
+    case matters because `[1, 2]` and `"text"` parse cleanly and then break the
+    first `.get()` downstream, which is a worse failure than not parsing at all.
+
+    A corrupt entry should cost the reader that one fact, not the page.
     """
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        value = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError, ValueError):
         return None
+    return value if isinstance(value, dict) else None
 
 
 def read_json_lines(path: Path, limit: int | None = None) -> list[dict[str, Any]]:

--- a/apps/llamaindex-tariff-desk/desk/models.py
+++ b/apps/llamaindex-tariff-desk/desk/models.py
@@ -15,6 +15,21 @@ DEFAULT_LLM = "claude-sonnet-5"
 DEFAULT_EMBED = "text-embedding-3-small"
 
 
+def _int_env(name: str, default: int) -> int:
+    """An int from the environment, falling back rather than raising.
+
+    A typo in a .env value should not take the app down with a ValueError from
+    deep inside model setup.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
 def configure_models(require_embeddings: bool = True) -> None:
     """Set Settings.llm and Settings.embed_model. Idempotent.
 
@@ -29,7 +44,7 @@ def configure_models(require_embeddings: bool = True) -> None:
     # These documents are structured JSON answers plus a Sources list, so they chunk
     # badly at the 1024 default — a duty table split mid-array loses the association
     # between a rate and its instrument.
-    Settings.chunk_size = int(os.environ.get("DESK_CHUNK_SIZE", "2048"))
+    Settings.chunk_size = _int_env("DESK_CHUNK_SIZE", 2048)
     Settings.chunk_overlap = 128
     if require_embeddings:
         _set_embeddings(Settings)

--- a/apps/llamaindex-tariff-desk/desk/models.py
+++ b/apps/llamaindex-tariff-desk/desk/models.py
@@ -1,0 +1,62 @@
+"""One place to configure the LlamaIndex models.
+
+Anthropic for the LLM (normalization and response synthesis), OpenAI for
+embeddings — Anthropic has no embeddings API, and local HuggingFace embeddings
+would add ~2GB of torch to a cookbook that should install in a minute.
+
+Both are overridable by env var so a reader can swap either without touching code.
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_LLM = "claude-sonnet-5"
+DEFAULT_EMBED = "text-embedding-3-small"
+
+
+def configure_models(require_embeddings: bool = True) -> None:
+    """Set Settings.llm and Settings.embed_model. Idempotent.
+
+    Assign without reading first: `Settings.llm` is a lazy property that resolves
+    LlamaIndex's *default* provider (OpenAI) on access, so merely inspecting it
+    raises ImportError when `llama-index-llms-openai` isn't installed — which it
+    isn't here, because the LLM is Anthropic.
+    """
+    from llama_index.core import Settings
+
+    _set_llm(Settings)
+    # These documents are structured JSON answers plus a Sources list, so they chunk
+    # badly at the 1024 default — a duty table split mid-array loses the association
+    # between a rate and its instrument.
+    Settings.chunk_size = int(os.environ.get("DESK_CHUNK_SIZE", "2048"))
+    Settings.chunk_overlap = 128
+    if require_embeddings:
+        _set_embeddings(Settings)
+
+
+def _set_llm(Settings) -> None:
+    from llama_index.llms.anthropic import Anthropic
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY is not set — needed for question normalization and "
+            "for writing answers from retrieved facts."
+        )
+    Settings.llm = Anthropic(
+        model=os.environ.get("DESK_LLM_MODEL", DEFAULT_LLM),
+        max_tokens=2048,
+    )
+
+
+def _set_embeddings(Settings) -> None:
+    from llama_index.embeddings.openai import OpenAIEmbedding
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError(
+            "OPENAI_API_KEY is not set — needed to embed the corpus. Every agent run "
+            "works without it; only the index does not."
+        )
+    Settings.embed_model = OpenAIEmbedding(
+        model=os.environ.get("DESK_EMBED_MODEL", DEFAULT_EMBED)
+    )

--- a/apps/llamaindex-tariff-desk/desk/normalize.py
+++ b/apps/llamaindex-tariff-desk/desk/normalize.py
@@ -1,0 +1,222 @@
+"""Question → canonical lane key.
+
+Why this file exists (DESIGN.md §5): free-text questions have no natural doc_id.
+"duty on batteries from Vietnam" and "Vietnam battery tariff rate" are the same
+lane, and if each spawns its own Document the corpus fills with near-duplicates
+that never refresh cleanly. Normalizing to `<hts_code>|<origin>|<destination>`
+before touching the index is what makes the corpus compound instead of rot.
+
+Classification stays human (DESIGN.md §11.3). This module never invents an HTS
+code: if the question doesn't carry one and the product isn't in the small local
+hint table, it returns `needs_hts_code` and the UI asks. It may *suggest* a code,
+always explicitly flagged as unconfirmed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .research import Lane
+
+# Deliberately tiny. Not a classification database — just enough to recognise the
+# demo lanes so a reader isn't forced to look up a code to try the app. Anything
+# outside this table goes to the human.
+KNOWN_PRODUCTS: dict[str, tuple[str, str]] = {
+    "lithium-ion battery": ("8507.60.00", "lithium-ion battery packs"),
+    "lithium ion battery": ("8507.60.00", "lithium-ion battery packs"),
+    "li-ion battery": ("8507.60.00", "lithium-ion battery packs"),
+    "aluminum extrusion": ("7604.29.10", "aluminum extrusions"),
+    "aluminium extrusion": ("7604.29.10", "aluminum extrusions"),
+    "cotton t-shirt": ("6109.10.00", "cotton knit t-shirts"),
+    "cotton tshirt": ("6109.10.00", "cotton knit t-shirts"),
+    "cotton t shirt": ("6109.10.00", "cotton knit t-shirts"),
+    "printed book": ("4901.99.00", "printed books"),
+    "solar panel": ("8541.43.00", "photovoltaic modules"),
+    "solar module": ("8541.43.00", "photovoltaic modules"),
+}
+
+# 4-to-10 digit HTS notation: 8507, 8507.60, 8507.60.00, 8507.60.0020
+HTS_RE = re.compile(r"\b(\d{4}(?:\.\d{2}){0,3}(?:\d{2})?)\b")
+
+COUNTRY_HINTS = (
+    "Vietnam", "China", "Mexico", "Canada", "India", "Bangladesh", "Thailand",
+    "Taiwan", "South Korea", "Korea", "Japan", "Germany", "France", "Italy",
+    "United Kingdom", "UK", "Brazil", "Indonesia", "Malaysia", "Philippines",
+    "Turkey", "Poland", "Czech Republic", "Netherlands", "Spain", "Cambodia",
+)
+
+_COUNTRY_CANON = {"uk": "United Kingdom", "korea": "South Korea"}
+
+DEFAULT_DESTINATION = "United States"
+
+SYSTEM = """You extract a trade lane from a question. Return JSON only.
+
+Fields:
+  hts_code    — the HTS subheading if the question states one, else null. NEVER invent one.
+  product     — the product in plain words, else null.
+  origin      — the country of origin as a full country name, else null.
+  destination — the importing country as a full country name. Default "United States".
+  intent      — "lane" for a question about a specific lane's duty treatment;
+                "corpus" for a question about the knowledge base itself
+                (what changed, what is stale, what do you cover);
+                "other" for anything else.
+
+Rules:
+  Never guess or derive an HTS code from a product description. That is a human
+  classification decision. If the question has no code, leave hts_code null.
+  Normalise country names ("VN" -> "Vietnam", "the UK" -> "United Kingdom").
+  Return only a JSON object, no prose and no code fences."""
+
+
+@dataclass
+class Normalized:
+    intent: str = "lane"
+    lane: Lane | None = None
+    product: str | None = None
+    origin: str | None = None
+    destination: str = DEFAULT_DESTINATION
+    hts_code: str | None = None
+    needs_hts_code: bool = False
+    needs_origin: bool = False
+    partial_code: bool = False
+    suggested_hts_code: str | None = None
+    suggestion_basis: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def ready(self) -> bool:
+        return self.lane is not None
+
+
+def _canon_country(name: str | None) -> str | None:
+    if not name:
+        return None
+    cleaned = name.strip().strip(".,")
+    return _COUNTRY_CANON.get(cleaned.lower(), cleaned)
+
+
+def _product_hint(text: str) -> tuple[str | None, str | None]:
+    low = text.lower()
+    for phrase, (code, label) in KNOWN_PRODUCTS.items():
+        if phrase in low:
+            return code, label
+    return None, None
+
+
+def heuristic(question: str) -> Normalized:
+    """LLM-free path. Used as a fallback and to keep tests offline and cheap."""
+    out = Normalized()
+    low = question.lower()
+
+    if any(p in low for p in ("what changed", "which lanes", "stale", "what do you cover",
+                              "coverage", "how fresh", "refresh")):
+        out.intent = "corpus"
+        return out
+
+    match = HTS_RE.search(question)
+    if match:
+        out.hts_code = match.group(1)
+
+    for country in COUNTRY_HINTS:
+        if re.search(rf"\b{re.escape(country)}\b", question, re.IGNORECASE):
+            canon = _canon_country(country)
+            if re.search(rf"(?:into|to)\s+(?:the\s+)?{re.escape(country)}\b", question, re.IGNORECASE):
+                out.destination = canon or DEFAULT_DESTINATION
+            elif out.origin is None:
+                out.origin = canon
+    hint_code, hint_label = _product_hint(question)
+    out.product = hint_label
+
+    if out.hts_code is None and hint_code:
+        out.suggested_hts_code = hint_code
+        out.suggestion_basis = "matched a known demo product; unconfirmed"
+
+    _finalize(out)
+    return out
+
+
+def digits_in(code: str | None) -> int:
+    return sum(c.isdigit() for c in str(code or ""))
+
+
+def _finalize(out: Normalized) -> None:
+    if out.intent != "lane":
+        return
+    # A base rate lives on a full statistical line (8 or 10 digits). A 4-digit heading
+    # or 6-digit subheading spans many lines with very different rates — footwear under
+    # heading 6404 runs from free to over 30% — so there is no single rate to report.
+    # Worth saying before spending runs on an unanswerable question.
+    if out.hts_code and digits_in(out.hts_code) < 8:
+        out.partial_code = True
+    if out.hts_code and out.origin:
+        out.lane = Lane(
+            hts_code=out.hts_code,
+            origin=out.origin,
+            destination=out.destination or DEFAULT_DESTINATION,
+            product=out.product or "",
+        )
+        return
+    if not out.hts_code:
+        out.needs_hts_code = True
+        out.notes.append(
+            "No HTS code in the question. Classification is a human decision — "
+            "supply a code to continue."
+        )
+    if not out.origin:
+        # Its own flag, not just a note. The "Use this" button prefills
+        # "…from " with the country left blank, so a question with a code and no
+        # origin is the *expected* intermediate state, not a malformed one.
+        out.needs_origin = True
+        out.notes.append("No country of origin in the question.")
+
+
+def normalize(question: str, llm: Any | None = None) -> Normalized:
+    """Normalize with an LLM when one is available, else fall back to heuristics."""
+    if llm is None:
+        return heuristic(question)
+
+    try:
+        raw = llm.complete(f"{SYSTEM}\n\nQuestion: {question}\nJSON:").text.strip()
+        raw = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
+        data = json.loads(raw)
+    except Exception:  # noqa: BLE001 — a bad key must not take the app down
+        out = heuristic(question)
+        out.notes.append("LLM normalization unavailable; used heuristics.")
+        return out
+
+    out = Normalized(
+        intent=(data.get("intent") or "lane").strip().lower(),
+        hts_code=(data.get("hts_code") or None),
+        product=(data.get("product") or None),
+        origin=_canon_country(data.get("origin")),
+        destination=_canon_country(data.get("destination")) or DEFAULT_DESTINATION,
+    )
+    # Trust the model to read a code that is present, never to derive one.
+    if out.hts_code and not HTS_RE.fullmatch(out.hts_code.strip()):
+        out.notes.append(f"Discarded malformed hts_code from the model: {out.hts_code!r}")
+        out.hts_code = None
+    if out.hts_code is None and out.product:
+        hint_code, _ = _product_hint(out.product)
+        if hint_code:
+            out.suggested_hts_code = hint_code
+            out.suggestion_basis = "matched a known demo product; unconfirmed"
+    _finalize(out)
+    return out
+
+
+def get_llm() -> Any | None:
+    """The Anthropic LLM used for normalization and response synthesis."""
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return None
+    try:
+        from llama_index.llms.anthropic import Anthropic
+    except ImportError:
+        return None
+    # claude-sonnet-5 verified against llama-index-llms-anthropic 0.11.10:
+    # completes, and metadata resolves (1M context). Override with DESK_LLM_MODEL.
+    return Anthropic(model=os.environ.get("DESK_LLM_MODEL", "claude-sonnet-5"),
+                     max_tokens=2048)

--- a/apps/llamaindex-tariff-desk/desk/research.py
+++ b/apps/llamaindex-tariff-desk/desk/research.py
@@ -32,6 +32,7 @@ from llama_index.tools.nimble import (
 from .agents_config import (
     EFFORT, OVERLAY_SCHEMA, OVERLAY_SOURCES, RATE_SCHEMA, RATE_SOURCES, TTL_DAYS,
 )
+from .io import read_json as io_read_json
 
 Kind = Literal["rate", "overlay"]
 
@@ -129,17 +130,8 @@ def use_live() -> bool:
 
 
 def read_json(path: Path) -> dict[str, Any] | None:
-    """Parse a persisted JSON file, or None if it is missing or unreadable.
-
-    State on disk can be truncated — a process killed mid-write leaves a partial
-    file — and a JSONDecodeError from a cache read should never break resumability
-    or the progress UI. `ingest.load_records` already skips unreadable files; this
-    makes the job and cache readers consistent with it.
-    """
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
+    """Kept as a re-export: `desk.io` owns the implementation now."""
+    return io_read_json(path)
 
 
 def cached_path(lane: Lane, kind: Kind) -> Path:

--- a/apps/llamaindex-tariff-desk/desk/research.py
+++ b/apps/llamaindex-tariff-desk/desk/research.py
@@ -137,7 +137,7 @@ def read_json(path: Path) -> dict[str, Any] | None:
     makes the job and cache readers consistent with it.
     """
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -206,7 +206,7 @@ def write_job(lane: Lane, kind: Kind, **fields: Any) -> dict[str, Any]:
     path = job_path(lane, kind)
     job = (read_json(path) or {}) if path.exists() else {}
     job.update({"lane_key": lane.key, "kind": kind, "updated_at": _now(), **fields})
-    path.write_text(json.dumps(job, indent=2))
+    path.write_text(json.dumps(job, indent=2), encoding="utf-8")
     return job
 
 
@@ -263,7 +263,7 @@ def _save_raw(lane: Lane, kind: Kind, doc_text: str, metadata: dict[str, Any],
         "text": doc_text,
         "metadata": metadata,
     }
-    cached_path(lane, kind).write_text(json.dumps(record, indent=2, default=str))
+    cached_path(lane, kind).write_text(json.dumps(record, indent=2, default=str), encoding="utf-8")
     return record
 
 

--- a/apps/llamaindex-tariff-desk/desk/research.py
+++ b/apps/llamaindex-tariff-desk/desk/research.py
@@ -128,6 +128,20 @@ def use_live() -> bool:
 # --- cache / freshness ----------------------------------------------------
 
 
+def read_json(path: Path) -> dict[str, Any] | None:
+    """Parse a persisted JSON file, or None if it is missing or unreadable.
+
+    State on disk can be truncated — a process killed mid-write leaves a partial
+    file — and a JSONDecodeError from a cache read should never break resumability
+    or the progress UI. `ingest.load_records` already skips unreadable files; this
+    makes the job and cache readers consistent with it.
+    """
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
 def cached_path(lane: Lane, kind: Kind) -> Path:
     """Where a NEW run gets written. Always data/runs — samples are read-only."""
     return RUNS_DIR / f"{lane.slug(kind)}.json"
@@ -145,7 +159,9 @@ def load_cached(lane: Lane, kind: Kind) -> dict[str, Any] | None:
 
     for candidate in (active_dir() / f"{lane.slug(kind)}.json", cached_path(lane, kind)):
         if candidate.exists():
-            return json.loads(candidate.read_text())
+            record = read_json(candidate)
+            if record is not None:
+                return record
     return None
 
 
@@ -188,7 +204,7 @@ def job_path(lane: Lane, kind: Kind) -> Path:
 def write_job(lane: Lane, kind: Kind, **fields: Any) -> dict[str, Any]:
     JOBS_DIR.mkdir(parents=True, exist_ok=True)
     path = job_path(lane, kind)
-    job = json.loads(path.read_text()) if path.exists() else {}
+    job = (read_json(path) or {}) if path.exists() else {}
     job.update({"lane_key": lane.key, "kind": kind, "updated_at": _now(), **fields})
     path.write_text(json.dumps(job, indent=2))
     return job
@@ -196,7 +212,7 @@ def write_job(lane: Lane, kind: Kind, **fields: Any) -> dict[str, Any]:
 
 def read_job(lane: Lane, kind: Kind) -> dict[str, Any] | None:
     path = job_path(lane, kind)
-    return json.loads(path.read_text()) if path.exists() else None
+    return read_json(path) if path.exists() else None
 
 
 def clear_job(lane: Lane, kind: Kind) -> None:
@@ -208,10 +224,9 @@ def open_jobs() -> list[dict[str, Any]]:
         return []
     jobs = []
     for path in sorted(JOBS_DIR.glob("*.json")):
-        try:
-            jobs.append(json.loads(path.read_text()))
-        except json.JSONDecodeError:
-            continue
+        job = read_json(path)
+        if job is not None:
+            jobs.append(job)
     return jobs
 
 

--- a/apps/llamaindex-tariff-desk/desk/research.py
+++ b/apps/llamaindex-tariff-desk/desk/research.py
@@ -1,0 +1,363 @@
+"""The Nimble layer: run a lane's two fact classes, save raw, stay resumable.
+
+Design rules this file exists to enforce (DESIGN.md §4):
+  * `timeout=1800`, never the 300 s default — the default is shorter than a
+    healthy run and is the single most likely thing to bite a reader.
+  * Raw Document text + full metadata hits disk BEFORE anything transforms it.
+  * A lane already researched and still fresh is never re-run.
+  * `NimbleAgentTimeoutError` is recoverable state, not failure: the run keeps
+    going server-side, so the ids are persisted for `recover_runs.py`.
+  * `NimbleAgentCreateAmbiguousError` is NEVER retried — creation is billable and
+    issued exactly once, so a run may exist with no id to address it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from llama_index.tools.nimble import (
+    NimbleAgentCreateAmbiguousError,
+    NimbleAgentRunError,
+    NimbleAgentTimeoutError,
+    NimbleAgentToolSpec,
+)
+
+from .agents_config import (
+    EFFORT, OVERLAY_SCHEMA, OVERLAY_SOURCES, RATE_SCHEMA, RATE_SOURCES, TTL_DAYS,
+)
+
+Kind = Literal["rate", "overlay"]
+
+HERE = Path(__file__).parent.parent
+RUNS_DIR = HERE / "data" / "runs"
+JOBS_DIR = HERE / "data" / "jobs"
+SAMPLES_DIR = HERE / "data" / "samples"
+
+TIMEOUT_S = 1800
+POLL_INTERVAL_S = 15
+MAX_CONCURRENT_RUNS = 4
+
+_slots = threading.BoundedSemaphore(MAX_CONCURRENT_RUNS)
+
+
+# --- lane identity --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Lane:
+    """A product moving from an origin into a destination."""
+
+    hts_code: str
+    origin: str
+    destination: str = "United States"
+    product: str = ""
+
+    @property
+    def key(self) -> str:
+        return f"{self.hts_code}|{self.origin}|{self.destination}"
+
+    @property
+    def rate_key(self) -> str:
+        """The base MFN rate is a property of the CODE, not the lane.
+
+        Discovered from the pre-warm corpus: 8507.60.00 returned 3.4% from both
+        Vietnam and China, 6109.10.00 returned 16.5% from both India and
+        Bangladesh. Keying rate Documents by full lane paid for the same research
+        once per origin. Origin-free keying means adding a new origin for a code
+        already covered costs ONE run (the overlay), not two.
+        """
+        return f"{self.hts_code}|{self.destination}"
+
+    def key_for(self, kind: Kind) -> str:
+        return self.rate_key if kind == "rate" else self.key
+
+    def doc_id(self, kind: Kind) -> str:
+        return f"{self.key_for(kind)}#{kind}"
+
+    def slug(self, kind: Kind) -> str:
+        safe = self.key_for(kind).replace("|", "_").replace("/", "-").replace(" ", "-")
+        return f"{safe}.{kind}"
+
+
+# --- tasks ----------------------------------------------------------------
+
+RATE_TASK = (
+    "Report the Column 1 General (MFN) duty rate for this HTS subheading in the "
+    "current Harmonized Tariff Schedule of the United States. This is a base "
+    "schedule rate only: do not include Section 301, Section 232, IEEPA, or "
+    "reciprocal duties. Quote the rate exactly as the schedule states it, name "
+    "the HTSUS revision it came from, and give the URL it was read from. If the "
+    "official schedule cannot be retrieved, say so explicitly rather than "
+    "estimating, and state which official mirrors were attempted."
+)
+
+OVERLAY_TASK = (
+    "Establish which duty overlays are currently in force for this lane — "
+    "Section 301, Section 232, IEEPA, reciprocal tariffs, and any exclusions. "
+    "Report each component separately with the legal instrument that created it "
+    "and its effective date; never blend them into one figure. Do not report the "
+    "Column 1 General (MFN) base rate. Where an instrument was later modified or "
+    "terminated, report the current state and cite both instruments. Put overlays "
+    "checked and confirmed not to apply in confirmed_absent, and anything you "
+    "could not verify in unverified."
+)
+
+_SPEC: dict[Kind, dict[str, Any]] = {
+    "rate": {"task": RATE_TASK, "schema": RATE_SCHEMA, "sources": RATE_SOURCES,
+             "env": "NIMBLE_RATE_AGENT_ID"},
+    "overlay": {"task": OVERLAY_TASK, "schema": OVERLAY_SCHEMA, "sources": OVERLAY_SOURCES,
+                "env": "NIMBLE_OVERLAY_AGENT_ID"},
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def use_live() -> bool:
+    return os.environ.get("USE_LIVE", "false").strip().lower() in {"1", "true", "yes"}
+
+
+# --- cache / freshness ----------------------------------------------------
+
+
+def cached_path(lane: Lane, kind: Kind) -> Path:
+    """Where a NEW run gets written. Always data/runs — samples are read-only."""
+    return RUNS_DIR / f"{lane.slug(kind)}.json"
+
+
+def load_cached(lane: Lane, kind: Kind) -> dict[str, Any] | None:
+    """Latest saved run for this lane+kind, from whichever corpus is active.
+
+    Must read the same directory the index was built from, or the badge and the
+    freshness guard disagree: the first version read `data/runs/` unconditionally and
+    reported a backdated sample as "from corpus" while the guard was withholding it
+    as stale.
+    """
+    from .ingest import active_dir  # local import keeps module import order simple
+
+    for candidate in (active_dir() / f"{lane.slug(kind)}.json", cached_path(lane, kind)):
+        if candidate.exists():
+            return json.loads(candidate.read_text())
+    return None
+
+
+def is_fresh(record: dict[str, Any], kind: Kind, now: datetime | None = None) -> bool:
+    """True while the record is inside its TTL. Rate: 90 days. Overlay: 7 days."""
+    stamp = record.get("researched_at")
+    if not stamp:
+        return False
+    try:
+        researched = datetime.fromisoformat(stamp)
+    except ValueError:
+        return False
+    if researched.tzinfo is None:
+        researched = researched.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    return now - researched < timedelta(days=TTL_DAYS[kind])
+
+
+def age_days(record: dict[str, Any]) -> float | None:
+    stamp = record.get("researched_at")
+    if not stamp:
+        return None
+    try:
+        researched = datetime.fromisoformat(stamp)
+    except ValueError:
+        return None
+    if researched.tzinfo is None:
+        researched = researched.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - researched
+    return round(delta.total_seconds() / 86400, 2)
+
+
+# --- job state (survives closing the tab) ---------------------------------
+
+
+def job_path(lane: Lane, kind: Kind) -> Path:
+    return JOBS_DIR / f"{lane.slug(kind)}.json"
+
+
+def write_job(lane: Lane, kind: Kind, **fields: Any) -> dict[str, Any]:
+    JOBS_DIR.mkdir(parents=True, exist_ok=True)
+    path = job_path(lane, kind)
+    job = json.loads(path.read_text()) if path.exists() else {}
+    job.update({"lane_key": lane.key, "kind": kind, "updated_at": _now(), **fields})
+    path.write_text(json.dumps(job, indent=2))
+    return job
+
+
+def read_job(lane: Lane, kind: Kind) -> dict[str, Any] | None:
+    path = job_path(lane, kind)
+    return json.loads(path.read_text()) if path.exists() else None
+
+
+def clear_job(lane: Lane, kind: Kind) -> None:
+    job_path(lane, kind).unlink(missing_ok=True)
+
+
+def open_jobs() -> list[dict[str, Any]]:
+    if not JOBS_DIR.exists():
+        return []
+    jobs = []
+    for path in sorted(JOBS_DIR.glob("*.json")):
+        try:
+            jobs.append(json.loads(path.read_text()))
+        except json.JSONDecodeError:
+            continue
+    return jobs
+
+
+# --- the run ---------------------------------------------------------------
+
+
+def _tool(kind: Kind) -> NimbleAgentToolSpec:
+    agent_id = os.environ.get(_SPEC[kind]["env"])
+    if not agent_id:
+        raise RuntimeError(
+            f"{_SPEC[kind]['env']} is not set — run setup_agents.py first"
+        )
+    return NimbleAgentToolSpec(
+        agent_id=agent_id,
+        effort=EFFORT[kind],
+        timeout=TIMEOUT_S,
+        poll_interval=POLL_INTERVAL_S,
+    )
+
+
+def _save_raw(lane: Lane, kind: Kind, doc_text: str, metadata: dict[str, Any],
+              elapsed: float) -> dict[str, Any]:
+    """Write the raw Document before anything transforms it."""
+    RUNS_DIR.mkdir(parents=True, exist_ok=True)
+    record = {
+        "lane": {"hts_code": lane.hts_code, "origin": lane.origin,
+                 "destination": lane.destination, "product": lane.product},
+        "lane_key": lane.key,
+        "doc_key": lane.key_for(kind),  # rate records are origin-free
+        "kind": kind,
+        "doc_id": lane.doc_id(kind),
+        "researched_at": _now(),
+        "elapsed_s": round(elapsed, 1),
+        "text": doc_text,
+        "metadata": metadata,
+    }
+    cached_path(lane, kind).write_text(json.dumps(record, indent=2, default=str))
+    return record
+
+
+def research(lane: Lane, kind: Kind, force: bool = False) -> dict[str, Any]:
+    """Research one fact class for one lane. Blocks. Returns the saved record.
+
+    Resumable by design: a fresh cached record short-circuits before any billable
+    call. Pass force=True to re-research regardless (that is what refresh does).
+    """
+    if not force:
+        cached = load_cached(lane, kind)
+        if cached and is_fresh(cached, kind):
+            cached["from_cache"] = True
+            return cached
+
+    if not use_live():
+        cached = load_cached(lane, kind)
+        if cached:
+            cached["from_cache"] = True
+            cached["stale_but_offline"] = not is_fresh(cached, kind)
+            return cached
+        raise RuntimeError(
+            f"USE_LIVE=false and no cached run for {lane.key} [{kind}]. "
+            "Set USE_LIVE=true to research it, or ship a sample for this lane."
+        )
+
+    spec = _SPEC[kind]
+    tool = _tool(kind)
+    input_data = {
+        "hts_code": lane.hts_code,
+        "origin": lane.origin,
+        "destination": lane.destination,
+    }
+    if lane.product:
+        input_data["product"] = lane.product
+
+    write_job(lane, kind, status="running", started_at=_now(), run_id=None)
+    started = time.monotonic()
+
+    with _slots:
+        try:
+            doc = tool.run(
+                spec["task"],
+                input_data=input_data,
+                output_schema=spec["schema"],
+                sources=spec["sources"],
+            )
+        except NimbleAgentTimeoutError as err:
+            # Not a failure. The run continues server-side; keep the ids so
+            # recover_runs.py can fetch the result later.
+            write_job(lane, kind, status="timeout", run_id=err.run_id,
+                      agent_id=getattr(err, "agent_id", None),
+                      note="run still executing server-side; recoverable")
+            raise
+        except NimbleAgentCreateAmbiguousError as err:
+            # Never retried: a billable run may exist with no id to address.
+            write_job(lane, kind, status="ambiguous_create",
+                      status_code=getattr(err, "status_code", None),
+                      note="DO NOT resubmit — reconcile against the dashboard")
+            raise
+        except NimbleAgentRunError as err:
+            write_job(lane, kind, status="failed", error=f"{type(err).__name__}: {err}",
+                      run_id=getattr(err, "run_id", None))
+            raise
+
+    record = _save_raw(lane, kind, doc.text, dict(doc.metadata or {}),
+                       time.monotonic() - started)
+    write_job(lane, kind, status="completed", run_id=record["metadata"].get("run_id"))
+    clear_job(lane, kind)
+    record["from_cache"] = False
+    return record
+
+
+# --- background execution (Streamlit must never block) --------------------
+
+
+@dataclass
+class ResearchTask:
+    lane: Lane
+    kinds: list[Kind] = field(default_factory=lambda: ["rate", "overlay"])
+    force: bool = False
+
+    def start(self) -> list[threading.Thread]:
+        threads = []
+        for kind in self.kinds:
+            t = threading.Thread(
+                target=self._run_one, args=(kind,),
+                name=f"research-{self.lane.slug(kind)}", daemon=True,
+            )
+            t.start()
+            threads.append(t)
+        return threads
+
+    def _run_one(self, kind: Kind) -> None:
+        try:
+            research(self.lane, kind, force=self.force)
+        except Exception:  # noqa: BLE001 — job file already carries the status
+            pass
+
+
+def needs_research(lane: Lane, kind: Kind) -> tuple[bool, str]:
+    """(should_run, why) — drives the UI badge."""
+    cached = load_cached(lane, kind)
+    if cached is None:
+        return True, "not covered"
+    age = age_days(cached)
+    human = ("just now" if (age or 0) < 0.04 else
+             f"{max(1, int(round((age or 0) * 24)))}h ago" if (age or 0) < 1 else
+             f"{int(round(age or 0))}d ago")
+    if not is_fresh(cached, kind):
+        return True, f"expired ({human}, holds for {TTL_DAYS[kind]}d)"
+    return False, f"researched {human}"

--- a/apps/llamaindex-tariff-desk/desk/router.py
+++ b/apps/llamaindex-tariff-desk/desk/router.py
@@ -140,7 +140,7 @@ def load_changes(limit: int = 50) -> list[dict[str, Any]]:
     if not CHANGES_LOG.exists():
         return []
     entries = []
-    for line in CHANGES_LOG.read_text().splitlines():
+    for line in CHANGES_LOG.read_text(encoding="utf-8").splitlines():
         try:
             entries.append(json.loads(line))
         except json.JSONDecodeError:

--- a/apps/llamaindex-tariff-desk/desk/router.py
+++ b/apps/llamaindex-tariff-desk/desk/router.py
@@ -1,0 +1,205 @@
+"""Retrieval: lane facts from the index, corpus questions from metadata.
+
+Two engines, and LlamaIndex chooses between them:
+
+  * **lane facts** — a metadata-filtered retriever over the vector index, scoped to
+    the exact `doc_id`s the normalizer resolved. Filtering by lane key rather than
+    relying on similarity alone is deliberate: "8507.60.00 from Vietnam" and
+    "8507.60.00 from China" are near-identical strings, and a top-k that mixes them
+    would attribute China's overlays to Vietnam. Similarity picks passages; the
+    filter guarantees the right lane.
+  * **corpus questions** — "what changed?", "what's stale?", "what do you cover?"
+    answered from node metadata and the change log, with **no research run and no
+    LLM call over the index**. Cheap, exact, and impossible to hallucinate.
+
+The freshness guard sits in the lane path, so an expired fact cannot be answered
+from silently.
+
+Requires an embedding model only where it touches the index.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from llama_index.core import Settings, get_response_synthesizer
+from llama_index.core.retrievers import VectorIndexRetriever
+from llama_index.core.vector_stores import (
+    FilterOperator, MetadataFilter, MetadataFilters,
+)
+
+from . import ingest
+from .freshness import FreshnessPostprocessor, freshness_preamble, stale_report
+from .research import Lane
+
+HERE = Path(__file__).parent.parent
+CHANGES_LOG = HERE / "data" / "changes.jsonl"
+
+ANSWER_TMPL = (
+    "You are answering a customs and trade question from a corpus of researched, "
+    "cited facts.\n\n"
+    "Rules you must follow:\n"
+    "- Report the base schedule rate and any duty overlays separately. Never present "
+    "a single blended figure unless you show the components you added.\n"
+    "- State the research date for every figure, and name the source.\n"
+    "- If a fact is marked STALE, say so instead of presenting it as current.\n"
+    "- If the context does not contain a figure, say it is not covered. Never "
+    "estimate a duty rate.\n"
+    "- This is decision-support, not customs advice. Where confidence is not high, "
+    "tell the reader to confirm against a binding ruling.\n\n"
+    "{freshness}\n\n"
+    "Context:\n{context_str}\n\n"
+    "Question: {query_str}\n"
+    "Answer:"
+)
+
+
+def lane_filters(lane: Lane) -> MetadataFilters:
+    """Both Documents for this lane: the origin-free rate and the lane overlay.
+
+    A single flat `IN` over the two doc_keys, not an OR of two AND groups —
+    `SimpleVectorStore` raises "Nested MetadataFilters are not supported". The keys
+    are unambiguous on their own (`8507.60.00|United States` for the rate,
+    `8507.60.00|Vietnam|United States` for the overlay), so `kind` never needs to be
+    part of the filter.
+    """
+    return MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="doc_key",
+                value=[lane.rate_key, lane.key],
+                operator=FilterOperator.IN,
+            )
+        ]
+    )
+
+
+def retrieve_lane_nodes(index, lane: Lane, strict: bool = True,
+                        top_k: int = 8) -> tuple[list, list]:
+    """(kept, withheld) nodes for a lane after the freshness guard."""
+    retriever = VectorIndexRetriever(
+        index=index, similarity_top_k=top_k, filters=lane_filters(lane)
+    )
+    nodes = retriever.retrieve(f"duty treatment for {lane.hts_code} from {lane.origin}")
+    guard = FreshnessPostprocessor(strict=False)
+    annotated = guard.postprocess_nodes(list(nodes))
+    if not strict:
+        return annotated, []
+    kept = [n for n in annotated if not n.node.metadata.get("is_stale")]
+    withheld = [n for n in annotated if n.node.metadata.get("is_stale")]
+    return kept, withheld
+
+
+def answer_lane(index, lane: Lane, question: str, strict: bool = True) -> dict[str, Any]:
+    """Answer a lane question from the corpus. Does NOT research — the caller decides.
+
+    Returns the answer plus what was withheld and why, so the UI can offer to
+    re-research rather than pretending the corpus is complete.
+    """
+    kept, withheld = retrieve_lane_nodes(index, lane, strict=strict)
+    if not kept:
+        return {
+            "answered": False,
+            "reason": "stale" if withheld else "not_covered",
+            "withheld": withheld,
+            "nodes": [],
+            "answer": None,
+        }
+
+    # Synthesize from the nodes already retrieved and already guarded — never
+    # re-retrieve. A second retrieval inside a query engine can select different
+    # nodes by similarity and then have the strict guard drop all of them, which
+    # returned a literal "Empty Response" for a lane whose base rate was perfectly
+    # fresh.
+    synth = get_response_synthesizer(
+        llm=Settings.llm,
+        text_qa_template=_qa_template(freshness_preamble(kept)),
+    )
+    response = synth.synthesize(question, nodes=kept)
+    return {
+        "answered": True,
+        "reason": None,
+        "withheld": withheld,
+        "nodes": kept,
+        "answer": str(response),
+    }
+
+
+def _qa_template(freshness_text: str):
+    from llama_index.core import PromptTemplate
+
+    return PromptTemplate(ANSWER_TMPL.replace("{freshness}", freshness_text or ""))
+
+
+# --- corpus questions: no run, no index, no hallucination -----------------
+
+
+def load_changes(limit: int = 50) -> list[dict[str, Any]]:
+    if not CHANGES_LOG.exists():
+        return []
+    entries = []
+    for line in CHANGES_LOG.read_text().splitlines():
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    entries.sort(key=lambda e: e.get("at") or "", reverse=True)
+    return entries[:limit]
+
+
+def _readable(key: str | None) -> str:
+    """`8507.60.00|Vietnam|United States` -> `Vietnam → United States (HTS 8507.60.00)`.
+
+    "Lane" is freight jargon and stays in the code, where it is the right word. It
+    should never reach a reader who has no reason to know it.
+    """
+    parts = (key or "").split("|")
+    if len(parts) == 3:
+        return f"{parts[1]} → {parts[2]} (HTS {parts[0]})"
+    if len(parts) == 2:
+        return f"base rate into {parts[1]} (HTS {parts[0]})"
+    return key or "unknown"
+
+
+def answer_corpus(question: str) -> dict[str, Any]:
+    """Answer a question about the corpus itself, deterministically."""
+    records = ingest.load_records()
+    low = question.lower()
+    cov = ingest.coverage(records)
+    report = stale_report(records)
+
+    if any(w in low for w in ("changed", "change log", "delta", "moved", "what's new")):
+        changes = [c for c in load_changes() if c.get("changes")]
+        if not changes:
+            body = ("Nothing has been refreshed yet, so there is no change history. "
+                    "A refresh records what moved — and 'nothing moved' is a valid result.")
+        else:
+            body = "What the corpus learned at the last refreshes:\n" + "\n".join(
+                f"- {c['at'][:10]} · {c['summary'][:300]}" for c in changes[:12]
+            )
+        return {"kind": "changes", "answer": body, "rows": changes}
+
+    if any(w in low for w in ("stale", "fresh", "old", "expired", "up to date")):
+        stale = [r for r in report if r["stale"]]
+        if stale:
+            body = f"{len(stale)} of {len(report)} facts are out of date:\n" + "\n".join(
+                f"- {_readable(r['doc_key'])} — researched {int(r['age_days'] or 0)} days "
+                f"ago, held for {r['ttl_days']}"
+                for r in stale
+            )
+        else:
+            body = (f"All {len(report)} facts are current "
+                    f"(duty details are re-checked after 7 days, base rates after 90).")
+        return {"kind": "freshness", "answer": body, "rows": report}
+
+    routes = "\n".join(f"- {_readable(k)}" for k in cov["lanes"])
+    body = (
+        f"The corpus holds {cov['records']} researched facts: "
+        f"{cov['rate_docs']} base rate(s) across {len(cov['hts_codes'])} tariff code(s), "
+        f"and duty details for {cov['overlay_docs']} product-and-origin combination(s)."
+        f"\n\nCovered:\n{routes}\n\n"
+        "Ask about something not listed and it will be researched and added."
+    )
+    return {"kind": "coverage", "answer": body, "rows": report}

--- a/apps/llamaindex-tariff-desk/desk/router.py
+++ b/apps/llamaindex-tariff-desk/desk/router.py
@@ -31,6 +31,7 @@ from llama_index.core.vector_stores import (
 )
 
 from . import ingest
+from .io import read_json_lines
 from .freshness import FreshnessPostprocessor, freshness_preamble, stale_report
 from .research import Lane
 
@@ -137,14 +138,13 @@ def _qa_template(freshness_text: str):
 
 
 def load_changes(limit: int = 50) -> list[dict[str, Any]]:
-    if not CHANGES_LOG.exists():
-        return []
-    entries = []
-    for line in CHANGES_LOG.read_text(encoding="utf-8").splitlines():
-        try:
-            entries.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
+    """The most recent change-log entries, newest first.
+
+    Only the tail of the file is read. The log grows by a line per refreshed fact
+    forever, and reading all of it to show six entries is wasteful once a corpus has
+    been refreshing on a schedule.
+    """
+    entries = read_json_lines(CHANGES_LOG, limit=limit)
     entries.sort(key=lambda e: e.get("at") or "", reverse=True)
     return entries[:limit]
 

--- a/apps/llamaindex-tariff-desk/prefetch_lookups.py
+++ b/apps/llamaindex-tariff-desk/prefetch_lookups.py
@@ -1,0 +1,61 @@
+"""Cache code lookups for the demo products so the lookup box works offline.
+
+`USE_LIVE=false` replays these, which keeps the demo free and safe to record. Run
+this once (live) after `setup_agents.py`.
+
+    USE_LIVE=true ./.venv/bin/python prefetch_lookups.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+HERE = Path(__file__).parent
+load_dotenv(HERE / ".env")
+sys.path.insert(0, str(HERE))
+
+from desk.classify import (  # noqa: E402
+    CACHE_DIR, SAMPLE_DIR, find_candidates, slugify, use_live,
+)
+
+# The corpus products, plus one deliberately not in the corpus so the lookup can be
+# demonstrated on something the desk has never seen.
+PRODUCTS = [
+    "lithium-ion battery packs",
+    "cotton knit t-shirts",
+    "aluminium extrusions",
+    "photovoltaic solar modules",
+    "printed books",
+    "stainless steel insulated drinks bottle",
+]
+
+
+def main() -> int:
+    if not use_live():
+        print("USE_LIVE must be true to prefetch", file=sys.stderr)
+        return 2
+    SAMPLE_DIR.mkdir(parents=True, exist_ok=True)
+    failures = 0
+    for product in PRODUCTS:
+        result = find_candidates(product)
+        if result.get("error"):
+            print(f"FAIL  {product}: {result['error'][:90]}", flush=True)
+            failures += 1
+            continue
+        count = len(result.get("candidates") or [])
+        where = "cached" if result.get("from_cache") else f"{result.get('elapsed_s')}s"
+        print(f"OK    {product}: {count} candidate(s) ({where})", flush=True)
+        src = CACHE_DIR / f"{slugify(product)}.json"
+        if src.exists():
+            shutil.copy2(src, SAMPLE_DIR / src.name)
+    print(f"\n{len(PRODUCTS) - failures}/{len(PRODUCTS)} cached into "
+          f"{SAMPLE_DIR.relative_to(HERE)}/")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/llamaindex-tariff-desk/prewarm.py
+++ b/apps/llamaindex-tariff-desk/prewarm.py
@@ -1,0 +1,106 @@
+"""Pre-warm the shipped corpus: research 8 lanes × 2 fact classes.
+
+Independent of embeddings — this only runs agents and saves raw records, so it can
+run before the index exists.
+
+Resumable: a lane already saved and fresh is skipped, so a crash or a Ctrl-C costs
+only the runs in flight. Progress is logged per completion, because a long job with
+no output is indistinguishable from a stuck one.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+HERE = Path(__file__).parent
+load_dotenv(HERE / ".env")
+sys.path.insert(0, str(HERE))
+
+from desk.research import (  # noqa: E402
+    Lane, is_fresh, load_cached, research, use_live,
+)
+
+# Deliberate spread: repeated codes across different origins (so the demo can
+# compare lanes), a likely duty-free line, and origins with different overlay
+# regimes. 8 lanes = 16 runs.
+LANES = [
+    Lane("8507.60.00", "Vietnam", product="lithium-ion battery packs"),
+    Lane("8507.60.00", "China", product="lithium-ion battery packs"),
+    Lane("7604.29.10", "Mexico", product="aluminum extrusions"),
+    Lane("7604.29.10", "China", product="aluminum extrusions"),
+    Lane("6109.10.00", "India", product="cotton knit t-shirts"),
+    Lane("6109.10.00", "Bangladesh", product="cotton knit t-shirts"),
+    Lane("4901.99.00", "United Kingdom", product="printed books"),
+    Lane("8541.43.00", "Malaysia", product="photovoltaic modules"),
+]
+
+KINDS = ("rate", "overlay")
+_print_lock = threading.Lock()
+
+
+def log(msg: str) -> None:
+    with _print_lock:
+        print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def main() -> int:
+    if not use_live():
+        print("USE_LIVE is false — pre-warming needs live runs.", file=sys.stderr)
+        print("Re-run with: USE_LIVE=true ./.venv/bin/python prewarm.py", file=sys.stderr)
+        return 2
+    for env_key in ("NIMBLE_RATE_AGENT_ID", "NIMBLE_OVERLAY_AGENT_ID"):
+        if not os.environ.get(env_key):
+            print(f"{env_key} is not set — run setup_agents.py first", file=sys.stderr)
+            return 2
+
+    todo = []
+    for lane in LANES:
+        for kind in KINDS:
+            cached = load_cached(lane, kind)
+            if cached and is_fresh(cached, kind):
+                log(f"SKIP  {lane.slug(kind)} — cached and fresh")
+                continue
+            todo.append((lane, kind))
+
+    total = len(todo)
+    log(f"{total} run(s) to do across {len(LANES)} lanes (4 concurrent)")
+    if not total:
+        return 0
+
+    done = failed = 0
+    started = time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = {pool.submit(research, lane, kind): (lane, kind) for lane, kind in todo}
+        for fut in as_completed(futures):
+            lane, kind = futures[fut]
+            try:
+                record = fut.result()
+                done += 1
+                trust = record.get("metadata") or {}
+                log(
+                    f"OK    {lane.slug(kind)} — {record.get('elapsed_s')}s "
+                    f"confidence={trust.get('confidence')} "
+                    f"[{done + failed}/{total}]"
+                )
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                log(f"FAIL  {lane.slug(kind)} — {type(exc).__name__}: {exc} "
+                    f"[{done + failed}/{total}]")
+
+    elapsed = (time.monotonic() - started) / 60
+    log(f"finished in {elapsed:.1f} min — {done} ok, {failed} failed")
+    if failed:
+        log("re-run to retry only the failures (cached successes are skipped)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/llamaindex-tariff-desk/recover_runs.py
+++ b/apps/llamaindex-tariff-desk/recover_runs.py
@@ -34,6 +34,7 @@ HERE = Path(__file__).parent
 load_dotenv(HERE / ".env")
 sys.path.insert(0, str(HERE))
 
+from desk.io import read_json  # noqa: E402
 from desk.research import (  # noqa: E402
     JOBS_DIR, Lane, _save_raw, clear_job, open_jobs,
 )
@@ -141,7 +142,9 @@ def main() -> int:
                     "NIMBLE_OVERLAY_AGENT_ID" if job.get("kind") == "overlay"
                     else "NIMBLE_RATE_AGENT_ID"))
                 for candidate in JOBS_DIR.glob("*.json"):
-                    existing = json.loads(candidate.read_text(encoding="utf-8"))
+                    existing = read_json(candidate)
+                    if existing is None:
+                        continue
                     if (existing.get("lane_key") == job.get("lane_key")
                             and existing.get("kind") == job.get("kind")):
                         existing["run_id"] = found

--- a/apps/llamaindex-tariff-desk/recover_runs.py
+++ b/apps/llamaindex-tariff-desk/recover_runs.py
@@ -141,13 +141,13 @@ def main() -> int:
                     "NIMBLE_OVERLAY_AGENT_ID" if job.get("kind") == "overlay"
                     else "NIMBLE_RATE_AGENT_ID"))
                 for candidate in JOBS_DIR.glob("*.json"):
-                    existing = json.loads(candidate.read_text())
+                    existing = json.loads(candidate.read_text(encoding="utf-8"))
                     if (existing.get("lane_key") == job.get("lane_key")
                             and existing.get("kind") == job.get("kind")):
                         existing["run_id"] = found
                         existing["agent_id"] = job.get("agent_id")
                         existing["reconciled"] = True
-                        candidate.write_text(json.dumps(existing, indent=2))
+                        candidate.write_text(json.dumps(existing, indent=2), encoding="utf-8")
 
     candidates = [j for j in jobs
                   if j.get("status") in RECOVERABLE and j.get("run_id")]

--- a/apps/llamaindex-tariff-desk/recover_runs.py
+++ b/apps/llamaindex-tariff-desk/recover_runs.py
@@ -1,0 +1,219 @@
+"""Collect runs that outlived their timeout.
+
+This is the function the integration docs leave as an exercise:
+
+    except NimbleAgentTimeoutError as error:
+        save_run_for_later(error.run_id, error.agent_id)   # your own function
+
+`NimbleAgentTimeoutError` is not a failure. The run keeps executing on Nimble's
+side and the result stays fetchable; only the client stopped waiting. `research()`
+persists `run_id` and `agent_id` into data/jobs/ when that happens, and this script
+fetches whatever has since completed and files it into the corpus as though the
+original call had returned.
+
+The connector itself has no start-now/collect-later split, so recovery goes through
+the runs API directly.
+
+    ./.venv/bin/python recover_runs.py            # report recoverable jobs
+    ./.venv/bin/python recover_runs.py --collect  # fetch and file the finished ones
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dotenv import load_dotenv
+from nimble_python import Nimble
+
+HERE = Path(__file__).parent
+load_dotenv(HERE / ".env")
+sys.path.insert(0, str(HERE))
+
+from desk.research import (  # noqa: E402
+    JOBS_DIR, Lane, _save_raw, clear_job, open_jobs,
+)
+
+RECOVERABLE = {"timeout", "running"}
+
+# How far apart a job's start and a run's creation may be and still be the same run.
+MATCH_WINDOW_S = 180
+
+
+def reconcile_missing_id(client, job: dict) -> str | None:
+    """Find the run id for a job that never got one, by creation time.
+
+    `run()` blocks and doesn't expose the run id until it returns or raises, so a
+    process killed mid-run leaves a job with `run_id: None` and a paid run with no
+    handle. This is the reconciliation the docs point at: list the agent's recent runs
+    and match by when they were created.
+
+    Time is the only usable key. With `input_data`, the run's `prompt` is the task
+    text — identical for every entity — so it cannot tell you which row a run was for.
+    If more than one run falls in the window, this refuses to guess.
+    """
+    started = job.get("started_at")
+    agent_id = job.get("agent_id") or os.environ.get(
+        "NIMBLE_OVERLAY_AGENT_ID" if job.get("kind") == "overlay"
+        else "NIMBLE_RATE_AGENT_ID"
+    )
+    if not (started and agent_id):
+        return None
+    began = datetime.fromisoformat(started)
+    if began.tzinfo is None:
+        began = began.replace(tzinfo=timezone.utc)
+
+    try:
+        payload = json.loads(client.agents.runs.list(agent_id=agent_id, limit=20).to_json())
+    except Exception as exc:  # noqa: BLE001
+        print(f"     could not list runs: {type(exc).__name__}: {exc}")
+        return None
+
+    matches = []
+    for run in payload.get("items") or []:
+        created = run.get("created_at")
+        if not created:
+            continue
+        when = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=timezone.utc)
+        if abs((when - began).total_seconds()) <= MATCH_WINDOW_S:
+            matches.append(run)
+
+    if not matches:
+        print(f"     no run on {agent_id} created within {MATCH_WINDOW_S}s of the job")
+        return None
+    if len(matches) > 1:
+        print(f"     {len(matches)} runs fall in the window — refusing to guess:")
+        for run in matches:
+            print(f"       {run.get('id')} {run.get('status')} {run.get('created_at')}")
+        return None
+    run_id = matches[0].get("id")
+    print(f"     reconciled to {run_id} ({matches[0].get('status')})")
+    return run_id
+
+
+def lane_from_job(job: dict) -> Lane:
+    hts, origin, destination = (job.get("lane_key") or "||").split("|", 2)
+    return Lane(hts_code=hts, origin=origin, destination=destination or "United States")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--collect", action="store_true",
+                       help="fetch results and file them into the corpus")
+    args = parser.parse_args()
+
+    jobs = open_jobs()
+    if not jobs:
+        print(f"no open jobs in {JOBS_DIR.relative_to(HERE)} — nothing to recover")
+        return 0
+
+    print(f"{len(jobs)} open job(s):")
+    for job in jobs:
+        print(f"  {job.get('lane_key')} [{job.get('kind')}] status={job.get('status')} "
+              f"run_id={job.get('run_id')}")
+        if job.get("status") == "ambiguous_create":
+            print("     ^ ambiguous create: DO NOT resubmit. A billable run may exist "
+                  "with no id. Reconcile in the dashboard.")
+
+    client = Nimble(api_key=os.environ["NIMBLE_API_KEY"])
+
+    # Jobs with no id can often still be reconciled from the agent's run history.
+    for job in jobs:
+        if job.get("status") in RECOVERABLE and not job.get("run_id"):
+            print(f"  {job.get('lane_key')} [{job.get('kind')}] has no run_id — "
+                  "reconciling against run history")
+            found = reconcile_missing_id(client, job)
+            if found:
+                job["run_id"] = found
+                job.setdefault("agent_id", os.environ.get(
+                    "NIMBLE_OVERLAY_AGENT_ID" if job.get("kind") == "overlay"
+                    else "NIMBLE_RATE_AGENT_ID"))
+                for candidate in JOBS_DIR.glob("*.json"):
+                    existing = json.loads(candidate.read_text())
+                    if (existing.get("lane_key") == job.get("lane_key")
+                            and existing.get("kind") == job.get("kind")):
+                        existing["run_id"] = found
+                        existing["agent_id"] = job.get("agent_id")
+                        existing["reconciled"] = True
+                        candidate.write_text(json.dumps(existing, indent=2))
+
+    candidates = [j for j in jobs
+                  if j.get("status") in RECOVERABLE and j.get("run_id")]
+    if not candidates:
+        print("\nnothing recoverable (a job needs a run_id and a non-terminal status)")
+        return 0
+    if not args.collect:
+        print(f"\n{len(candidates)} recoverable — pass --collect to fetch")
+        return 0
+
+    recovered = failed = pending = 0
+
+    for job in candidates:
+        lane, kind, run_id = lane_from_job(job), job["kind"], job["run_id"]
+        agent_id = job.get("agent_id")
+        label = f"{job.get('lane_key')} [{kind}] {run_id}"
+        try:
+            run = client.agents.runs.get(run_id, agent_id=agent_id)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {label}: could not poll — {type(exc).__name__}: {exc}")
+            failed += 1
+            continue
+
+        if getattr(run, "is_active", False):
+            print(f"  {label}: still running — leave the job in place")
+            pending += 1
+            continue
+        if run.status != "completed":
+            print(f"  {label}: terminated as {run.status} — clearing job")
+            clear_job(lane, kind)
+            failed += 1
+            continue
+
+        try:
+            result = client.agents.runs.result(run_id, agent_id=agent_id)
+            payload = json.loads(result.to_json())
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {label}: completed but result fetch failed — "
+                  f"{type(exc).__name__}: {exc}")
+            failed += 1
+            continue
+
+        output = payload.get("output") or {}
+        content = output.get("content")
+        trust = output.get("trust") or {}
+        text = content if isinstance(content, str) else json.dumps(content, indent=2)
+        sources = trust.get("sources") or []
+        if sources:
+            text += "\n\nSources:\n" + "\n".join(
+                f"- {s.get('title')} — {s.get('url')} ({s.get('type')})" for s in sources
+            )
+        metadata = {
+            "run_id": run_id,
+            "web_search_agent_id": agent_id,
+            "effort": getattr(run, "effort", None),
+            "output_type": output.get("type"),
+            "confidence": trust.get("confidence"),
+            "reasoning": trust.get("reasoning"),
+            "sources": sources,
+            "claims": trust.get("claims") or [],
+            "recovered": True,
+        }
+        _save_raw(lane, kind, text, metadata, elapsed=0.0)
+        clear_job(lane, kind)
+        print(f"  {label}: recovered — confidence={trust.get('confidence')}")
+        recovered += 1
+
+    print(f"\n{recovered} recovered, {pending} still running, {failed} unrecoverable")
+    if recovered:
+        print("re-run the index build to pick these up")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/llamaindex-tariff-desk/recover_runs.py
+++ b/apps/llamaindex-tariff-desk/recover_runs.py
@@ -121,7 +121,13 @@ def main() -> int:
             print("     ^ ambiguous create: DO NOT resubmit. A billable run may exist "
                   "with no id. Reconcile in the dashboard.")
 
-    client = Nimble(api_key=os.environ["NIMBLE_API_KEY"])
+    api_key = os.environ.get("NIMBLE_API_KEY")
+    if not api_key:
+        print("\nNIMBLE_API_KEY is not set, so runs cannot be reconciled or fetched. "
+              "The job files above are still intact; set the key and re-run.",
+              file=sys.stderr)
+        return 2
+    client = Nimble(api_key=api_key)
 
     # Jobs with no id can often still be reconciled from the agent's run history.
     for job in jobs:

--- a/apps/llamaindex-tariff-desk/refresh.py
+++ b/apps/llamaindex-tariff-desk/refresh.py
@@ -25,8 +25,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
-MAX_CONCURRENT_REFRESH = 4
-
 from dotenv import load_dotenv
 
 HERE = Path(__file__).parent
@@ -40,6 +38,7 @@ from desk.research import Lane, cached_path, research, use_live  # noqa: E402
 
 HISTORY_DIR = HERE / "data" / "history"
 CHANGES_LOG = HERE / "data" / "changes.jsonl"
+MAX_CONCURRENT_REFRESH = 4
 
 
 def lane_from_record(record: dict) -> Lane:
@@ -135,7 +134,7 @@ def main() -> int:
         }
         with io_lock:
             print(f"  {time.monotonic() - started:.0f}s — {line[:150]}", flush=True)
-            with CHANGES_LOG.open("a") as fh:
+            with CHANGES_LOG.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(entry, default=str) + "\n")
         return entry
 

--- a/apps/llamaindex-tariff-desk/refresh.py
+++ b/apps/llamaindex-tariff-desk/refresh.py
@@ -1,0 +1,160 @@
+"""Re-research stale facts and record what moved.
+
+Only the volatile half normally comes back: overlays expire in 7 days, base rates in
+90. That asymmetry is the point — a refresh is cheap because most of the corpus does
+not need re-asking.
+
+  ./.venv/bin/python refresh.py                    # dry run: what is stale
+  USE_LIVE=true ./.venv/bin/python refresh.py --go
+  USE_LIVE=true ./.venv/bin/python refresh.py --go --lane "8507.60.00|Vietnam|United States"
+  USE_LIVE=true ./.venv/bin/python refresh.py --go --kind overlay --force
+
+The previous version of every refreshed record is kept under data/history/, which is
+what lets the demo show a real before/after instead of a staged one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+
+MAX_CONCURRENT_REFRESH = 4
+
+from dotenv import load_dotenv
+
+HERE = Path(__file__).parent
+load_dotenv(HERE / ".env")
+sys.path.insert(0, str(HERE))
+
+from desk import ingest  # noqa: E402
+from desk.delta import diff_content, summarize  # noqa: E402
+from desk.freshness import assess  # noqa: E402
+from desk.research import Lane, cached_path, research, use_live  # noqa: E402
+
+HISTORY_DIR = HERE / "data" / "history"
+CHANGES_LOG = HERE / "data" / "changes.jsonl"
+
+
+def lane_from_record(record: dict) -> Lane:
+    lane = record.get("lane") or {}
+    return Lane(
+        hts_code=lane.get("hts_code", ""),
+        origin=lane.get("origin", ""),
+        destination=lane.get("destination", "United States"),
+        product=lane.get("product", ""),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--go", action="store_true", help="actually re-research")
+    parser.add_argument("--lane", help="limit to one lane key")
+    parser.add_argument("--kind", choices=["rate", "overlay"], help="limit to one fact class")
+    parser.add_argument("--force", action="store_true", help="refresh even if fresh")
+    args = parser.parse_args()
+
+    records = ingest.load_records()
+    if not records:
+        print("no corpus on disk — run prewarm.py first", file=sys.stderr)
+        return 2
+
+    candidates = []
+    for record in records:
+        if args.kind and record.get("kind") != args.kind:
+            continue
+        if args.lane and record.get("lane_key") != args.lane:
+            continue
+        verdict = assess({"kind": record.get("kind"),
+                          "researched_at": record.get("researched_at")})
+        if verdict.stale or args.force:
+            candidates.append((record, verdict))
+
+    doc_label = lambda r: f"{r.get('doc_key') or r.get('lane_key')} [{r.get('kind')}]"  # noqa: E731
+
+    if not candidates:
+        print(f"nothing to refresh — {len(records)} record(s), all inside TTL")
+        print("(use --force to refresh anyway)")
+        return 0
+
+    print(f"{len(candidates)} record(s) to refresh:")
+    for record, verdict in candidates:
+        print(f"  {doc_label(record):58} {verdict.describe()}")
+
+    if not args.go:
+        print("\ndry run — pass --go to re-research")
+        return 0
+    if not use_live():
+        print("\nUSE_LIVE is false — refresh needs live runs", file=sys.stderr)
+        return 2
+
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    all_changes: list[dict] = []
+    io_lock = threading.Lock()
+
+    def refresh_one(record: dict) -> dict | None:
+        kind = record["kind"]
+        lane = lane_from_record(record)
+        before = ingest.parsed_content(record)
+
+        # Keep the old version: this is what makes a real before/after possible.
+        current = cached_path(lane, kind)
+        if current.exists():
+            with io_lock:
+                shutil.copy2(current, HISTORY_DIR / f"{lane.slug(kind)}.{stamp}.json")
+
+        started = time.monotonic()
+        try:
+            fresh = research(lane, kind, force=True)
+        except Exception as exc:  # noqa: BLE001
+            with io_lock:
+                print(f"  FAILED {doc_label(record)} — {type(exc).__name__}: {exc}", flush=True)
+            return None
+
+        after = ingest.parsed_content(fresh)
+        changes = diff_content(kind, before, after)
+        line = summarize(kind, record.get("doc_key") or record.get("lane_key"), changes)
+        entry = {
+            "at": datetime.now(timezone.utc).isoformat(),
+            "doc_key": record.get("doc_key") or record.get("lane_key"),
+            "lane_key": record.get("lane_key"),
+            "kind": kind,
+            "previous_researched_at": record.get("researched_at"),
+            "researched_at": fresh.get("researched_at"),
+            "run_id": (fresh.get("metadata") or {}).get("run_id"),
+            "confidence": (fresh.get("metadata") or {}).get("confidence"),
+            "changes": changes,
+            "summary": line,
+        }
+        with io_lock:
+            print(f"  {time.monotonic() - started:.0f}s — {line[:150]}", flush=True)
+            with CHANGES_LOG.open("a") as fh:
+                fh.write(json.dumps(entry, default=str) + "\n")
+        return entry
+
+    # Concurrent, like prewarm. Sequential refresh made a 50-lane watchlist an
+    # hour-long wait; research() also caps in-flight runs by semaphore.
+    print(f"\nrefreshing {len(candidates)} record(s), {MAX_CONCURRENT_REFRESH} at a time")
+    with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_REFRESH) as pool:
+        futures = [pool.submit(refresh_one, record) for record, _ in candidates]
+        for fut in as_completed(futures):
+            entry = fut.result()
+            if entry:
+                all_changes.append(entry)
+
+    moved = [e for e in all_changes if e["changes"]]
+    print(f"\n{len(all_changes)} refreshed, {len(moved)} with material changes")
+    if not moved and all_changes:
+        print("nothing moved — that is a valid result, not an empty run")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/llamaindex-tariff-desk/requirements.txt
+++ b/apps/llamaindex-tariff-desk/requirements.txt
@@ -1,0 +1,25 @@
+# Tariff Desk — verified working set, 2026-08-05 (Python 3.10+)
+
+# The Nimble connector. Pulls llama-index-core and nimble-python itself.
+llama-index-tools-nimble>=0.2.0,<0.3
+
+# LLM: question normalization and writing answers from retrieved facts.
+llama-index-llms-anthropic>=0.11.10,<0.12
+
+# Embeddings: Anthropic has no embeddings API, and local HuggingFace embeddings
+# would add ~2GB of torch to the install.
+llama-index-embeddings-openai>=0.6.0,<0.7
+
+streamlit>=1.61.0,<2
+
+# Pin required, not optional. Streamlit 1.61 allows `starlette<2`, but Starlette 1.x
+# changed `GZipResponder.__init__` to take a `thread_minimum_size` argument that
+# Streamlit's `_MediaAwareGZipResponder` subclass does not pass — so every page load
+# raises TypeError while /_stcore/health still returns ok, which makes it look like a
+# browser or network problem rather than a dependency one. Verified 2026-08-05.
+starlette>=0.46.0,<1
+
+python-dotenv>=1.2.0,<2
+
+# Tests (the offline suite needs no API keys and no billable runs)
+pytest>=8

--- a/apps/llamaindex-tariff-desk/setup_agents.py
+++ b/apps/llamaindex-tariff-desk/setup_agents.py
@@ -25,10 +25,10 @@ ENV_KEYS = {"rate": "NIMBLE_RATE_AGENT_ID",
 
 
 def write_env(key: str, value: str) -> None:
-    lines = ENV_PATH.read_text().splitlines() if ENV_PATH.exists() else []
+    lines = ENV_PATH.read_text(encoding="utf-8").splitlines() if ENV_PATH.exists() else []
     lines = [ln for ln in lines if not ln.startswith(f"{key}=")]
     lines.append(f"{key}={value}")
-    ENV_PATH.write_text("\n".join(lines) + "\n")
+    ENV_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def main() -> int:

--- a/apps/llamaindex-tariff-desk/setup_agents.py
+++ b/apps/llamaindex-tariff-desk/setup_agents.py
@@ -1,0 +1,99 @@
+"""Provision the two Web Search Agents once, then verify them.
+
+Idempotent: if the ids are already in .env, this reports and exits without
+creating duplicates. Only ever creates; never deletes anything it did not create.
+
+The connector (`NimbleAgentToolSpec`) is execution-only by design and cannot do
+this — agent administration stays off the LLM surface. That is why provisioning
+is a separate one-time script.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from nimble_python import Nimble
+
+sys.path.insert(0, str(Path(__file__).parent))
+from desk.agents_config import AGENTS  # noqa: E402
+
+ENV_PATH = Path(__file__).parent / ".env"
+ENV_KEYS = {"rate": "NIMBLE_RATE_AGENT_ID",
+            "overlay": "NIMBLE_OVERLAY_AGENT_ID",
+            "hts": "NIMBLE_HTS_AGENT_ID"}
+
+
+def write_env(key: str, value: str) -> None:
+    lines = ENV_PATH.read_text().splitlines() if ENV_PATH.exists() else []
+    lines = [ln for ln in lines if not ln.startswith(f"{key}=")]
+    lines.append(f"{key}={value}")
+    ENV_PATH.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    load_dotenv(ENV_PATH)
+    if not os.environ.get("NIMBLE_API_KEY"):
+        print("NIMBLE_API_KEY is not set", file=sys.stderr)
+        return 2
+
+    client = Nimble(api_key=os.environ["NIMBLE_API_KEY"])
+
+    for kind, cfg in AGENTS.items():
+        env_key = ENV_KEYS[kind]
+        existing = os.environ.get(env_key)
+        if existing:
+            print(f"[{kind}] already provisioned: {existing} — skipping create")
+            agent_id = existing
+        else:
+            agent = client.agents.create(
+                display_name=cfg["display_name"],
+                description=cfg["description"],
+                icon=cfg["icon"],
+                use_case=cfg["use_case"],
+                effort=cfg["effort"],
+                skill=cfg["skill"],
+                goals=cfg["goals"],
+                sources=cfg["sources"],
+                output_schema=cfg["output_schema"],
+                suggested_questions=cfg["suggested_questions"],
+            )
+            agent_id = agent.id
+            print(f"[{kind}] created {agent_id}")
+            write_env(env_key, agent_id)
+
+        # Verify: created-from-scratch agents keep inline fields (quirk 6a), but
+        # a GET is cheap and source enforcement depends on sources.allow landing.
+        got = client.agents.get(agent_id)
+        allow = (getattr(got.sources, "allow", None) or []) if got.sources else []
+        goals = getattr(got, "goals", None) or []
+        schema = getattr(got, "output_schema", None)
+        skill = getattr(got, "skill", None) or ""
+        sq = getattr(got, "suggested_questions", None) or []
+
+        print(
+            f"[{kind}] verify: effort={got.effort} use_case={got.use_case} "
+            f"skill={len(skill)}ch goals={len(goals)} "
+            f"sources.allow={len(allow)} schema={'Y' if schema else 'N'} "
+            f"suggested_questions={len(sq)}"
+        )
+        problems = []
+        if not allow:
+            problems.append("sources.allow is EMPTY — no whitelist landed")
+        if not goals:
+            problems.append("goals are EMPTY — no acceptance criteria")
+        if not schema:
+            problems.append("output_schema is EMPTY")
+        if not skill:
+            problems.append("skill is EMPTY")
+        for p in problems:
+            print(f"[{kind}] !! {p}")
+        if problems:
+            return 1
+
+    print(f"\nall {len(AGENTS)} agents provisioned and verified; ids written to .env")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -361,6 +361,63 @@ def test_cached_loader_does_not_catch_configuration_errors():
         "the wrapper is what turns the error into a message for the reader"
 
 
+# --- the shared reader (Qodo review, PR #44) ------------------------------
+
+
+def test_read_json_survives_every_way_a_file_can_be_unreadable(tmp_path):
+    """Truncated, absent, and not-a-file all return None rather than raising.
+
+    OSError was the gap: `ingest.load_records` caught only JSONDecodeError, so an
+    unreadable path took the page down while a corrupt one did not.
+    """
+    from desk.io import read_json
+
+    truncated = tmp_path / "half.json"
+    truncated.write_text('{"lane_key": "8507.60.00|Vietnam|Unit', encoding="utf-8")
+    assert read_json(truncated) is None
+
+    assert read_json(tmp_path / "absent.json") is None
+
+    a_directory = tmp_path / "dir.json"
+    a_directory.mkdir()
+    assert read_json(a_directory) is None, "IsADirectoryError is an OSError"
+
+    good = tmp_path / "ok.json"
+    good.write_text('{"status": "running"}', encoding="utf-8")
+    assert read_json(good) == {"status": "running"}
+
+
+def test_load_records_skips_an_unreadable_path(tmp_path):
+    """The OSError case, through the real loader."""
+    (tmp_path / "notafile.json").mkdir()
+    (tmp_path / "good.json").write_text(
+        '{"kind": "rate", "doc_key": "x|US", "researched_at": "2026-08-05T00:00:00+00:00"}',
+        encoding="utf-8")
+    records = ingest.load_records(tmp_path)
+    assert len(records) == 1 and records[0]["doc_key"] == "x|US"
+
+
+def test_change_log_reader_skips_bad_lines_and_bounds_the_read(tmp_path):
+    from desk.io import TAIL_BYTES, read_json_lines
+
+    log = tmp_path / "changes.jsonl"
+    assert read_json_lines(log) == [], "a missing log is empty, not an error"
+
+    lines = [f'{{"at": "2026-08-0{i % 9 + 1}", "n": {i}}}' for i in range(40)]
+    lines.insert(7, "{ this is not json")
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    entries = read_json_lines(log)
+    assert len(entries) == 40, "the unparseable line is skipped, the rest survive"
+
+    # A log far bigger than the tail window is read only in part.
+    big = tmp_path / "big.jsonl"
+    big.write_text("".join('{"at": "2026-08-05", "pad": "%s"}\n' % ("x" * 500)
+                           for _ in range(2000)), encoding="utf-8")
+    assert big.stat().st_size > TAIL_BYTES
+    tail = read_json_lines(big, limit=6)
+    assert 0 < len(tail) <= 24, "bounded, and enough to fill a limit of 6"
+
+
 # --- documents ------------------------------------------------------------
 
 

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -1,0 +1,312 @@
+"""Everything testable without an embedding model or a billable run.
+
+Runs against the real pre-warmed corpus in data/runs/, so these are not toy
+fixtures — a regression in the trust mapping shows up here.
+
+    ./.venv/bin/python -m pytest tests/ -q
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent.parent
+sys.path.insert(0, str(HERE))
+
+from desk import freshness, ingest  # noqa: E402
+from desk.agents_config import TTL_DAYS  # noqa: E402
+from desk.research import Lane  # noqa: E402
+
+NOW = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def records():
+    """Every record that could ship, from BOTH corpus directories.
+
+    Not `load_records()`: that follows `active_dir()`, which depends on `USE_LIVE`,
+    which the tests never set — so the suite quietly validated `data/samples/` while
+    the app served `data/runs/`. An unverified rate record sat in runs/ and the suite
+    passed. Validate whatever exists, wherever it exists.
+    """
+    seen, recs = set(), []
+    for directory in (ingest.RUNS_DIR, ingest.SAMPLES_DIR):
+        for record in ingest.load_records(directory):
+            key = (record.get("doc_key") or record.get("lane_key"), record.get("kind"))
+            if key in seen:      # same fact in both dirs; runs wins, it is read first
+                continue
+            seen.add(key)
+            recs.append(record)
+    if not recs:
+        pytest.skip("no corpus on disk — run prewarm.py first")
+    return recs
+
+
+# --- keying ---------------------------------------------------------------
+
+
+def test_rate_key_is_origin_free():
+    """The MFN rate belongs to the code, not the lane (corpus-verified)."""
+    vn = Lane("8507.60.00", "Vietnam")
+    cn = Lane("8507.60.00", "China")
+    assert vn.doc_id("rate") == cn.doc_id("rate")
+    assert vn.doc_id("overlay") != cn.doc_id("overlay")
+
+
+def test_overlay_key_includes_origin():
+    lane = Lane("8507.60.00", "Vietnam")
+    assert lane.doc_id("overlay") == "8507.60.00|Vietnam|United States#overlay"
+    assert lane.doc_id("rate") == "8507.60.00|United States#rate"
+
+
+# --- freshness ------------------------------------------------------------
+
+
+def test_ttls_differ_by_fact_class():
+    """The whole reason there are two agents."""
+    assert TTL_DAYS["rate"] > TTL_DAYS["overlay"]
+
+
+def test_overlay_goes_stale_before_rate():
+    stamp = (NOW - timedelta(days=30)).isoformat()
+    assert freshness.is_stale(stamp, "overlay", now=NOW) is True
+    assert freshness.is_stale(stamp, "rate", now=NOW) is False
+
+
+def test_missing_timestamp_is_stale():
+    """Absence of proof is not freshness."""
+    assert freshness.is_stale(None, "rate", now=NOW) is True
+    assert freshness.is_stale("not-a-date", "rate", now=NOW) is True
+
+
+def test_unknown_kind_gets_strictest_ttl():
+    assert freshness.ttl_for("nonsense") == min(TTL_DAYS.values())
+
+
+def test_naive_timestamp_treated_as_utc():
+    naive = (NOW - timedelta(days=1)).replace(tzinfo=None).isoformat()
+    assert freshness.age_in_days(naive, now=NOW) == pytest.approx(1.0, abs=0.01)
+
+
+def test_boundary_is_stale_at_exactly_ttl():
+    stamp = (NOW - timedelta(days=TTL_DAYS["overlay"])).isoformat()
+    assert freshness.is_stale(stamp, "overlay", now=NOW) is True
+
+
+def test_verdict_describes_staleness_in_words():
+    stamp = (NOW - timedelta(days=40)).isoformat()
+    verdict = freshness.assess({"kind": "overlay", "researched_at": stamp}, now=NOW)
+    assert "STALE" in verdict.describe()
+    assert str(TTL_DAYS["overlay"]) in verdict.describe()
+
+
+# --- trust mapping over the real corpus -----------------------------------
+
+
+def test_every_record_parses_as_structured_json(records):
+    for record in records:
+        assert ingest.parsed_content(record) is not None, record.get("doc_key")
+
+
+def test_claims_are_keyed_by_json_path(records):
+    """Per-cell citation depends on this. Without output_schema it would not hold."""
+    for record in records:
+        paths = ingest.claim_index(record["metadata"])
+        assert paths, f"no path-keyed claims in {record.get('doc_key')}"
+        assert all(p.startswith("$") for p in paths)
+
+
+def test_echoed_input_fields_are_separated_from_research(records):
+    """`pre_existing` zero-citation claims are echoes of input_data, not facts."""
+    rate = [r for r in records if r["kind"] == "rate"]
+    assert rate, "expected rate records in the corpus"
+    for record in rate:
+        researched, echoes = ingest.split_claims(record["metadata"])
+        assert researched, "a rate record with no researched claims is a bug"
+        for claim in echoes:
+            assert not claim.get("citations")
+            assert (claim.get("confidence") or "").lower() == "pre_existing"
+
+
+def test_every_source_in_the_corpus_is_primary(records):
+    """Consequence of sources.allow being a hard whitelist (smoke 3)."""
+    for record in records:
+        sources = record["metadata"].get("sources") or []
+        assert sources, f"no sources for {record.get('doc_key')}"
+        assert ingest.primary_source_count(record["metadata"]) == len(sources)
+
+
+def test_rate_records_verified_against_official_schedule(records):
+    for record in [r for r in records if r["kind"] == "rate"]:
+        content = ingest.parsed_content(record)
+        assert content.get("verified_against_official_schedule") is True
+        assert content.get("general_rate")
+        assert "not verified" not in str(content["general_rate"]).lower()
+
+
+def test_overlay_records_never_report_a_base_rate(records):
+    """Overlay and base rate must not bleed into each other."""
+    for record in [r for r in records if r["kind"] == "overlay"]:
+        content = ingest.parsed_content(record)
+        assert "general_rate" not in content
+
+
+# --- duty filter: schema validation only, no text heuristics ---------------
+#
+# An earlier version of this suite had ~15 tests for regex guards that inferred
+# meaning from prose. The guards produced false positives and were removed; these
+# two checks read fields the agent explicitly set.
+
+
+def test_duty_marked_not_in_force_is_excluded():
+    content = {"additional_duties": [
+        {"authority": "EO 14257", "rate": "20%", "in_force": False},
+    ]}
+    in_force, excluded = ingest.split_duties(content, as_of=NOW.isoformat())
+    assert in_force == []
+    assert "not in force" in excluded[0]["excluded_because"]
+
+
+def test_duty_whose_window_closed_is_excluded():
+    """A Section 122-style surcharge that ended before the research date."""
+    content = {"additional_duties": [
+        {"authority": "Proclamation 11012", "rate": "10%", "in_force": True,
+         "effective_date": "2026-02-24", "ends": "2026-07-24"},
+    ]}
+    in_force, excluded = ingest.split_duties(content, as_of=NOW.isoformat())
+    assert in_force == []
+    assert "window closed" in excluded[0]["excluded_because"]
+
+
+def test_open_ended_duty_in_force_survives():
+    content = {"additional_duties": [
+        {"authority": "Section 301 List 3", "rate": "25%", "in_force": True,
+         "effective_date": "2024-01-01", "ends": None},
+    ]}
+    in_force, excluded = ingest.split_duties(content, as_of=NOW.isoformat())
+    assert len(in_force) == 1 and excluded == []
+
+
+def test_empty_duties_is_a_valid_answer():
+    assert ingest.split_duties({"additional_duties": []}) == ([], [])
+    assert ingest.split_duties(None) == ([], [])
+
+
+def test_unverified_gaps_are_carried_to_node_metadata(records):
+    """The actual lesson: `confidence` does not account for coverage gaps."""
+    for record in records:
+        content = ingest.parsed_content(record) or {}
+        meta = ingest.node_metadata(record)
+        assert meta["unverified"] == (content.get("unverified") or [])
+
+
+def test_duty_counts_add_up(records):
+    for record in [r for r in records if r["kind"] == "overlay"]:
+        content = ingest.parsed_content(record)
+        meta = ingest.node_metadata(record)
+        total = len(content.get("additional_duties") or [])
+        assert meta["duties_in_force"] + meta["duties_excluded"] == total
+
+
+# --- question normalization edge cases ------------------------------------
+
+
+def test_code_without_origin_asks_for_the_country():
+    """The crash Tom hit: the 'Use this' button prefills a code with no country, and
+    a question with a code but no origin produced no Lane and no flag."""
+    from desk.normalize import heuristic
+
+    for question in ("What's the duty on HTS 6404.11.00 from ",
+                     "What's the duty on HTS 6404.11.00 from <country>?",
+                     "What's the duty on HTS 6404.11.00?"):
+        out = heuristic(question)
+        assert out.lane is None
+        assert out.needs_origin is True, question
+        assert out.needs_hts_code is False, "the code was present"
+
+
+def test_code_with_origin_produces_a_lane():
+    from desk.normalize import heuristic
+
+    out = heuristic("What's the duty on HTS 6404.11.00 from Vietnam?")
+    assert out.lane is not None
+    assert out.needs_origin is False and out.needs_hts_code is False
+    assert out.lane.key == "6404.11.00|Vietnam|United States"
+
+
+def test_neither_code_nor_origin_flags_both():
+    from desk.normalize import heuristic
+
+    out = heuristic("What's the duty on running shoes?")
+    assert out.lane is None
+    assert out.needs_hts_code is True and out.needs_origin is True
+
+
+# --- documents ------------------------------------------------------------
+
+
+def test_documents_get_stable_ids_and_dated_text(records):
+    docs = ingest.to_documents(records)
+    ids = [d.doc_id for d in docs]
+    assert len(ids) == len(set(ids)), "duplicate doc_ids would break refresh upsert"
+    for doc in docs:
+        # The agent only sees text; the date must survive there too.
+        assert "Researched:" in doc.text
+        assert doc.metadata["researched_at"]
+        assert doc.metadata["kind"] in {"rate", "overlay"}
+
+
+def test_document_ids_are_stable_across_reingest(records):
+    first = {d.doc_id for d in ingest.to_documents(records)}
+    second = {d.doc_id for d in ingest.to_documents(records)}
+    assert first == second
+
+
+def test_coverage_counts_lanes_by_overlay_not_rate(records):
+    cov = ingest.coverage(records)
+    assert cov["overlay_docs"] == len(cov["lanes"])
+    assert cov["rate_docs"] == len(cov["hts_codes"])
+
+
+# --- postprocessor --------------------------------------------------------
+
+
+def _node(kind: str, age_days: float):
+    from llama_index.core.schema import NodeWithScore, TextNode
+
+    stamp = (NOW - timedelta(days=age_days)).isoformat()
+    return NodeWithScore(
+        node=TextNode(text="x", metadata={"kind": kind, "researched_at": stamp,
+                                         "doc_key": f"{kind}-{age_days}d"}),
+        score=1.0,
+    )
+
+
+def test_strict_postprocessor_withholds_stale_nodes():
+    nodes = [_node("overlay", 1), _node("overlay", 40), _node("rate", 40)]
+    kept = freshness.FreshnessPostprocessor(strict=True, now=NOW).postprocess_nodes(nodes)
+    keys = {n.node.metadata["doc_key"] for n in kept}
+    assert keys == {"overlay-1d", "rate-40d"}
+
+
+def test_lenient_postprocessor_keeps_but_marks_stale():
+    nodes = [_node("overlay", 40)]
+    kept = freshness.FreshnessPostprocessor(strict=False, now=NOW).postprocess_nodes(nodes)
+    assert len(kept) == 1
+    assert kept[0].node.metadata[freshness.STALE_KEY] is True
+    assert kept[0].node.metadata[freshness.AGE_KEY] == pytest.approx(40, abs=0.1)
+
+
+def test_preamble_forces_dates_and_flags_echoes():
+    text = freshness.freshness_preamble([_node("overlay", 40), _node("rate", 2)], now=NOW)
+    assert "STALE" in text
+    assert "research date" in text
+    assert "pre_existing" in text
+
+
+def test_preamble_empty_without_nodes():
+    assert freshness.freshness_preamble([]) == ""

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -332,27 +332,32 @@ def test_bad_env_int_falls_back_instead_of_raising(monkeypatch):
 # --- cached-failure regression (Qodo review, PR #44) ----------------------
 
 
-def test_cached_loader_propagates_instead_of_caching_a_failure(monkeypatch):
-    """The cached function must raise, not return None.
+def test_cached_loader_does_not_catch_configuration_errors():
+    """The cached loader must contain no except clause; the wrapper must have one.
 
     Catching inside `@st.cache_resource` stored None as the cached resource, so a
-    reader who fixed their .env kept seeing the same error until they restarted the
-    process. Streamlit does not cache exceptions, so letting it raise is what makes
-    a corrected key take effect on the next rerun.
+    reader who corrected their .env kept seeing the same error until restarting.
+    Streamlit does not cache exceptions, so propagating is what makes retry work.
+
+    Checked by reading the source rather than importing app.py: importing it runs
+    module-level Streamlit and dotenv calls, and reaching through `__wrapped__` to
+    bypass the cache depends on a private attribute that may change.
     """
-    import app as app_module
+    import ast
 
-    def boom():
-        raise RuntimeError("OPENAI_API_KEY is not set")
+    tree = ast.parse((HERE / "app.py").read_text())
+    funcs = {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
 
-    monkeypatch.setattr(app_module, "configure_models", boom)
+    loader = funcs["_load_index"]
+    assert any("cache_resource" in ast.unparse(d) for d in loader.decorator_list), \
+        "_load_index is the cached one"
+    assert not [n for n in ast.walk(loader) if isinstance(n, ast.ExceptHandler)], \
+        "the cached loader must propagate, not swallow: catching here caches None"
 
-    # The cached loader, called through its underlying function to bypass the cache.
-    with pytest.raises(RuntimeError):
-        app_module._load_index.__wrapped__()
-
-    # The uncached wrapper is what turns it into something the reader can act on.
-    assert app_module._index() is None
+    wrapper = funcs["_index"]
+    assert not wrapper.decorator_list, "the wrapper must not be cached"
+    assert [n for n in ast.walk(wrapper) if isinstance(n, ast.ExceptHandler)], \
+        "the wrapper is what turns the error into a message for the reader"
 
 
 # --- documents ------------------------------------------------------------

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -246,6 +246,45 @@ def test_neither_code_nor_origin_flags_both():
     assert out.needs_hts_code is True and out.needs_origin is True
 
 
+# --- corrupt persisted state (Qodo review, PR #44) ------------------------
+
+
+def test_truncated_json_reads_as_none_not_an_exception(tmp_path):
+    """A process killed mid-write leaves a partial file. Reading it must not raise
+    into the progress UI or break resumability."""
+    from desk.research import read_json
+
+    partial = tmp_path / "half.json"
+    partial.write_text('{"lane_key": "8507.60.00|Vietnam|United')   # truncated
+    assert read_json(partial) is None
+
+    missing = tmp_path / "nope.json"
+    assert read_json(missing) is None
+
+    good = tmp_path / "ok.json"
+    good.write_text('{"status": "running"}')
+    assert read_json(good) == {"status": "running"}
+
+
+def test_corrupt_job_file_is_skipped_by_open_jobs(tmp_path, monkeypatch):
+    from desk import research
+
+    monkeypatch.setattr(research, "JOBS_DIR", tmp_path)
+    (tmp_path / "bad.json").write_text("{oh no")
+    (tmp_path / "good.json").write_text('{"lane_key": "x|y|z", "kind": "overlay"}')
+    jobs = research.open_jobs()
+    assert len(jobs) == 1 and jobs[0]["lane_key"] == "x|y|z"
+
+
+def test_corrupt_lookup_cache_is_skipped(tmp_path, monkeypatch):
+    from desk import classify
+
+    monkeypatch.setattr(classify, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(classify, "SAMPLE_DIR", tmp_path / "absent")
+    (tmp_path / f"{classify.slugify('widgets')}.json").write_text("not json at all")
+    assert classify.cached("widgets") is None
+
+
 # --- documents ------------------------------------------------------------
 
 

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -267,6 +267,17 @@ def test_truncated_json_reads_as_none_not_an_exception(tmp_path):
     assert read_json(good) == {"status": "running"}
 
 
+def test_read_json_rejects_valid_json_that_is_not_an_object(tmp_path):
+    """`[1, 2]` and `"text"` parse cleanly and then break the first .get() call,
+    which is a worse failure than not parsing at all."""
+    from desk.io import read_json
+
+    for payload in ("[1, 2]", '"just a string"', "42", "true", "null"):
+        f = tmp_path / "x.json"
+        f.write_text(payload, encoding="utf-8")
+        assert read_json(f) is None, f"{payload} is not a usable record"
+
+
 def test_corrupt_job_file_is_skipped_by_open_jobs(tmp_path, monkeypatch):
     from desk import research
 

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -255,14 +255,15 @@ def test_truncated_json_reads_as_none_not_an_exception(tmp_path):
     from desk.research import read_json
 
     partial = tmp_path / "half.json"
-    partial.write_text('{"lane_key": "8507.60.00|Vietnam|United')   # truncated
+    partial.write_text('{"lane_key": "8507.60.00|Vietnam|United',      # truncated
+                       encoding="utf-8")
     assert read_json(partial) is None
 
     missing = tmp_path / "nope.json"
     assert read_json(missing) is None
 
     good = tmp_path / "ok.json"
-    good.write_text('{"status": "running"}')
+    good.write_text('{"status": "running"}', encoding="utf-8")
     assert read_json(good) == {"status": "running"}
 
 
@@ -270,8 +271,8 @@ def test_corrupt_job_file_is_skipped_by_open_jobs(tmp_path, monkeypatch):
     from desk import research
 
     monkeypatch.setattr(research, "JOBS_DIR", tmp_path)
-    (tmp_path / "bad.json").write_text("{oh no")
-    (tmp_path / "good.json").write_text('{"lane_key": "x|y|z", "kind": "overlay"}')
+    (tmp_path / "bad.json").write_text("{oh no", encoding="utf-8")
+    (tmp_path / "good.json").write_text('{"lane_key": "x|y|z", "kind": "overlay"}', encoding="utf-8")
     jobs = research.open_jobs()
     assert len(jobs) == 1 and jobs[0]["lane_key"] == "x|y|z"
 
@@ -281,7 +282,7 @@ def test_corrupt_lookup_cache_is_skipped(tmp_path, monkeypatch):
 
     monkeypatch.setattr(classify, "CACHE_DIR", tmp_path)
     monkeypatch.setattr(classify, "SAMPLE_DIR", tmp_path / "absent")
-    (tmp_path / f"{classify.slugify('widgets')}.json").write_text("not json at all")
+    (tmp_path / f"{classify.slugify('widgets')}.json").write_text("not json at all", encoding="utf-8")
     assert classify.cached("widgets") is None
 
 
@@ -345,7 +346,7 @@ def test_cached_loader_does_not_catch_configuration_errors():
     """
     import ast
 
-    tree = ast.parse((HERE / "app.py").read_text())
+    tree = ast.parse((HERE / "app.py").read_text(encoding="utf-8"))
     funcs = {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
 
     loader = funcs["_load_index"]

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -285,6 +285,50 @@ def test_corrupt_lookup_cache_is_skipped(tmp_path, monkeypatch):
     assert classify.cached("widgets") is None
 
 
+# --- change detection and env parsing (Qodo review, PR #44) ---------------
+
+
+def test_diff_distinguishes_false_from_missing():
+    """`str(x or "")` collapsed False, 0 and None into the same thing, hiding a real
+    change. verified_against_official_schedule is explicitly allowed to be false."""
+    from desk.delta import diff_content
+
+    changes = diff_content("rate",
+                           {"verified_against_official_schedule": None},
+                           {"verified_against_official_schedule": False})
+    assert changes, "None -> False is a real change and must be reported"
+
+    unchanged = diff_content("rate",
+                             {"verified_against_official_schedule": False},
+                             {"verified_against_official_schedule": False})
+    assert not unchanged
+
+
+def test_diff_reports_a_rate_becoming_unverified():
+    from desk.delta import diff_content
+
+    changes = diff_content("rate",
+                           {"general_rate": "3.4%", "verified_against_official_schedule": True},
+                           {"general_rate": "not verified", "verified_against_official_schedule": False})
+    fields = {c["field"] for c in changes}
+    assert "general_rate" in fields
+    assert "verified_against_official_schedule" in fields
+
+
+def test_bad_env_int_falls_back_instead_of_raising(monkeypatch):
+    """A typo in .env should not crash model setup from deep inside LlamaIndex."""
+    from desk.models import _int_env
+
+    monkeypatch.setenv("DESK_TEST_INT", "not a number")
+    assert _int_env("DESK_TEST_INT", 2048) == 2048
+    monkeypatch.setenv("DESK_TEST_INT", "")
+    assert _int_env("DESK_TEST_INT", 2048) == 2048
+    monkeypatch.setenv("DESK_TEST_INT", "512")
+    assert _int_env("DESK_TEST_INT", 2048) == 512
+    monkeypatch.delenv("DESK_TEST_INT")
+    assert _int_env("DESK_TEST_INT", 2048) == 2048
+
+
 # --- documents ------------------------------------------------------------
 
 

--- a/apps/llamaindex-tariff-desk/tests/test_offline.py
+++ b/apps/llamaindex-tariff-desk/tests/test_offline.py
@@ -329,6 +329,32 @@ def test_bad_env_int_falls_back_instead_of_raising(monkeypatch):
     assert _int_env("DESK_TEST_INT", 2048) == 2048
 
 
+# --- cached-failure regression (Qodo review, PR #44) ----------------------
+
+
+def test_cached_loader_propagates_instead_of_caching_a_failure(monkeypatch):
+    """The cached function must raise, not return None.
+
+    Catching inside `@st.cache_resource` stored None as the cached resource, so a
+    reader who fixed their .env kept seeing the same error until they restarted the
+    process. Streamlit does not cache exceptions, so letting it raise is what makes
+    a corrected key take effect on the next rerun.
+    """
+    import app as app_module
+
+    def boom():
+        raise RuntimeError("OPENAI_API_KEY is not set")
+
+    monkeypatch.setattr(app_module, "configure_models", boom)
+
+    # The cached loader, called through its underlying function to bypass the cache.
+    with pytest.raises(RuntimeError):
+        app_module._load_index.__wrapped__()
+
+    # The uncached wrapper is what turns it into something the reader can act on.
+    assert app_module._index() is None
+
+
 # --- documents ------------------------------------------------------------
 
 


### PR DESCRIPTION
A demo of the [`llama-index-tools-nimble`](https://pypi.org/project/llama-index-tools-nimble/) integration, under `apps/llamaindex-tariff-desk/`.

## What it is

A RAG index whose corpus is built from Nimble Web Search Agent runs, dated per fact, and refreshed on a shelf life rather than uploaded once. Ask what the duty is on a product from a country; get an answer assembled from cited, dated facts. If the corpus doesn't cover it, agents research it and the result joins the index.

The premise: retrieval-augmented generation exists because a model's knowledge is frozen at training time, but a vector store built once has the same disease — it relocates the staleness into your index, where nobody notices.

## Three agents

| Agent | Reads | Effort | Shelf life |
|---|---|---|---|
| `tariff-schedule-rate` | official schedule (USITC), CBP | `medium` | 90 days |
| `tariff-policy-overlay` | Federal Register, USTR, White House, CBP | `high` | 7 days |
| `hts-code-candidates` | official schedule + CBP rulings | `medium` | per query |

The split came out of measurement: one run asked for both the rate and the overlays let the schedule lookup fail quietly into `unverified`. Narrowing each task fixed it. The overlay agent runs at `high` because `medium` listed expired instruments as active and, on one lane, never found the order that had terminated a duty.

## Findings worth carrying into other integrations

- **`timeout` defaults to 300s** while the default effort takes 5–15 minutes, so an out-of-the-box configuration fails on healthy runs.
- **`run()` blocks for the whole run** with no start-now/collect-later split. `recover_runs.py` reconciles work that outlived its deadline against the agent's run history — the `save_run_for_later` the docs leave as an exercise.
- **`output_schema` is what buys per-claim citations** keyed by JSON path. Without it, claims key by prose callout and can't attach to a field.
- **`sources.allow` is a hard whitelist** and a missing domain fails silently, surfacing only as gaps in `unverified`.
- **`input_data` puts an agent in row-enrichment mode.** A subject you want researched belongs in the task text; passing it as `input_data` returned the row unchanged with zero sources.
- **`confidence` grades what was claimed, not what was covered.** A run returns `high` while leaving facts unverified, so the UI gives gaps equal billing.
- **`starlette` is pinned `<1`.** Streamlit permits a newer version that breaks its own gzip middleware; every page returns 500 while `/_stcore/health` stays green, which reads as a browser problem rather than a dependency one.

## Verification

`ai-setup.md` was run literally in a clean directory: fresh venv from `requirements.txt`, integration import, agent provisioning, index build, tests, app serving. 31 tests pass with no API keys and no billable calls.

Ships a 17-fact corpus and six cached code lookups so the app demos offline, including one deliberately expired fact so the freshness guard has something to catch.

## Scope

A demonstration, not a compliance reference. Every figure carries its source and research date; none have been reviewed by a customs professional, and the README, app header and setup notes each say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)