### PR TITLE
Fix the competitor-intel skill fetch after the upstream skills flatten

### DIFF
--- a/claude-managed-agents/competitor-intel/scripts/00-setup.sh
+++ b/claude-managed-agents/competitor-intel/scripts/00-setup.sh
@@ -46,7 +46,7 @@ ant beta:memory-stores:memories create --memory-store-id "$MEMSTORE_ID" \
   --path "/business-profile.json" --content "$(cat profile/business-profile.json)" --transform id -r >/dev/null
 
 echo "== 6. Fetch the skill from github.com/Nimbleway/agent-skills =="
-REPO="Nimbleway/agent-skills"; SRC="skills/business-research/competitor-intel"
+REPO="Nimbleway/agent-skills"; SRC="skills/competitor-intel"
 rm -rf skill/competitor-intel && mkdir -p skill/competitor-intel
 gh api "repos/$REPO/git/trees/main?recursive=1" \
   -q ".tree[] | select(.type==\"blob\") | select(.path|startswith(\"$SRC/\")) | .path" \

--- a/claude-managed-agents/competitor-intel/scripts/00-setup.sh
+++ b/claude-managed-agents/competitor-intel/scripts/00-setup.sh
@@ -52,6 +52,12 @@ gh api "repos/$REPO/git/trees/main?recursive=1" \
   -q ".tree[] | select(.type==\"blob\") | select(.path|startswith(\"$SRC/\")) | .path" \
 | while read -r p; do rel="${p#"$SRC"/}"; mkdir -p "skill/competitor-intel/$(dirname "$rel")"; \
     gh api "repos/$REPO/contents/$p" -H "Accept: application/vnd.github.raw" > "skill/competitor-intel/$rel"; done
+# Fail here rather than at the upload: a fetch that matches nothing still exits 0, so a stale
+# SRC would otherwise surface two steps later as a misleading "skill upload failed".
+[ -f skill/competitor-intel/SKILL.md ] || {
+  echo "ERROR: no SKILL.md fetched from $SRC — the upstream layout may have changed." >&2
+  echo "Check https://github.com/$REPO/tree/main/skills and update SRC above to match." >&2
+  exit 1; }
 
 echo "== 7. Upload the skill via raw API (curl) =="
 # ant beta:skills create sends --file by basename; curl lets us set folder-prefixed multipart


### PR DESCRIPTION
The managed-agent setup script fetches the `competitor-intel` skill from
`Nimbleway/agent-skills` by path. That repository now stores every skill as a
direct child of `skills/`, so the previous nested path no longer resolves and
the fetch returned no files.

## Changes

**Point the fetch at the current layout** — `SRC` becomes `skills/competitor-intel`.

**Fail at the fetch instead of the upload.** A tree query that matches no paths
still exits 0, so the script continued with an empty skill directory and
reported `ERROR: skill upload failed` two steps later, pointing at the wrong
step. Step 6 now checks that `SKILL.md` arrived and names the likely cause:

```
ERROR: no SKILL.md fetched from skills/... — the upstream layout may have changed.
Check https://github.com/Nimbleway/agent-skills/tree/main/skills and update SRC above to match.
```

## Verification

Step 6 was run verbatim against the current `agent-skills` default branch:

- fetches 5 files, with `SKILL.md` at the top level of `skill/competitor-intel/`,
  where the step 7 multipart upload expects it
- the guard exits 1 with the message above when given the previous nested path,
  and exits 0 on the current one
- the trailing slash in the path filter keeps the fetch from matching the
  sibling `competitor-positioning` skill

Steps 1-5 and 7-8 are unchanged and were not exercised here; they provision live
control-plane resources and need `NIMBLE_API_KEY` and `SLACK_BOT_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)